### PR TITLE
feat(chapter-uploader): upload failure tracking + DAG parse timeout fix

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -225,3 +225,9 @@ congress_channel_logo.png
 channels4_profile.jpg
 test_thumbnail*.jpg
 thumbnail_*.jpg
+thumbnail_*.png
+
+# Local tool state
+.atl/
+.pi/
+opencode.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -64,3 +64,17 @@ The `utils/` folder contains common functionality shared across all DAG projects
 - **Install dependencies**: `conda run -n airflow pip install <package>`
 - **Required packages**: beautifulsoup4, requests, urllib3, apache-airflow, openai (when needed)
 - Always use the conda environment to ensure consistent dependencies and avoid module conflicts
+
+## Agent skills
+
+### Issue tracker
+
+Issues live in GitHub Issues. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Default five-label vocabulary. See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context layout — `CONTEXT.md` + `docs/adr/` at repo root. See `docs/agents/domain.md`.

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -11,6 +11,8 @@ import logging
 
 logger = logging.getLogger(__name__)
 
+CHAPTER_UPLOAD_ABANDON_THRESHOLD = 3  # 3rd recorded failure excludes the chapter
+
 class CongressionalVideoDB:
     """Database operations for congressional video management"""
 
@@ -766,6 +768,43 @@ class CongressionalVideoDB:
                     WHERE chapter_id = %s
                 """, (youtube_video_id, chapter_id))
                 logger.info(f"Marked chapter {chapter_id} as uploaded to YouTube: {youtube_video_id}")
+
+    def record_chapter_upload_failure(self, chapter_id: int, error_message: str | None = None) -> None:
+        """
+        Record a failed per-chapter YouTube upload attempt.
+
+        Increments the cumulative failure counter and, once it reaches
+        CHAPTER_UPLOAD_ABANDON_THRESHOLD (3), marks the chapter abandoned so it is
+        excluded from uploadable_chapters. The row is never deleted; the counter is
+        cumulative for the life of the row and never resets or un-abandons.
+
+        Args:
+            chapter_id: Database ID of the chapter that failed to upload.
+            error_message: Optional last error text from the upload result payload.
+        """
+        chapters_table = self.pg_conn.get_qualified_table('video_chapters')
+
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(f"""
+                    UPDATE {chapters_table} SET
+                        upload_attempts = upload_attempts + 1,
+                        last_upload_error = %s,
+                        is_upload_abandoned = (upload_attempts + 1 >= {CHAPTER_UPLOAD_ABANDON_THRESHOLD}),
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    RETURNING upload_attempts, is_upload_abandoned
+                """, (error_message, chapter_id))
+                result = cur.fetchone()
+                logger.info(
+                    f"Recorded upload failure for chapter {chapter_id} "
+                    f"(threshold={CHAPTER_UPLOAD_ABANDON_THRESHOLD})"
+                )
+                if result and result.get('upload_attempts') == CHAPTER_UPLOAD_ABANDON_THRESHOLD:
+                    logger.warning(
+                        f"Chapter {chapter_id} abandoned after "
+                        f"{CHAPTER_UPLOAD_ABANDON_THRESHOLD} failed uploads"
+                    )
 
     # ==================== Video Shorts (Reap Pipeline) ====================
 

--- a/congress_videos/modules/postgres_operators.py
+++ b/congress_videos/modules/postgres_operators.py
@@ -1,10 +1,13 @@
 """Custom PostgreSQL operators for Airflow."""
 
+import logging
 from typing import Dict, Optional
 
 from airflow.models import BaseOperator
 
 from .database import CongressionalVideoDB
+
+logger = logging.getLogger(__name__)
 
 class PostgreSQLOperator(BaseOperator):
     """Custom operator for PostgreSQL operations with XCom integration"""
@@ -399,6 +402,7 @@ class PostgreSQLOperator(BaseOperator):
             else:
                 updated_count = 0
                 failed_count = 0
+                recorded_failures = 0
                 details = []
 
                 for upload_detail in upload_results['upload_details']:
@@ -425,12 +429,35 @@ class PostgreSQLOperator(BaseOperator):
                             })
                             print(f"❌ Failed to mark chapter {chapter_id}: {e}")
                     elif not success:
-                        print(f"⏭️ Skipping chapter {chapter_id}: upload was not successful")
-                        details.append({
-                            'chapter_id': chapter_id,
-                            'status': 'skipped',
-                            'reason': 'upload_failed'
-                        })
+                        if chapter_id:
+                            try:
+                                db.record_chapter_upload_failure(chapter_id, upload_detail.get('error'))
+                                recorded_failures += 1
+                                details.append({
+                                    'chapter_id': chapter_id,
+                                    'status': 'failure_recorded',
+                                })
+                                print(f"📉 Recorded upload failure for chapter {chapter_id}")
+                            except Exception as e:
+                                failed_count += 1
+                                details.append({
+                                    'chapter_id': chapter_id,
+                                    'status': 'failed',
+                                    'error': str(e),
+                                })
+                                print(f"❌ Failed to record upload failure for chapter {chapter_id}: {e}")
+                                logger.error(
+                                    f"Failed to RECORD upload failure for chapter {chapter_id} in the "
+                                    f"database (this attempt's failure count is now uncounted): {e}"
+                                )
+                        else:
+                            # Defensive: no resolvable chapter_id — cannot target a row, log-and-skip (no DB write)
+                            print("⏭️ Skipping failed upload with no chapter_id")
+                            details.append({
+                                'chapter_id': chapter_id,
+                                'status': 'skipped',
+                                'reason': 'upload_failed_no_chapter_id',
+                            })
                     elif success and (not chapter_id or not youtube_video_id):
                         # Debug: upload succeeded but missing tracking fields
                         print(f"⚠️ Upload succeeded but missing fields: chapter_id={chapter_id}, youtube_video_id={youtube_video_id}")
@@ -444,9 +471,10 @@ class PostgreSQLOperator(BaseOperator):
                 result = {
                     'updated_chapters': updated_count,
                     'failed_updates': failed_count,
+                    'recorded_failures': recorded_failures,
                     'details': details
                 }
-                print(f"✅ Updated {updated_count} chapters, {failed_count} failed")
+                print(f"✅ Updated {updated_count} chapters, {failed_count} failed, {recorded_failures} failures recorded")
 
         elif self.operation == 'get_chapters_for_shorts':
             """Get video chapters eligible for Reap Shorts processing"""

--- a/congress_videos/scripts/check_pending_source_integrity.py
+++ b/congress_videos/scripts/check_pending_source_integrity.py
@@ -1,0 +1,102 @@
+"""
+Check source-file integrity for videos pending chapter upload.
+
+Queries the ``uploadable_chapters`` view for chapters not yet uploaded,
+resolves each unique source video on disk (same lookup logic as
+``extract_chapters_from_video``), and runs a full ffmpeg decode-to-null
+pass per source to detect corrupted files before extraction runs.
+
+Usage (inside the airflow container, same env as the DAGs):
+    conda run -n airflow python congress_videos/scripts/check_pending_source_integrity.py
+    conda run -n airflow python congress_videos/scripts/check_pending_source_integrity.py --min-relevance-score 4
+"""
+
+import argparse
+import os
+import subprocess
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from congress_videos.modules.database import CongressionalVideoDB  # noqa: E402
+from utils.airflow_helpers import ensure_project_data_directory  # noqa: E402
+
+
+def find_source_video(data_directory: str, video_id: str) -> str | None:
+    """Locate the source video file, mirroring extract_chapters_from_video's lookup."""
+    downloads_folder = os.path.join(data_directory, 'downloads')
+    if not os.path.exists(downloads_folder):
+        return None
+
+    video_extensions = ('.mp4', '.mkv', '.webm')
+    for date_folder in os.listdir(downloads_folder):
+        video_folder = os.path.join(downloads_folder, date_folder, str(video_id))
+        if not os.path.exists(video_folder):
+            continue
+        for file in os.listdir(video_folder):
+            if file.endswith(video_extensions) and 'chapter_video' not in file:
+                return os.path.join(video_folder, file)
+    return None
+
+
+def check_integrity(source_path: str) -> tuple[bool, int]:
+    """Full decode-to-null pass. Returns (ok, error_line_count)."""
+    result = subprocess.run(
+        [
+            'ffmpeg', '-v', 'error', '-err_detect', 'ignore_err',
+            '-i', source_path, '-f', 'null', '-',
+        ],
+        capture_output=True,
+        text=True,
+    )
+    error_lines = [line for line in result.stderr.splitlines() if line.strip()]
+    return result.returncode == 0, len(error_lines)
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument('--min-relevance-score', type=int, default=4)
+    parser.add_argument('--limit', type=int, default=None)
+    args = parser.parse_args()
+
+    db = CongressionalVideoDB()
+    chapters = db.get_uploadable_chapters(
+        limit=args.limit, min_relevance_score=args.min_relevance_score
+    )
+
+    if not chapters:
+        print("No pending uploadable chapters found.")
+        return
+
+    video_ids = sorted({c['video_id'] for c in chapters})
+    print(f"{len(chapters)} pending chapters across {len(video_ids)} source video(s).\n")
+
+    data_directory = ensure_project_data_directory('congress_videos')
+
+    results = []
+    for video_id in video_ids:
+        source_path = find_source_video(data_directory, video_id)
+        if not source_path:
+            print(f"[MISSING] {video_id}: no source file found on disk")
+            results.append((video_id, 'MISSING', None))
+            continue
+
+        print(f"Checking {video_id} ({os.path.basename(source_path)}) ...", flush=True)
+        ok, error_count = check_integrity(source_path)
+        status = 'OK' if ok else 'CORRUPT'
+        print(f"  -> {status} ({error_count} decode error lines)")
+        results.append((video_id, status, error_count))
+
+    print("\n--- Summary ---")
+    for video_id, status, error_count in results:
+        suffix = f" ({error_count} errors)" if error_count is not None else ""
+        print(f"{video_id}: {status}{suffix}")
+
+    corrupt = [r for r in results if r[1] in ('CORRUPT', 'MISSING')]
+    if corrupt:
+        print(f"\n{len(corrupt)} video(s) need attention: {[r[0] for r in corrupt]}")
+        sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()

