### PR TITLE
feat(shorts): link short to source video + reap scheduling fixes

### DIFF
--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1136,7 +1136,7 @@ class CongressionalVideoDB:
                 cur.execute(
                     f"""SELECT vc.chapter_id, vc.title, vc.description, vc.speakers,
                                vc.key_speakers, vc.topics, vc.scoring_reasoning,
-                               vc.relevance_score,
+                               vc.relevance_score, vc.youtube_video_id,
                                ysv.video_title AS source_video_title,
                                ysv.video_url   AS source_video_url,
                                ysv.session_number,

--- a/congress_videos/reap_processor_dag.py
+++ b/congress_videos/reap_processor_dag.py
@@ -1,7 +1,7 @@
 """
 Congress Reap Processor DAG
 
-Runs on its own cron schedule (daily at 14:30). On each run, claims exactly one
+Runs on its own cron schedule (daily at 14:30 and 17:30 UTC). On each run, claims exactly one
 video_shorts row with reap_status='pending' from the queue, uploads the staged clip
 to Reap, waits for job completion via sensor, and downloads all resulting shorts.
 """
@@ -121,7 +121,7 @@ with DAG(
     'congress_reap_processor',
     default_args=default_args,
     description='Claim one pending clip from the queue, upload to Reap, wait for completion, download shorts',
-    schedule='30 14 * * *',
+    schedule='30 14,17 * * *',
     start_date=datetime(2025, 11, 14),
     catchup=False,
     max_active_runs=1,

--- a/congress_videos/reap_shorts_uploader_dag.py
+++ b/congress_videos/reap_shorts_uploader_dag.py
@@ -48,11 +48,15 @@ _MONTHS = [
 ]
 
 
-def _format_source_footer(source_title: str | None, source_url: str | None) -> str:
-    """Return a source video attribution line, or '' if either arg is falsy."""
-    if not source_title or not source_url:
+def _format_own_channel_footer(youtube_video_id: str | None) -> str:
+    """Return an own-channel footer linking the full long-form video, or '' if ID is absent.
+
+    Hard contract: if youtube_video_id is None or empty, no footer is appended.
+    There is NO fallback to the source video URL.
+    """
+    if not youtube_video_id:
         return ''
-    return f'\n\n📺 Extraído de: {source_title}\n{source_url}'
+    return f'\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v={youtube_video_id}'
 
 
 def _format_session_line(session_number: int | None, session_date: date | None) -> str:
@@ -200,7 +204,7 @@ with DAG(
                         f"{ai_result.get('error')}"
                     )
 
-            description += _format_source_footer(ch.get('source_video_title'), ch.get('source_video_url'))
+            description += _format_own_channel_footer(ch.get('youtube_video_id'))
             description += _format_session_line(ch.get('session_number'), ch.get('session_date'))
 
             metadata_list.append({

--- a/tests/congress_videos/modules/test_reap_db_methods.py
+++ b/tests/congress_videos/modules/test_reap_db_methods.py
@@ -312,7 +312,7 @@ class TestGetChapterTitles:
 class TestGetChapterMetadata:
 
     def test_get_chapter_metadata_returns_source_fields(self, db):
-        """AC#1 — chapter with linked source video returns both source fields."""
+        """AC#1 — chapter with linked source video returns both source fields and youtube_video_id."""
         instance, mock_cursor = db
         mock_cursor.fetchone.return_value = {
             "chapter_id": 1,
@@ -323,6 +323,7 @@ class TestGetChapterMetadata:
             "topics": ["vivienda"],
             "scoring_reasoning": "Relevant",
             "relevance_score": 4,
+            "youtube_video_id": "yt-own-abc",
             "source_video_title": "Sesión plenaria 2024-01-15",
             "source_video_url": "https://youtube.com/watch?v=abc123",
         }
@@ -330,11 +331,12 @@ class TestGetChapterMetadata:
         result = instance.get_chapter_metadata(1)
 
         assert result is not None
+        assert result["youtube_video_id"] == "yt-own-abc"
         assert result["source_video_title"] == "Sesión plenaria 2024-01-15"
         assert result["source_video_url"] == "https://youtube.com/watch?v=abc123"
 
     def test_get_chapter_metadata_null_source(self, db):
-        """AC#2, AC#7 — chapter with no source video row returns None for both fields."""
+        """AC#2, AC#7 — chapter with no source video row returns None for source fields and youtube_video_id."""
         instance, mock_cursor = db
         mock_cursor.fetchone.return_value = {
             "chapter_id": 2,
@@ -345,6 +347,7 @@ class TestGetChapterMetadata:
             "topics": [],
             "scoring_reasoning": "",
             "relevance_score": 3,
+            "youtube_video_id": None,
             "source_video_title": None,
             "source_video_url": None,
         }
@@ -352,6 +355,7 @@ class TestGetChapterMetadata:
         result = instance.get_chapter_metadata(2)
 
         assert result is not None
+        assert result["youtube_video_id"] is None
         assert result["source_video_title"] is None
         assert result["source_video_url"] is None
 
@@ -376,12 +380,13 @@ class TestGetChapterMetadata:
         assert "youtube_source_videos" in sql
 
     def test_get_chapter_metadata_selects_source_columns(self, db):
-        """Query must select source_video_title and source_video_url aliases."""
+        """Query must select youtube_video_id, source_video_title and source_video_url aliases."""
         instance, mock_cursor = db
         mock_cursor.fetchone.return_value = None
 
         instance.get_chapter_metadata(1)
 
         sql = mock_cursor.execute.call_args[0][0]
+        assert "youtube_video_id" in sql
         assert "source_video_title" in sql
         assert "source_video_url" in sql

--- a/tests/congress_videos/test_reap_processor_dag.py
+++ b/tests/congress_videos/test_reap_processor_dag.py
@@ -56,7 +56,7 @@ class TestCongressReapProcessorDAGLoads:
 
     def test_dag_has_correct_schedule(self):
         from congress_videos.reap_processor_dag import dag
-        assert dag.schedule == '30 14 * * *'
+        assert dag.schedule == '30 14,17 * * *'
 
     def test_dag_has_max_active_runs_1(self):
         from congress_videos.reap_processor_dag import dag

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -340,6 +340,7 @@ def _make_chapter_metadata(**overrides) -> dict:
         "topics": ["presupuestos"],
         "scoring_reasoning": "Alta relevancia",
         "relevance_score": 4,
+        "youtube_video_id": None,
         "source_video_title": None,
         "source_video_url": None,
         "session_number": None,
@@ -350,19 +351,58 @@ def _make_chapter_metadata(**overrides) -> dict:
 
 
 # ---------------------------------------------------------------------------
-# _generate_metadata — source video footer tests
+# _format_own_channel_footer — unit tests
+# ---------------------------------------------------------------------------
+
+class TestFormatOwnChannelFooter:
+
+    def test_returns_own_channel_url_when_id_present(self):
+        """Happy path: youtube_video_id set → footer with own-channel URL."""
+        from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
+
+        result = _format_own_channel_footer('abc123')
+
+        assert result == '\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v=abc123'
+
+    def test_returns_empty_string_when_id_is_none(self):
+        """Null guard: youtube_video_id=None → no footer (hard contract)."""
+        from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
+
+        result = _format_own_channel_footer(None)
+
+        assert result == ''
+
+    def test_returns_empty_string_when_id_is_empty_string(self):
+        """Empty-string guard: youtube_video_id='' → no footer."""
+        from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
+
+        result = _format_own_channel_footer('')
+
+        assert result == ''
+
+    def test_source_url_never_appears_in_footer(self):
+        """No fallback to source URL — only own-channel URL is used."""
+        from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
+
+        result = _format_own_channel_footer('yt-XYZ')
+
+        assert 'youtube.com/watch?v=yt-XYZ' in result
+        assert 'Extraído de:' not in result
+
+
+# ---------------------------------------------------------------------------
+# _generate_metadata — own-channel footer integration tests
 # ---------------------------------------------------------------------------
 
 class TestGenerateMetadataFooter:
 
-    def test_generate_metadata_footer_appended(self, mocker):
-        """AC#4 — description ends with footer when source_video_title and source_video_url are set."""
+    def test_generate_metadata_footer_appended_when_youtube_video_id_set(self, mocker):
+        """AC#4 — description ends with own-channel footer when youtube_video_id is set."""
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
         mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
         mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            source_video_title="Sesión plenaria 2024-01-15",
-            source_video_url="https://youtube.com/watch?v=abc123",
+            youtube_video_id='yt-own-abc',
         )
 
         mocker.patch("os.path.exists", return_value=False)