--- a/congress_videos/sql/migrations/011_add_chapter_upload_failure_tracking.sql
+++ b/congress_videos/sql/migrations/011_add_chapter_upload_failure_tracking.sql
@@ -1,0 +1,62 @@
+-- Migration: Add per-chapter upload failure tracking + exclude abandoned chapters
+-- Created: 2026-07-23
+-- Depends on: 010_add_timeline_column.sql (uploadable_chapters view),
+--             youtube_chapters_schema.sql (video_chapters table)
+--
+-- Records per-chapter YouTube upload failures (partial failures inside an otherwise
+-- successful generic_youtube_uploader run). After the 3rd recorded failure a chapter is
+-- soft-excluded from the upload queue via is_upload_abandoned; the row is never deleted.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + DROP VIEW IF EXISTS + CREATE VIEW are safe to
+-- re-run. Runner runs `SET search_path TO {schema}, public` first, so names are UNQUALIFIED.
+--
+-- Example (development): psql ... -c "SET search_path TO development, public;" -f 011_add_chapter_upload_failure_tracking.sql
+-- Example (production):  psql ... -c "SET search_path TO production, public;"  -f 011_add_chapter_upload_failure_tracking.sql
+
+-- Step 1: Add failure-tracking columns (additive, safe defaults).
+ALTER TABLE video_chapters
+    ADD COLUMN IF NOT EXISTS upload_attempts INTEGER DEFAULT 0;
+ALTER TABLE video_chapters
+    ADD COLUMN IF NOT EXISTS is_upload_abandoned BOOLEAN DEFAULT FALSE;
+ALTER TABLE video_chapters
+    ADD COLUMN IF NOT EXISTS last_upload_error TEXT;
+
+-- Step 2: Recreate uploadable_chapters to also exclude abandoned chapters.
+-- SELECT list is IDENTICAL to migration 010; only the WHERE clause gains the new predicate.
+-- DROP + CREATE (not CREATE OR REPLACE) for consistency with 010 and unconditional safety.
+DROP VIEW IF EXISTS uploadable_chapters;
+CREATE VIEW uploadable_chapters AS
+SELECT
+    vc.chapter_id,
+    vc.video_id,
+    ysv.video_title AS source_video_title,
+    ysv.session_number,
+    ysv.session_date,
+    vc.title AS chapter_title,
+    vc.description,
+    vc.duration_minutes,
+    vc.speakers,
+    vc.topics,
+    vc.timeline,
+    vc.start_time,
+    vc.end_time,
+    vc.relevance_score,
+    vc.speaker_relevance_points,
+    vc.topic_relevance_points,
+    vc.public_interest_points,
+    vc.scoring_reasoning,
+    vc.key_speakers,
+    vc.is_current_topic,
+    vc.is_uploaded_to_youtube,
+    vc.created_at,
+    CURRENT_DATE - DATE(vc.created_at) AS days_since_created
+FROM video_chapters vc
+JOIN youtube_source_videos ysv ON vc.video_id = ysv.video_id
+WHERE
+    vc.is_uploaded_to_youtube = FALSE
+    AND vc.relevance_score >= 2
+    AND vc.is_upload_abandoned = FALSE
+ORDER BY
+    ysv.session_date DESC NULLS LAST,
+    vc.relevance_score DESC,
+    vc.created_at DESC;

--- a/congress_videos/sql/production_schema.sql
+++ b/congress_videos/sql/production_schema.sql
@@ -93,6 +93,11 @@ CREATE TABLE IF NOT EXISTS production.video_chapters (
     youtube_video_id VARCHAR(50), -- YouTube video ID once uploaded as separate video
     youtube_upload_date TIMESTAMP,
 
+    -- Upload failure tracking (soft-delete after repeated failures)
+    upload_attempts INTEGER DEFAULT 0,
+    is_upload_abandoned BOOLEAN DEFAULT FALSE,
+    last_upload_error TEXT,
+
     -- Timestamps
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -145,6 +150,7 @@ JOIN production.youtube_source_videos ysv ON vc.video_id = ysv.video_id
 WHERE
     vc.is_uploaded_to_youtube = FALSE
     AND vc.relevance_score >= 2  -- Only high-relevance chapters (score >= 2/5)
+    AND vc.is_upload_abandoned = FALSE
 ORDER BY
     vc.relevance_score DESC,  -- Higher relevance score first
     vc.created_at DESC;        -- Newer chapters first
@@ -194,5 +200,8 @@ COMMENT ON COLUMN production.video_chapters.relevance_score IS 'Total relevance 
 COMMENT ON COLUMN production.video_chapters.speaker_relevance_points IS 'Speaker relevance (0-2): Are key political figures involved?';
 COMMENT ON COLUMN production.video_chapters.topic_relevance_points IS 'Topic relevance (0-2): Is it a current/hot topic in Spain?';
 COMMENT ON COLUMN production.video_chapters.public_interest_points IS 'Public interest (0-1): Could it generate media interest?';
+COMMENT ON COLUMN production.video_chapters.upload_attempts IS 'Cumulative count of recorded per-chapter upload FAILURES (successes never touch it)';
+COMMENT ON COLUMN production.video_chapters.is_upload_abandoned IS 'TRUE once upload_attempts reaches the abandon threshold (3); excludes the chapter from uploadable_chapters';
+COMMENT ON COLUMN production.video_chapters.last_upload_error IS 'Last recorded per-chapter upload failure message';
 COMMENT ON VIEW production.uploadable_chapters IS 'Shows chapters eligible for YouTube upload (relevance_score >= 2)';
 COMMENT ON VIEW production.chapter_statistics IS 'Provides aggregate statistics about chapters by source video';

--- a/congress_videos/sql/youtube_chapters_schema.sql
+++ b/congress_videos/sql/youtube_chapters_schema.sql
@@ -79,6 +79,11 @@ CREATE TABLE IF NOT EXISTS development.video_chapters (
     youtube_video_id VARCHAR(50), -- YouTube video ID once uploaded as separate video
     youtube_upload_date TIMESTAMP,
 
+    -- Upload failure tracking (soft-delete after repeated failures)
+    upload_attempts INTEGER DEFAULT 0,
+    is_upload_abandoned BOOLEAN DEFAULT FALSE,
+    last_upload_error TEXT,
+
     -- Timestamps
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -129,6 +134,7 @@ JOIN development.youtube_source_videos ysv ON vc.video_id = ysv.video_id
 WHERE
     vc.is_uploaded_to_youtube = FALSE
     AND vc.relevance_score >= 2  -- Only high-relevance chapters (score >= 4/5)
+    AND vc.is_upload_abandoned = FALSE
 ORDER BY
     ysv.session_date DESC NULLS LAST,  -- Most recent session first
     vc.relevance_score DESC,           -- Highest score within same session
@@ -173,5 +179,8 @@ COMMENT ON COLUMN development.video_chapters.relevance_score IS 'Total relevance
 COMMENT ON COLUMN development.video_chapters.speaker_relevance_points IS 'Speaker relevance (0-2): Are key political figures involved?';
 COMMENT ON COLUMN development.video_chapters.topic_relevance_points IS 'Topic relevance (0-2): Is it a current/hot topic in Spain?';
 COMMENT ON COLUMN development.video_chapters.public_interest_points IS 'Public interest (0-1): Could it generate media interest?';
+COMMENT ON COLUMN development.video_chapters.upload_attempts IS 'Cumulative count of recorded per-chapter upload FAILURES (successes never touch it)';
+COMMENT ON COLUMN development.video_chapters.is_upload_abandoned IS 'TRUE once upload_attempts reaches the abandon threshold (3); excludes the chapter from uploadable_chapters';
+COMMENT ON COLUMN development.video_chapters.last_upload_error IS 'Last recorded per-chapter upload failure message';
 COMMENT ON VIEW development.uploadable_chapters IS 'Shows chapters eligible for YouTube upload (relevance_score >= 4)';
 COMMENT ON VIEW development.chapter_statistics IS 'Provides aggregate statistics about chapters by source video';

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -27,10 +27,6 @@ from airflow.operators.python import PythonOperator, ShortCircuitOperator
 from airflow.api.common.trigger_dag import trigger_dag as trigger_dag_api
 
 from congress_videos.modules.postgres_operators import PostgreSQLOperator
-from congress_videos.modules.youtube import youtube_ai
-from congress_videos.modules.youtube import prepare_chapter_upload_config
-from congress_videos.modules import thumbnail_generator as thumb_gen
-from congress_videos.modules import video_splitter
 from utils.airflow_helpers import ensure_project_data_directory, xcom_task
 from utils.env_loader import load_env_if_local
 
@@ -99,69 +95,54 @@ with DAG(
         output_xcom_key='uploadable_chapters'
     )
 
-    # Step 2: Generate YouTube metadata for chapters
-    # Uses chapter title, description, speakers, and topics to create
-    # optimized YouTube titles and descriptions
-    t2 = PythonOperator(
-        task_id='generate_youtube_metadata',
-        python_callable=lambda ti: xcom_task(
+    def _generate_youtube_metadata(ti):
+        from congress_videos.modules.youtube import youtube_ai
+        return xcom_task(
             ti,
             lambda: youtube_ai.generate_youtube_metadata_for_selected_videos(
                 ti.xcom_pull(key='uploadable_chapters')
             ),
             'youtube_metadata_results'
-        ),
-    )
+        )
 
-    # Step 3: Generate thumbnail text using AI (3-6 words, max 40 chars)
-    t3 = PythonOperator(
-        task_id='generate_thumbnail_text',
-        python_callable=lambda ti: xcom_task(
+    def _generate_thumbnail_text(ti):
+        from congress_videos.modules import thumbnail_generator as thumb_gen
+        return xcom_task(
             ti,
             lambda: thumb_gen.generate_thumbnail_text_for_videos(
                 ti.xcom_pull(key='uploadable_chapters'),
                 ti.xcom_pull(key='youtube_metadata_results')
             ),
             'thumbnail_text_results'
-        ),
-    )
+        )
 
-    # Step 4: Generate thumbnails and save to video_id/chapter_id/ folder
-    # Creates folder structure: data/congress_videos/{video_id}/{chapter_id}/thumbnail.png
-    t4 = PythonOperator(
-        task_id='generate_thumbnails',
-        python_callable=lambda ti: xcom_task(
+    def _generate_thumbnails(ti):
+        from congress_videos.modules import thumbnail_generator as thumb_gen
+        return xcom_task(
             ti,
             lambda: thumb_gen.generate_video_thumbnails(
                 ti.xcom_pull(key='uploadable_chapters'),
                 ti.xcom_pull(key='thumbnail_text_results'),
-                None,  # No download_results for chapters
+                None,
                 ti.xcom_pull(key='data_directory_path')
             ),
             'thumbnail_results'
-        ),
-    )
+        )
 
-    # Step 5: Extract chapter videos from source YouTube videos using ffmpeg
-    # For each chapter, extracts video segment using start_time and end_time
-    # Saves to: data/congress_videos/{video_id}/{chapter_id}/chapter_video.mp4
-    t5 = PythonOperator(
-        task_id='extract_chapter_videos',
-        python_callable=lambda ti: xcom_task(
+    def _extract_chapter_videos(ti):
+        from congress_videos.modules import video_splitter
+        return xcom_task(
             ti,
             lambda: video_splitter.extract_chapters_from_video(
                 ti.xcom_pull(key='uploadable_chapters'),
                 ti.xcom_pull(key='data_directory_path')
             ),
             'chapter_extraction_results'
-        ),
-    )
+        )
 
-    # Step 6: Prepare upload configuration for generic YouTube uploader DAG
-    # Combines extraction results, metadata, and thumbnails into upload config
-    t6 = PythonOperator(
-        task_id='prepare_upload_config',
-        python_callable=lambda ti, **context: xcom_task(
+    def _prepare_upload_config(ti, **context):
+        from congress_videos.modules.youtube import prepare_chapter_upload_config
+        return xcom_task(
             ti,
             lambda: prepare_chapter_upload_config(
                 ti.xcom_pull(key='chapter_extraction_results'),
@@ -170,7 +151,36 @@ with DAG(
                 is_testing=context["params"].get("isTesting", False)
             ),
             'upload_config'
-        ),
+        )
+
+    # Step 2: Generate YouTube metadata for chapters
+    t2 = PythonOperator(
+        task_id='generate_youtube_metadata',
+        python_callable=_generate_youtube_metadata,
+    )
+
+    # Step 3: Generate thumbnail text using AI (3-6 words, max 40 chars)
+    t3 = PythonOperator(
+        task_id='generate_thumbnail_text',
+        python_callable=_generate_thumbnail_text,
+    )
+
+    # Step 4: Generate thumbnails and save to video_id/chapter_id/ folder
+    t4 = PythonOperator(
+        task_id='generate_thumbnails',
+        python_callable=_generate_thumbnails,
+    )
+
+    # Step 5: Extract chapter videos from source YouTube videos using ffmpeg
+    t5 = PythonOperator(
+        task_id='extract_chapter_videos',
+        python_callable=_extract_chapter_videos,
+    )
+
+    # Step 6: Prepare upload configuration for generic YouTube uploader DAG
+    t6 = PythonOperator(
+        task_id='prepare_upload_config',
+        python_callable=_prepare_upload_config,
     )
 
     # Step 7: Trigger generic YouTube uploader DAG and wait for completion

--- a/docs/PLAN_GENERALIZACION_BEST_MOMENTS.md
+++ b/docs/PLAN_GENERALIZACION_BEST_MOMENTS.md
@@ -1,0 +1,426 @@
+# Plan de Generalización: Detección de Mejores Momentos en Videos Largos
+
+> **Autor:** Alonso Zurera & Buffy (AI Assistant)
+> **Fecha:** 2026-07-23
+> **Estado:** ✅ Plan consolidado (v2) — listo para Fase 1a
+
+---
+
+## 1. Resumen Ejecutivo
+
+Actualmente el proyecto tiene un pipeline altamente especializado para **sesiones plenarias del Congreso de los Diputados de España** (`congress_youtube_channel_monitor` DAG). El objetivo es **generalizar** el núcleo del pipeline —la detección de los mejores momentos en videos largos— para que sea reutilizable con **cualquier tipo de video largo**, en cualquier idioma, con cualquier dominio temático.
+
+---
+
+## 2. Lo que YA tenemos (inventario de assets reutilizables)
+
+### 2.1 Pipeline core (el "corazón" de la detección)
+
+El pipeline actual, que vive en `congress_videos/modules/youtube/download.py`, es:
+
+```
+[Vídeo largo + Transcripción/SRT]
+    │
+    ▼
+① split_srt_by_silence()       → divide SRT en chunks por pausas de silencio
+    │                              (detección adaptativa de gaps)
+    ▼
+② summarize_silence_chunks()    → cada chunk → GPT-4o-mini extrae:
+    │                              speakers, topics, timeline, summary
+    ▼
+③ identify_interesting_chapters() → AI decide si dividir el chunk en
+    │                               sub-capítulos (con map-reduce para SRTs largos)
+    ▼
+④ merge_interesting_chapters()  → consolida y deduplica capítulos
+    │
+    ▼
+⑤ score_chapters_relevance()    → puntúa cada capítulo (0-5)
+    │                              con 3 criterios: speaker, topic, interés público
+    ▼
+⑥ [Guardar en DB / subir a YouTube / crear Shorts]
+```
+
+### 2.2 Módulos y utilidades reutilizables
+
+| Módulo | Qué hace | Acoplamiento |
+|---|---|---|
+| `utils/ai_chapter_analyzer.py` | `detect_silence_gaps()`, `chunk_by_silence()` | **Bajo** — genérico, opera sobre texto SRT |
+| `congress_videos/modules/youtube/map_reduce_chapters.py` | `window_srt()`, `map_chapters()`, `reduce_chapters()` | **Bajo** — genérico, recibe `identify_fn` inyectable |
+| `congress_videos/srt_helpers.py` | `parse_srt_to_text()`, `select_pretrim_window()` | **Medio** — pre-trim usa prompt fijo |
+| `congress_videos/modules/vad_helpers.py` | VAD para trim de silencio en bordes | **Bajo** — genérico |
+| `congress_videos/modules/video_splitter.py` | `split_video_chapter()`, `build_ffmpeg_cut_cmd()` | **Bajo** — genérico |
+| `utils/ai_helpers.py` | `generate_json_completion()` | **Bajo** — wrapper genérico de OpenAI |
+| `utils/llm_cache.py` | `cached_json_completion()` | **Bajo** — cache idempotente genérico |
+| `utils/whisper_helpers.py` | `transcribe_audio_file()`, `merge_srt_files()` | **Bajo** — genérico |
+| `utils/time_utils.py` | `parse_timestamp()`, `format_timestamp()` | **Bajo** — utilidades puras |
+| `congress_videos/modules/youtube/youtube_ai.py` | `score_chapters_relevance()`, metadata generation | **Alto** — específico del Congreso |
+| `congress_videos/config/ai_prompts.py` | **TODOS los prompts de IA** | **Alto** — 100% específico |
+
+---
+
+## 3. Diagnóstico: ¿Qué está acoplado al Congreso?
+
+### 3.1 Prompts de IA (el acoplamiento más fuerte)
+
+**Archivo:** `congress_videos/config/ai_prompts.py`
+
+Todos los prompts asumen: debates parlamentarios españoles, oradores políticos, temas de actualidad española, idioma español.
+
+**Prompts a generalizar:**
+
+| Prompt | Estrategia |
+|---|---|
+| `CHAPTER_IDENTIFICATION_SYSTEM_PROMPT` | → Parametrizar con `{content_type}` y `{language}` |
+| `CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE` | → Parametrizar con ejemplos del dominio |
+| `CHAPTER_RELEVANCE_SCORING_SYSTEM_PROMPT` | → Criterios configurables desde YAML/JSON |
+| `CHAPTER_RELEVANCE_SCORING_USER_PROMPT_TEMPLATE` | → Parametrizar con `{current_date}`, `{domain_context}` |
+| `CHUNK_SUMMARY_SYSTEM_PROMPT` | → Generalizar |
+| `CHUNK_SUMMARY_USER_PROMPT_TEMPLATE` | → Ya es relativamente genérico |
+| `SHORTS_METADATA_*` | → Fuera del scope (no generalizamos Shorts) |
+
+### 3.2 Lógica de scoring
+
+El scoring 0-5 actual es inherentemente político: speaker_relevance (Sánchez/Feijóo), topic_relevance (crisis/escaándalos), public_interest (confrontación). Para otros dominios los criterios son completamente distintos.
+
+---
+
+## 4. TODAS las decisiones tomadas ✅
+
+| # | Decisión | Elección |
+|---|---|---|
+| 1 | Dominios adicionales | Conferencias tech, podcasts (contenido basado en diálogo) |
+| 2 | ¿Generalizar Shorts/Reap también? | **NO** — solo el pipeline de detección de capítulos |
+| 3 | Compatibilidad hacia atrás | **SÍ** — el Congreso debe funcionar exactamente igual |
+| 4 | Escala de scoring | **0-5 fija** para todos los dominios |
+| 5 | Input del motor | **`video_path` + `srt_path` opcional** |
+| 6 | Output del motor | **Devuelve datos + guarda en DB** (si se pasa conexión) |
+| 7 | Modelos de IA | **Solo OpenAI (GPT-4o-mini)** por ahora |
+| 8 | Formato de DomainConfig | **YAML / JSON** por dominio |
+| 9 | API pública | **Función `pipeline()`** — simple, testeable, sin Airflow |
+| 10 | Manejo de errores | **Best-effort** — fallbacks, nunca crashea |
+| 11 | Transcripción | **Automática con Whisper** si no se pasa SRT |
+| 12 | Nombre del módulo | `utils/best_moments/` |
+
+---
+
+## 5. Arquitectura final propuesta
+
+### 5.1 Testing strategy: LLM inyectable
+
+El motor genérico debe ser **testeable sin llamadas reales a OpenAI**. Para ello,
+el pipeline recibe un `llm_client` inyectable (Protocol) que los tests pueden
+reemplazar con un mock. Esto sigue el mismo patrón que `map_reduce_chapters` ya
+usa con `identify_fn`.
+
+```python
+class LLMClient(Protocol):
+    """Interface for LLM calls — swap for mocks in tests."""
+    def json_completion(
+        self, system_prompt: str, user_prompt: str,
+        *, model: str, temperature: float, max_tokens: int
+    ) -> dict: ...
+```
+
+En producción se inyecta `OpenAIClient` (wrapper de `generate_json_completion`).
+En tests se inyecta un mock que devuelve respuestas predefinidas.
+
+### 5.2 API pública
+
+```python
+# utils/best_moments/pipeline.py
+
+def pipeline(
+    video_path: str,
+    domain_config_path: str,        # path a YAML/JSON
+    *,
+    save_callback: Callable[[PipelineResult], None] | None = None,
+    srt_path: str | None = None,
+    llm_client: LLMClient | None = None,  # inyectable para tests
+) -> PipelineResult:
+    """
+    Detecta los mejores momentos en un video largo.
+
+    Args:
+        video_path: Ruta al archivo de video (.mp4, .mkv, .webm).
+        domain_config_path: Ruta al archivo YAML/JSON de configuración del dominio.
+        save_callback: Si se proporciona, se llama con el PipelineResult para
+            persistir los capítulos. El motor NUNCA toca la DB directamente.
+        srt_path: Ruta opcional a SRT existente. Si no se da, se transcribe con Whisper.
+        llm_client: Cliente LLM inyectable. Si es None, se usa OpenAIClient por defecto.
+            Los tests inyectan un mock para evitar llamadas reales a OpenAI.
+
+    Returns:
+        PipelineResult con scored_chapters y metadata.
+
+    Ejemplo desde el DAG del Congreso:
+        result = pipeline(
+            video_path,
+            "congress_videos/config/domain_config.yaml",
+            save_callback=lambda r: db.save_youtube_chapters_to_db(
+                r.to_scored_chapters_dict()
+            ),
+        )
+
+    Ejemplo en un test:
+        mock_llm = MockLLMClient({"interesting_chapters": [...]})
+        result = pipeline(video_path, config, llm_client=mock_llm)
+        assert result.total_chapters == 3
+    """
+```
+
+> **Decisión de diseño:** Usamos un **callback** para persistencia + **LLM inyectable**
+> para testing. El motor no sabe nada de PostgreSQL ni requiere OpenAI real para ser testeado.
+
+### 5.2 Estructura de archivos
+
+```
+utils/
+  best_moments/                          ← NUEVO: motor genérico
+    __init__.py
+    pipeline.py                          ← orquesta el pipeline ①→⑤
+    config.py                            ← carga DomainConfig desde YAML/JSON
+    scoring.py                           ← scoring 0-5 con criterios configurables
+    prompts.py                           ← prompts parametrizables con {placeholders}
+    types.py                             ← dataclasses: DomainConfig, PipelineResult, Chapter
+    map_reduce.py                        ← movido desde congress_videos/modules/youtube/
+    chunking.py                          ← split por silencio (movido de download.py)
+    temp_files.py                        ← gestión de archivos temporales SRT
+  vad_helpers.py                         ← movido desde congress_videos/modules/
+  ai_chapter_analyzer.py                 ← se queda, ya es genérico
+
+congress_videos/                         ← instancia de dominio
+  config/
+    domain_config.yaml                   ← configuración YAML del Congreso
+    ai_prompts.py                        ← prompts específicos del Congreso (se mantienen)
+  modules/
+    youtube/
+      download.py                        ← SOLO descarga de video/audio (yt-dlp)
+      youtube_ai.py                      ← metadata YouTube (titles, descriptions, chapters block)
+    srt_helpers.py                       ← pre-trim para Shorts (se queda en Congreso)
+
+docs/
+  PLAN_GENERALIZACION_BEST_MOMENTS.md    ← este documento
+```
+
+### 5.3 DomainConfig (YAML)
+
+```yaml
+# congress_videos/config/domain_config.yaml
+domain_name: "congress"
+language: "es"
+language_name: "español"
+content_type: "sesiones parlamentarias españolas"
+
+transcription:
+  whisper_model_size: "tiny"
+  prefer_youtube_subtitles: true
+
+chunking:
+  min_silence_seconds: 15
+  min_chunk_duration_minutes: 10
+  max_chunk_duration_minutes: 20
+  use_adaptive_silence: true
+  adaptive_percentile: 75.0
+
+chapter_identification:
+  min_chapter_duration_minutes: 15
+  max_chapter_duration_minutes: 120
+  llm_model: "gpt-4o-mini"
+  map_reduce_window_chars: 80000
+  map_reduce_overlap_pct: 0.12
+
+scoring:
+  criteria:
+    - name: "speaker_relevance"
+      display_name: "Relevancia de los Speakers"
+      max_points: 2
+      description: "¿Participan líderes de partidos o gobierno?"
+      examples: |
+        - 2 puntos: Presidente del Gobierno, líder de la oposición, vicepresidenta
+        - 1 punto: Ministros, portavoces parlamentarios
+        - 0 puntos: Diputados sin relevancia mediática
+    - name: "topic_relevance"
+      display_name: "Actualidad de los Temas"
+      max_points: 2
+      description: "¿Es un tema candente en España?"
+      examples: |
+        - 2 puntos: Crisis nacionales, escándalos, reformas importantes
+        - 1 punto: Economía, empleo, vivienda, sanidad
+        - 0 puntos: Temas administrativos o técnicos
+    - name: "public_interest"
+      display_name: "Potencial de Interés Público"
+      max_points: 1
+      description: "¿Puede generar interés mediático o viral?"
+      examples: |
+        - 1 punto: Confrontación directa, revelaciones, potencial viral
+        - 0 puntos: Debate técnico sin elementos llamativos
+  min_upload_score: 2
+
+prompts:
+  chapter_identification_system: |
+    Eres un experto en identificar contenido interesante en {content_type} para crear clips.
+    ...
+  chapter_identification_user: |
+    Analiza este segmento de {content_type}...
+    {domain_specific_instructions}
+    ...
+```
+
+### 5.4 PipelineResult + conversión a dict para DB callback
+
+```python
+@dataclass
+class Chapter:
+    title: str
+    description: str
+    start_time: str           # "HH:MM:SS,mmm"
+    end_time: str             # "HH:MM:SS,mmm"
+    duration_minutes: float
+    speakers: list[str]
+    topics: list[str]
+    timeline: list[dict]      # [{time, speaker, content}, ...]
+    relevance_score: int      # 0-5
+    speaker_relevance_points: int   # 0-2
+    topic_relevance_points: int     # 0-2
+    public_interest_points: int     # 0-1
+    scoring_reasoning: str
+    key_speakers: list[str]
+    is_current_topic: bool
+
+    def to_dict(self) -> dict:
+        """Convertir al dict que espera el adapter de DB."""
+        return {
+            "title": self.title,
+            "description": self.description,
+            "start_time": self.start_time,
+            "end_time": self.end_time,
+            "duration_minutes": self.duration_minutes,
+            "speakers": self.speakers,
+            "topics": self.topics,
+            "timeline": self.timeline,
+            "relevance_score": self.relevance_score,
+            "speaker_relevance_points": self.speaker_relevance_points,
+            "topic_relevance_points": self.topic_relevance_points,
+            "public_interest_points": self.public_interest_points,
+            "scoring_reasoning": self.scoring_reasoning,
+            "key_speakers": self.key_speakers,
+            "is_current_topic": self.is_current_topic,
+        }
+
+@dataclass
+class PipelineResult:
+    video_id: str
+    video_title: str
+    total_chapters: int
+    chapters: list[Chapter]
+    errors: list[str]         # non-fatal errors (best-effort)
+    srt_path: str | None      # path al SRT usado/generado
+
+    def to_scored_chapters_dict(self) -> dict:
+        """
+        Convierte el resultado al formato exacto que espera
+        CongressionalVideoDB.save_youtube_chapters_to_db().
+
+        Este método es el contrato entre el motor genérico y los
+        adapters de persistencia de cada dominio.
+        """
+        return {
+            "total_videos": 1,
+            "total_chapters_scored": self.total_chapters,
+            "successful_scores": self.total_chapters,
+            "failed_scores": 0,
+            "videos": [{
+                "video_id": self.video_id,
+                "video_title": self.video_title,
+                "total_chapters": self.total_chapters,
+                "scored_chapters": [c.to_dict() for c in self.chapters],
+            }],
+        }
+```
+
+---
+
+## 6. Plan de Implementación (por fases)
+
+### Fase 1a: Crear el motor genérico (SIN tocar el Congreso)
+
+**Objetivo:** Crear `utils/best_moments/` completo, con tests, sin modificar
+**ni una sola línea** del código del Congreso. El Congreso sigue funcionando
+exactamente igual con su código actual.
+
+1. Crear `utils/best_moments/types.py` — `DomainConfig`, `ScoringCriterion`, `PipelineResult`, `Chapter`, `LLMClient` (Protocol)
+2. Crear `utils/best_moments/config.py` — carga `DomainConfig` desde YAML/JSON con defaults
+3. Crear `utils/best_moments/prompts.py` — prompts parametrizables con `{placeholders}`
+4. Crear `utils/best_moments/scoring.py` — scoring 0-5 genérico (reimplementa `score_chapters_relevance()` sin acoplamiento al Congreso)
+5. Mover `congress_videos/modules/youtube/map_reduce_chapters.py` → `utils/best_moments/map_reduce.py`
+6. Crear `utils/best_moments/chunking.py` — `split_by_silence()` + `summarize_chunks()` (extraídos de `download.py`)
+7. Crear `utils/best_moments/temp_files.py` — gestión de archivos temporales SRT
+8. Crear `utils/best_moments/pipeline.py` — orquestador ①→⑤, con `llm_client` inyectable
+9. Escribir tests unitarios con `MockLLMClient`
+
+### Fase 1b: Refactorizar el Congreso para usar el motor
+
+**Objetivo:** Hacer que `congress_videos/modules/youtube/download.py` delegue
+en `utils/best_moments/pipeline.py`. Verificar que el DAG funciona idéntico.
+
+1. Crear `congress_videos/config/domain_config.yaml` con la config del Congreso
+2. Refactorizar `download.py` para que sus funciones sean wrappers de `pipeline()`
+3. Actualizar imports en `youtube_channel_monitor_dag.py` si es necesario
+4. Ejecutar `pytest tests/congress_videos/ -x -q` — deben pasar todos
+5. Ejecutar `conda run -n airflow python -c "from congress_videos.youtube_channel_monitor_dag import dag"` — debe cargar sin errores
+
+### Fase 2: Primer dominio nuevo (prueba de fuego)
+
+1. Elegir un dominio (ej: conferencias tech)
+2. Crear `configs/tech_conference.yaml`
+3. Escribir tests para el nuevo dominio
+4. Ejecutar el pipeline con un video real y verificar resultados
+
+### Fase 3: Refactorización del DAG (opcional)
+
+1. Simplificar el DAG del Congreso para usar `pipeline()` directamente
+2. (Opcional) Crear un DAG factory genérico para Airflow
+
+---
+
+## 7. Riesgos y mitigaciones
+
+| Riesgo | Mitigación |
+|---|---|
+| **Sobre-generalización** | El Congreso sigue siendo "first-class citizen" con su config validada |
+| **Regresión en calidad del Congreso** | Tests de integración comparando outputs antes/después |
+| **Scoring inherentemente específico del dominio** | Criterios configurables vía YAML + prompt template por dominio |
+| **Complejidad del map-reduce** | Se mantiene tal cual — ya está bien desacoplado (recibe `identify_fn` inyectable) |
+| **🆕 Colisión de cache LLM entre dominios** | Incluir `domain_name` en la clave de hash de `llm_cache` |
+| **🆕 Archivos temporales de SRT** | El motor gestiona su propio `tempfile` lifecycle con limpieza al terminar |
+| **🆕 Acoplamiento de `vad_helpers` a `constants.py`** | Convertir constantes VAD en parámetros con defaults; mover a `utils/` |
+
+---
+
+## 8. Cómo `scoring.py` reemplaza `score_chapters_relevance()`
+
+Actualmente `score_chapters_relevance()` vive en `congress_videos/modules/youtube/youtube_ai.py`
+y usa prompts hardcodeados de `congress_videos/config/ai_prompts.py`. En el motor genérico:
+
+1. **`scoring.py`** contiene la lógica genérica: recibe capítulos + `DomainConfig.scoring.criteria`
+2. **Construye el prompt de scoring** usando los criterios del YAML (no prompts hardcodeados)
+3. **Llama al LLM** vía `llm_client.json_completion()` (inyectable)
+4. **Devuelve los capítulos puntuados** con `relevance_score` y campos de scoring
+
+El `youtube_ai.py` del Congreso se queda con las funciones que SÍ son específicas:
+`generate_youtube_title()`, `generate_youtube_description()`,
+`build_youtube_chapters_block()`, y `generate_youtube_metadata_for_selected_videos()`.
+
+---
+
+## 9. Próximos pasos
+
+1. ✅ Plan consolidado v2 (este documento)
+2. ⬜ Crear issues de GitHub para la Fase 1a
+3. ⬜ Implementar `utils/best_moments/types.py` + `config.py`
+4. ⬜ Implementar `utils/best_moments/prompts.py` + `scoring.py`
+5. ⬜ Implementar `utils/best_moments/chunking.py` + `temp_files.py`
+6. ⬜ Mover `map_reduce_chapters.py` → `utils/best_moments/map_reduce.py`
+7. ⬜ Implementar `utils/best_moments/pipeline.py`
+8. ⬜ Escribir tests unitarios con `MockLLMClient`
+9. ⬜ Fase 1b: Refactorizar Congreso + validar que no se rompe nada

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,35 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The `/domain-modeling` skill creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo:
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-example-decision.md
+│   └── 0002-another-decision.md
+└── src/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/domain-modeling`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (example) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,45 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## Pull requests as a triage surface
+
+**PRs as a request surface: no.** _(Set to `yes` if this repo treats external PRs as feature requests; `/triage` reads this flag.)_
+
+When set to `yes`, PRs run through the same labels and states as issues, using the `gh pr` equivalents:
+
+- **Read a PR**: `gh pr view <number> --comments` and `gh pr diff <number>` for the diff.
+- **List external PRs for triage**: `gh pr list --state open --json number,title,body,labels,author,authorAssociation,comments` then keep only `authorAssociation` of `CONTRIBUTOR`, `FIRST_TIME_CONTRIBUTOR`, or `NONE` (drop `OWNER`/`MEMBER`/`COLLABORATOR`).
+- **Comment / label / close**: `gh pr comment`, `gh pr edit --add-label`/`--remove-label`, `gh pr close`.
+
+GitHub shares one number space across issues and PRs, so a bare `#42` may be either — resolve with `gh pr view 42` and fall back to `gh issue view 42`.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.
+
+## Wayfinding operations
+
+Used by `/wayfinder`. The **map** is a single issue with **child** issues as tickets.
+
+- **Map**: a single issue labelled `wayfinder:map`, holding the Notes / Decisions-so-far / Fog body. `gh issue create --label wayfinder:map`.
+- **Child ticket**: an issue linked to the map as a GitHub sub-issue (`gh api` on the sub-issues endpoint). Where sub-issues aren't enabled, add the child to a task list in the map body and put `Part of #<map>` at the top of the child body. Labels: `wayfinder:<type>` (`research`/`prototype`/`grilling`/`task`). Once claimed, the ticket is assigned to the driving dev.
+- **Blocking**: GitHub's **native issue dependencies** — the canonical, UI-visible representation. Add an edge with `gh api --method POST repos/<owner>/<repo>/issues/<child>/dependencies/blocked_by -F issue_id=<blocker-db-id>`, where `<blocker-db-id>` is the blocker's numeric **database id** (`gh api repos/<owner>/<repo>/issues/<n> --jq .id`, _not_ the `#number` or `node_id`). GitHub reports `issue_dependencies_summary.blocked_by` (open blockers only — the live gate). Where dependencies aren't available, fall back to a `Blocked by: #<n>, #<n>` line at the top of the child body. A ticket is unblocked when every blocker is closed.
+- **Frontier query**: list the map's open children (`gh issue list --state open`, scoped to the map's sub-issues / task list), drop any with an open blocker (`issue_dependencies_summary.blocked_by > 0`, or an open issue in the `Blocked by` line) or an assignee; first in map order wins.
+- **Claim**: `gh issue edit <n> --add-assignee @me` — the session's first write.
+- **Resolve**: `gh issue comment <n> --body "<answer>"`, then `gh issue close <n>`, then append a context pointer (gist + link) to the map's Decisions-so-far.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.

--- a/openspec/config.yaml
+++ b/openspec/config.yaml
@@ -1,0 +1,54 @@
+strict_tdd: true
+context: |
+  airflow-dags is a Node.js/TypeScript, Python project.
+  Detected markers: pyproject.toml, GitHub Actions.
+  Additional evidence: Test-like files detected (52); examples: tests/__init__.py, tests/conftest.py, tests/congress_videos/__init__.py, tests/congress_videos/config/__init__.py, tests/congress_videos/config/test_paths.py.
+  Primary test command: pytest.
+  Unit tests: pytest (pytest).
+  Integration tests: none.
+  E2E tests: none.
+rules:
+  proposal:
+    require_problem_statement: true
+  spec:
+    require_acceptance_criteria: true
+  design:
+    require_tradeoffs: true
+  tasks:
+    protect_review_workload: true
+  apply:
+    test_command: "pytest"
+  verify:
+    test_command: "pytest"
+testing:
+  detected: "2026-07-23"
+  runner:
+    command: "pytest"
+    framework: "pytest"
+  layers:
+    unit: "pytest"
+    integration: ""
+    e2e: ""
+  commands:
+    unit:
+      - scope: "."
+        command: "pytest"
+        framework: "pytest"
+    integration:
+      []
+    e2e:
+      []
+  coverage:
+    command: ""
+    commands:
+      []
+quality:
+  lint: ""
+  lint_commands:
+    []
+  typecheck: ""
+  typecheck_commands:
+    []
+  format: ""
+  format_commands:
+    []

--- a/tests/congress_videos/modules/test_database.py
+++ b/tests/congress_videos/modules/test_database.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import os
 from datetime import date
 from unittest.mock import MagicMock, call, patch
@@ -605,6 +606,74 @@ class TestMarkChapterUploaded:
         sql, params = mock_cursor.execute.call_args[0]
         assert "yt-safe-id" not in sql
         assert "yt-safe-id" in params
+
+
+# --------------------------------------------------------------------------- #
+# record_chapter_upload_failure
+# --------------------------------------------------------------------------- #
+
+class TestRecordChapterUploadFailure:
+
+    def test_normal_increment_updates_attempts_and_error(self, db):
+        """Non-threshold-crossing failure increments upload_attempts, stores error."""
+        instance, mock_cursor = db
+
+        instance.record_chapter_upload_failure(chapter_id=7, error_message="quota exceeded")
+
+        sql, params = mock_cursor.execute.call_args[0]
+        assert "UPDATE" in sql
+        assert "upload_attempts = upload_attempts + 1" in sql
+        assert "is_upload_abandoned" in sql
+        assert "last_upload_error" in sql
+        assert params == ("quota exceeded", 7)
+
+    def test_threshold_crossing_sets_abandoned_condition(self, db):
+        """SQL encodes the >= 3 (CHAPTER_UPLOAD_ABANDON_THRESHOLD) abandon condition."""
+        instance, mock_cursor = db
+
+        instance.record_chapter_upload_failure(chapter_id=9, error_message="timeout")
+
+        sql, _ = mock_cursor.execute.call_args[0]
+        assert ">= 3" in sql
+
+    def test_error_message_none_path(self, db):
+        """error_message=None is passed through as a None param, not a crash."""
+        instance, mock_cursor = db
+
+        instance.record_chapter_upload_failure(chapter_id=11, error_message=None)
+
+        sql, params = mock_cursor.execute.call_args[0]
+        assert params == (None, 11)
+
+    def test_warning_logged_when_threshold_crossed_on_this_call(self, db, caplog):
+        """A distinct WARNING fires when this call is the one crossing the abandon threshold."""
+        instance, mock_cursor = db
+        mock_cursor.fetchone.return_value = {
+            "upload_attempts": 3,
+            "is_upload_abandoned": True,
+        }
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.database"):
+            instance.record_chapter_upload_failure(chapter_id=42, error_message="boom")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 1
+        assert "42" in warnings[0].message
+        assert "abandoned" in warnings[0].message.lower()
+
+    def test_no_warning_logged_for_ordinary_retry_increment(self, db, caplog):
+        """An ordinary (non-crossing) failure increment does not emit the abandonment WARNING."""
+        instance, mock_cursor = db
+        mock_cursor.fetchone.return_value = {
+            "upload_attempts": 1,
+            "is_upload_abandoned": False,
+        }
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.database"):
+            instance.record_chapter_upload_failure(chapter_id=43, error_message="boom")
+
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING]
+        assert len(warnings) == 0
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/congress_videos/modules/test_postgres_operators_extended.py
+++ b/tests/congress_videos/modules/test_postgres_operators_extended.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 import sys
 import types
 from unittest.mock import MagicMock
@@ -536,8 +537,8 @@ class TestExecuteMarkChaptersUploaded:
         assert result["updated_chapters"] == 1
         mock_db.mark_chapter_uploaded.assert_called_once_with("ch-01", "yt-xyz")
 
-    def test_skips_failed_upload(self, mock_db, mock_task_instance, make_context):
-        """Failed upload is skipped and recorded as 'skipped' in details."""
+    def test_failed_upload_records_failure(self, mock_db, mock_task_instance, make_context):
+        """Failed upload with a resolvable chapter_id records the failure via the DB."""
         from congress_videos.modules.postgres_operators import PostgreSQLOperator
 
         mock_task_instance.xcom_store["upload_results"] = {
@@ -554,7 +555,117 @@ class TestExecuteMarkChaptersUploaded:
         result = op.execute(make_context(ti=mock_task_instance))
 
         assert result["updated_chapters"] == 0
+        mock_db.record_chapter_upload_failure.assert_called_once_with("ch-02", None)
         mock_db.mark_chapter_uploaded.assert_not_called()
+
+    def test_failed_upload_with_error_records_error_text(
+        self, mock_db, mock_task_instance, make_context
+    ):
+        """Failed upload carrying an 'error' string forwards it to record_chapter_upload_failure."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["upload_results"] = {
+            "upload_details": [
+                {
+                    "chapter_id": "ch-03",
+                    "youtube_video_id": None,
+                    "success": False,
+                    "error": "quota exceeded",
+                }
+            ]
+        }
+
+        op = PostgreSQLOperator(task_id="t", operation="mark_chapters_uploaded")
+        op.execute(make_context(ti=mock_task_instance))
+
+        mock_db.record_chapter_upload_failure.assert_called_once_with("ch-03", "quota exceeded")
+
+    def test_failed_upload_no_chapter_id_is_defensively_skipped(
+        self, mock_db, mock_task_instance, make_context
+    ):
+        """Failed upload with no resolvable chapter_id never calls the DB and never crashes."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["upload_results"] = {
+            "upload_details": [
+                {
+                    "chapter_id": None,
+                    "youtube_video_id": None,
+                    "success": False,
+                    "error": "unknown",
+                }
+            ]
+        }
+
+        op = PostgreSQLOperator(task_id="t", operation="mark_chapters_uploaded")
+        result = op.execute(make_context(ti=mock_task_instance))
+
+        mock_db.record_chapter_upload_failure.assert_not_called()
+        assert any(
+            d["status"] == "skipped" and d.get("reason") == "upload_failed_no_chapter_id"
+            for d in result["details"]
+        )
+
+    def test_two_failed_uploads_recorded_independently(
+        self, mock_db, mock_task_instance, make_context
+    ):
+        """Two distinct failed chapters in one batch each record their own failure."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["upload_results"] = {
+            "upload_details": [
+                {
+                    "chapter_id": "ch-10",
+                    "youtube_video_id": None,
+                    "success": False,
+                    "error": "err-a",
+                },
+                {
+                    "chapter_id": "ch-11",
+                    "youtube_video_id": None,
+                    "success": False,
+                    "error": "err-b",
+                },
+            ]
+        }
+
+        op = PostgreSQLOperator(task_id="t", operation="mark_chapters_uploaded")
+        op.execute(make_context(ti=mock_task_instance))
+
+        mock_db.record_chapter_upload_failure.assert_any_call("ch-10", "err-a")
+        mock_db.record_chapter_upload_failure.assert_any_call("ch-11", "err-b")
+        assert mock_db.record_chapter_upload_failure.call_count == 2
+
+    def test_db_write_failure_while_recording_is_distinguishably_logged(
+        self, mock_db, mock_task_instance, make_context, caplog
+    ):
+        """If record_chapter_upload_failure itself raises, log a distinguishable ERROR
+        (recording the failure was lost) and keep the loop going without raising."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db.record_chapter_upload_failure.side_effect = Exception("transient DB error")
+
+        mock_task_instance.xcom_store["upload_results"] = {
+            "upload_details": [
+                {
+                    "chapter_id": "ch-20",
+                    "youtube_video_id": None,
+                    "success": False,
+                    "error": "upload failed",
+                }
+            ]
+        }
+
+        op = PostgreSQLOperator(task_id="t", operation="mark_chapters_uploaded")
+
+        with caplog.at_level(logging.ERROR):
+            result = op.execute(make_context(ti=mock_task_instance))
+
+        errors = [r for r in caplog.records if r.levelno == logging.ERROR]
+        assert len(errors) == 1
+        assert "ch-20" in errors[0].message
+        assert "record" in errors[0].message.lower()
+        assert any(d["status"] == "failed" for d in result["details"])
 
     def test_successful_upload_missing_fields_recorded_as_skipped(
         self, mock_db, mock_task_instance, make_context

--- a/tests/utils/test_migrations_dag.py
+++ b/tests/utils/test_migrations_dag.py
@@ -294,6 +294,17 @@ class TestMigrationIdempotency:
         # Unqualified — no schema prefix like "development.llm_cache".
         assert ".llm_cache" not in sql
 
+    def test_011_chapter_upload_failure_tracking_exists_with_columns_and_view(self):
+        """Migration 011 must exist and add failure-tracking columns + updated view."""
+        path = MIGRATIONS_DIR / "011_add_chapter_upload_failure_tracking.sql"
+        assert path.exists(), f"Missing migration: {path}"
+        sql = path.read_text()
+        assert "ADD COLUMN IF NOT EXISTS upload_attempts" in sql
+        assert "ADD COLUMN IF NOT EXISTS is_upload_abandoned" in sql
+        assert "ADD COLUMN IF NOT EXISTS last_upload_error" in sql
+        assert "DROP VIEW IF EXISTS uploadable_chapters" in sql
+        assert "is_upload_abandoned = FALSE" in sql
+
     @pytest.mark.parametrize("path", _MIGRATION_FILES, ids=lambda p: p.name)
     def test_no_bare_create_table(self, path: Path):
         sql = path.read_text()


### PR DESCRIPTION
Closes #20

## Summary

- Adds per-chapter upload failure tracking: after 3 recorded failures `is_upload_abandoned` flips to `TRUE` and the chapter is excluded from `uploadable_chapters` forever (soft-delete, row preserved).
- Fixes `youtube_upload_dag` DagBag import timeout by moving PIL/OpenAI/youtube_ai imports from module level to lazy imports inside each task callable.
- Adds migration 011 (`upload_attempts`, `is_upload_abandoned`, `last_upload_error` columns + recreated view).

## Changed files

| File | Change |
|------|--------|
| `congress_videos/sql/migrations/011_add_chapter_upload_failure_tracking.sql` | New migration: 3 columns + recreated `uploadable_chapters` view |
| `congress_videos/sql/production_schema.sql` | Schema snapshot updated with failure-tracking columns |
| `congress_videos/sql/youtube_chapters_schema.sql` | Dev schema snapshot updated |
| `congress_videos/modules/database.py` | `record_chapter_upload_failure()` + `CHAPTER_UPLOAD_ABANDON_THRESHOLD = 3` |
| `congress_videos/modules/postgres_operators.py` | Calls failure recorder on per-chapter failure instead of silent skip |
| `congress_videos/youtube_upload_dag.py` | Lazy imports for PIL/OpenAI/youtube_ai/video_splitter task callables |
| `tests/congress_videos/modules/test_database.py` | Tests for failure recording (threshold, cumulative counter, error text) |
| `tests/congress_videos/modules/test_postgres_operators_extended.py` | Operator-level failure-recording integration tests |
| `tests/utils/test_migrations_dag.py` | Migration 011 validator entry |

## Test plan

- [ ] `conda run -n airflow python -m pytest` — full suite
- [ ] `conda run -n airflow python -m pytest tests/congress_videos/modules/test_database.py -k upload_failure -v`
- [ ] `conda run -n airflow python -m pytest tests/congress_videos/modules/test_postgres_operators_extended.py -v`
- [ ] Verify DAG loads without timeout in Airflow UI after deploy