@@ -373,17 +413,17 @@ class TestGenerateMetadataFooter:
 
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
-        expected_suffix = "\n\n📺 Extraído de: Sesión plenaria 2024-01-15\nhttps://youtube.com/watch?v=abc123"
+        expected_suffix = '\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v=yt-own-abc'
         assert description.endswith(expected_suffix), f"Description was: {description!r}"
 
-    def test_generate_metadata_no_footer_when_source_null(self, mocker):
-        """AC#5 — description is unchanged when source_video_title is None."""
+    def test_generate_metadata_no_footer_when_youtube_video_id_null(self, mocker):
+        """AC#5 — description has NO footer and source URL does NOT appear when youtube_video_id is None."""
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
         mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
         mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            source_video_title=None,
-            source_video_url=None,
+            youtube_video_id=None,
+            source_video_url="https://youtube.com/watch?v=source-should-not-appear",
         )
 
         mocker.patch("os.path.exists", return_value=False)
@@ -394,7 +434,8 @@ class TestGenerateMetadataFooter:
 
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
-        assert "📺 Extraído de:" not in description
+        assert '📺 Vídeo completo:' not in description
+        assert 'source-should-not-appear' not in description
 
     def test_generate_metadata_source_fields_not_in_ai_prompt(self, mocker):
         """AC#6 — source_video_title and source_video_url must NOT appear in the AI user prompt."""
@@ -402,6 +443,7 @@ class TestGenerateMetadataFooter:
 
         mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
         mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
+            youtube_video_id='yt-prompt-test',
             source_video_title="Sesión con fuente",
             source_video_url="https://youtube.com/watch?v=xyz789",
         )

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -23,7 +23,7 @@ class TestReapShortsUploaderDAGLoads:
 
     def test_dag_schedule(self):
         from congress_videos.reap_shorts_uploader_dag import dag
-        assert dag.schedule == "0,30 17-20 * * *"
+        assert dag.schedule == '0 8,10,13,15,18,20,22 * * *'
 
     def test_dag_correct_task_ids(self):
         from congress_videos.reap_shorts_uploader_dag import dag


### PR DESCRIPTION
## Resumen

Lleva a `main` los 3 commits pendientes en `dev`:

- **feat(shorts): link short description to own-channel video** — añade el footer "📺 Vídeo completo" al short enlazando al vídeo de canal propio (`youtube_video_id`). Solo LECTURA de columna ya existente en `video_chapters`, **sin migración nueva**.
- **fix(reap): run congress_reap_processor at 14:30 and 17:30 UTC** — ajuste de schedule del DAG.
- **fix(test): update stale shorts uploader schedule assertion** — alinea el test con el nuevo schedule.

## Notas

- ✅ **No requiere migración de BD** — `youtube_video_id` ya existe en el esquema base de `video_chapters`.
- Fast-forward limpio sobre `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)