### PR TITLE
feat(congress-videos): detect source codec before ffmpeg cuts

### DIFF
--- a/congress_videos/modules/video_splitter.py
+++ b/congress_videos/modules/video_splitter.py
@@ -11,6 +11,11 @@ import logging
 import os
 import subprocess
 
+from utils.codec_detection import (
+    cut_mode_for_reencode,
+    get_cached_codec,
+    reencode_for_codec,
+)
 from utils.time_utils import parse_timestamp
 
 
@@ -133,7 +138,7 @@ def convert_srt_time_to_seconds(srt_time: str) -> float:
         return 0.0
 
 
-def split_video_chapter(source_video_path, output_path, start_time, end_time):
+def split_video_chapter(source_video_path, output_path, start_time, end_time, codec_cache=None):
     """
     Split a video segment using ffmpeg.
 
@@ -149,10 +154,20 @@ def split_video_chapter(source_video_path, output_path, start_time, end_time):
         output_path: Path where the extracted chapter will be saved
         start_time: Start time in SRT format (HH:MM:SS,mmm)
         end_time: End time in SRT format (HH:MM:SS,mmm)
+        codec_cache: Optional shared dict for memoizing codec probes across
+            calls (see :func:`utils.codec_detection.get_cached_codec`).
+            Passing ``None`` disables memoization (each call probes).
 
     Returns:
-        Dict with success status and file info
+        Dict with success status and file info. Always includes
+        ``source_codec`` (the detected/cached source codec, or
+        ``"unknown"`` if detection was never reached) and ``cut_mode``
+        (``"reencode"`` or ``"stream_copy"``, from
+        :func:`utils.codec_detection.cut_mode_for_reencode`) in both the
+        success dict and both failure-path dicts.
     """
+    source_codec = "unknown"
+    reencode = False
     try:
         # Ensure source video exists
         if not os.path.exists(source_video_path):
@@ -170,12 +185,17 @@ def split_video_chapter(source_video_path, output_path, start_time, end_time):
         output_dir = os.path.dirname(output_path)
         os.makedirs(output_dir, exist_ok=True)
 
+        # Determine codec-aware re-encode decision before building the command.
+        source_codec = get_cached_codec(source_video_path, codec_cache)
+        reencode = reencode_for_codec(source_codec)
+
         # Build frame-accurate ffmpeg command (input-seek + re-encode).
         ffmpeg_command = build_ffmpeg_cut_cmd(
             src=source_video_path,
             out=output_path,
             start=start_seconds,
             duration=duration_seconds,
+            reencode=reencode,
         )
         timeout = compute_ffmpeg_timeout(duration_seconds)
 
@@ -208,6 +228,8 @@ def split_video_chapter(source_video_path, output_path, start_time, end_time):
             "duration_seconds": duration_seconds,
             "start_time": start_time,
             "end_time": end_time,
+            "source_codec": source_codec,
+            "cut_mode": cut_mode_for_reencode(reencode),
             "error": None
         }
 
@@ -217,6 +239,11 @@ def split_video_chapter(source_video_path, output_path, start_time, end_time):
         return {
             "success": False,
             "output_path": None,
+            "source_codec": source_codec,
+            # Reuses the `reencode` local computed in the try block (defaulted to
+            # False above, matching reencode_for_codec's fail-safe stream-copy
+            # default for "unknown") instead of recomputing it here.
+            "cut_mode": cut_mode_for_reencode(reencode),
             "error": error_msg
         }
     except Exception as e:
@@ -225,6 +252,11 @@ def split_video_chapter(source_video_path, output_path, start_time, end_time):
         return {
             "success": False,
             "output_path": None,
+            "source_codec": source_codec,
+            # Reuses the `reencode` local computed in the try block (defaulted to
+            # False above, matching reencode_for_codec's fail-safe stream-copy
+            # default for "unknown") instead of recomputing it here.
+            "cut_mode": cut_mode_for_reencode(reencode),
             "error": error_msg
         }
 
@@ -279,6 +311,8 @@ def extract_chapters_from_video(uploadable_chapters, data_directory):
         'results': []
     }
 
+    codec_cache: dict = {}
+
     for chapter in uploadable_chapters:
         chapter_id = chapter.get('chapter_id')
         video_id = chapter.get('video_id')
@@ -331,7 +365,8 @@ def extract_chapters_from_video(uploadable_chapters, data_directory):
                 source_video_path=source_video_path,
                 output_path=output_path,
                 start_time=start_time,
-                end_time=end_time
+                end_time=end_time,
+                codec_cache=codec_cache,
             )
 
             result['chapter_id'] = chapter_id

--- a/congress_videos/reap_clip_preparer_dag.py
+++ b/congress_videos/reap_clip_preparer_dag.py
@@ -26,6 +26,11 @@ from congress_videos.modules.video_splitter import (
 )
 from congress_videos.srt_helpers import find_srt_for_chapter, select_pretrim_window
 from utils.airflow_helpers import ensure_project_data_directory, xcom_task
+from utils.codec_detection import (
+    cut_mode_for_reencode,
+    get_cached_codec,
+    reencode_for_codec,
+)
 from utils.env_loader import load_env_if_local
 
 load_env_if_local()
@@ -65,8 +70,16 @@ def _find_source_video(video_id: str) -> str | None:
     return None
 
 
-def _ffmpeg_extract_window(source_path: str, dest_path: str, start_secs: float, end_secs: float) -> None:
-    """Re-extract a precise time window from source into dest_path using ffmpeg."""
+def _ffmpeg_extract_window(
+    source_path: str, dest_path: str, start_secs: float, end_secs: float, reencode: bool = True
+) -> None:
+    """Re-extract a precise time window from source into dest_path using ffmpeg.
+
+    ``reencode`` defaults to ``True`` to preserve backward compatibility for any
+    caller that omits it. The pre-trim call site passes the raw source's cached
+    codec decision (see ``_extract_and_pretrim_clip``) so this mirrors the
+    chapter cut's re-encode-vs-stream-copy choice for the same source.
+    """
     os.makedirs(os.path.dirname(dest_path), exist_ok=True)
     duration = end_secs - start_secs
     cmd = build_ffmpeg_cut_cmd(
@@ -74,6 +87,7 @@ def _ffmpeg_extract_window(source_path: str, dest_path: str, start_secs: float, 
         out=dest_path,
         start=start_secs,
         duration=duration,
+        reencode=reencode,
     )
     timeout = compute_ffmpeg_timeout(duration)
     result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
@@ -130,6 +144,7 @@ with DAG(
         target_secs = context['params']['pre_trim_target_secs']
         inserted_count = 0
         blocked_chapters = []
+        codec_cache: dict = {}
 
         for chapter in chapters:
             chapter_id = chapter['chapter_id']
@@ -144,6 +159,14 @@ with DAG(
                 )
                 continue
 
+            # Deliberate: this is the raw source's codec decision (probed from
+            # source_video_path, cached in codec_cache). It is reused below for the
+            # pre-trim step against clip_path (the already-cut chapter) because
+            # stream-copy preserves the source's original codec into the cut chapter --
+            # re-probing clip_path would be a redundant probe. Do not "optimize" this.
+            source_codec = get_cached_codec(source_video_path, codec_cache)
+            reencode = reencode_for_codec(source_codec)
+
             chapter_folder = os.path.join(PROJECT_DATA_DIR, str(video_id), str(chapter_id))
             os.makedirs(chapter_folder, exist_ok=True)
             clip_path = os.path.join(chapter_folder, f'chapter_{chapter_id}.mp4')
@@ -153,6 +176,7 @@ with DAG(
                 output_path=clip_path,
                 start_time=_interval_to_srt(start_time),
                 end_time=_interval_to_srt(end_time),
+                codec_cache=codec_cache,
             )
 
             if not result['success']:
@@ -191,17 +215,24 @@ with DAG(
                 trimmed_path = os.path.join(chapter_folder, f'chapter_{chapter_id}_trimmed.mp4')
 
                 try:
+                    # `reencode` reuses the RAW SOURCE's codec decision computed above
+                    # (from source_video_path), NOT a fresh probe of clip_path (the
+                    # already-cut chapter). Deliberate: stream-copy preserves the
+                    # source's original codec into the cut chapter, so re-probing
+                    # clip_path would be redundant. Do not "optimize" this into a probe.
                     _ffmpeg_extract_window(
                         source_path=clip_path,
                         dest_path=trimmed_path,
                         start_secs=pretrim_start,
                         end_secs=pretrim_end,
+                        reencode=reencode,
                     )
                     clip_path = trimmed_path
                     duration = pretrim_end - pretrim_start
                     logging.info(
-                        "Chapter %s pre-trimmed: %.1f–%.1fs (%.0fs) srt_window=%s",
+                        "Chapter %s pre-trimmed: %.1f–%.1fs (%.0fs) srt_window=%s source_codec=%s cut_mode=%s",
                         chapter_id, pretrim_start, pretrim_end, duration, pretrim_used_srt,
+                        source_codec, cut_mode_for_reencode(reencode),
                     )
                 except RuntimeError as exc:
                     logging.error(

--- a/openspec/changes/ffmpeg-codec-aware-cuts/apply-progress.md
+++ b/openspec/changes/ffmpeg-codec-aware-cuts/apply-progress.md
@@ -1,0 +1,198 @@
+# Apply Progress: ffmpeg-codec-aware-cuts
+
+Delivery context: single PR against `dev` (size:exception recorded — ~480-650 estimated
+changed lines vs 400-line budget, user chose one PR over chaining). No chain_strategy
+applies. Strict TDD Mode active throughout (RED → GREEN → TRIANGULATE → REFACTOR per unit).
+
+## Environment note (sandbox limitation — read before trusting "full suite" claims)
+
+This apply ran in a sandbox without `conda`/the `airflow` env (per sdd-init obs #7, the
+canonical test command is `conda run -n airflow python -m pytest`; `conda` is not on PATH
+here). To execute real tests I created a throwaway venv (`/tmp/venv-airflow-test`, **not**
+part of the repo) and installed `pytest`, `pytest-cov`, `pytest-mock`, `pytest-xdist`,
+`freezegun`, `psycopg2-binary`, plus a **minimal local stub of the `airflow` package**
+(DAG/PythonOperator/ShortCircuitOperator/AirflowException/TaskInstance) installed only into
+that venv's site-packages so `congress_videos/reap_clip_preparer_dag.py` could be imported
+and its real (pre-existing) test suite could run. This stub is NOT part of the repo, was not
+committed anywhere, and does not affect production code or the real `conda run -n airflow`
+env used in CI/other environments.
+
+Consequence: all TDD evidence below for the touched files is from REAL pytest runs (not
+inferred), but:
+- The repo-wide `--cov-fail-under=80` gate could not be validated end-to-end here — many
+  unrelated modules fail to import in this sandbox venv (missing `openai`, `googleapiclient`,
+  `beautifulsoup4`/`urllib3`, `webrtcvad-wheels`, etc. — all pre-existing, unrelated to this
+  change). A full-suite run with real deps must happen in the real `airflow` conda env before
+  merge (task left unchecked, see below).
+- The NAS smoke check (known-bad AV1 videos GMZ5TwfZJHw / sahjXSGn-Ak) requires NAS access
+  not available in this sandbox — not runnable here, left unchecked and deferred to
+  sdd-verify/real environment per the task's own fallback instruction.
+
+Everything else (all new/changed test files, all 3 slices' wiring) ran for real and is GREEN.
+
+## Persistence note
+
+Engram HTTP server was unreachable during this session (`mem_search`/`mem_save` reported
+"could not reach the Engram HTTP server at http://127.0.0.1:7437"). Tasks (obs #66), spec
+(obs #60), design (obs #64), and sdd-init (obs #7) were still readable via cached
+`mem_search` results, so inputs were retrieved successfully. This apply-progress and the
+tasks checkbox updates are persisted to the **openspec** file store (this file +
+`openspec/changes/ffmpeg-codec-aware-cuts/tasks.md`). An `mem_save`/`mem_update` attempt to
+also write to Engram is included below for completeness; if the server was still down when
+this ran, the parent/orchestrator should retry the Engram write once the server is back up.
+
+## Files changed
+
+- `utils/codec_detection.py` — **new**: `detect_video_codec`, `get_cached_codec`,
+  `reencode_for_codec`, `cut_mode_for_reencode`.
+- `tests/utils/test_codec_detection.py` — **new**, 31 tests.
+  (Deviation from design.md's illustrative path `utils/test_codec_detection.py`: the repo's
+  actual test convention, confirmed by reading `tests/utils/` and root `conftest.py`
+  (`testpaths=["tests"]`), is a mirrored `tests/<pkg>/test_*.py` tree, not co-located
+  `test_*.py` next to source. Used the real convention; same test content/coverage.)
+- `congress_videos/modules/video_splitter.py` — `split_video_chapter` gains optional
+  `codec_cache=None`; probes codec via `get_cached_codec`, decides `reencode` via
+  `reencode_for_codec`, passes it to `build_ffmpeg_cut_cmd`; adds `source_codec`/`cut_mode` to
+  the result dict on all paths (success + both except blocks); `source_codec` initialized to
+  `"unknown"` before `try` so failure-before-probe paths still report consistent fields.
+  `extract_chapters_from_video` creates one `codec_cache = {}` before its loop and threads it
+  into every `split_video_chapter` call.
+- `tests/congress_videos/modules/test_video_splitter.py` — 5 existing tests updated to mock
+  `utils.codec_detection.detect_video_codec` (audit/regression-proofing, see Slice 2 below);
+  10 new tests added (`TestSplitVideoChapterCodecAware` x7, cache-sharing tests x2 in
+  `TestExtractChaptersFromVideo`, plus the key-list update). 45 tests total, all passing.
+- `congress_videos/reap_clip_preparer_dag.py` — imports `get_cached_codec`,
+  `reencode_for_codec`, `cut_mode_for_reencode`; `_ffmpeg_extract_window` gains optional
+  `reencode=True` (backward-compat default); `_extract_and_pretrim_clip`'s loop creates one
+  `codec_cache = {}`, computes `source_codec`/`reencode` from the **raw** `source_video_path`
+  (not `clip_path`) per design Decision 1, threads the cache into `split_video_chapter`, passes
+  `reencode` into the pre-trim call, and extends the existing pre-trim info log line with
+  ` source_codec=%s cut_mode=%s`. No DB schema / result-dict change at this site (pre-trim has
+  no returned dict, per spec Requirement 5).
+- `tests/congress_videos/test_reap_clip_preparer_dag.py` — `_setup_mocks` helper extended to
+  mock `detect_video_codec` (audit/regression-proofing); 7 new tests added
+  (`_ffmpeg_extract_window` reencode param x2, raw-source-not-clip-path x2, log-line extension,
+  cross-site single-probe sharing). 26 tests total, all passing.
+- `utils/youtube_downloader.py` — imports `detect_video_codec`; new `_warn_if_not_h264(file_path, *, context)`
+  helper (reuses `detect_video_codec`, no reimplementation); wired at both insertion points
+  per design Decision 4: the yt-dlp success block (after "Ready for YouTube upload!") and the
+  pytubefix success early-return in `download_youtube_video_for_upload`. No `format_map`/
+  `ydl_opts`/download-behavior changes.
+- `tests/utils/test_youtube_downloader.py` — 7 new tests (`TestWarnIfNotH264` x4,
+  `TestWarnIfNotH264WiredIntoYtdlpSuccessPath` x3 including the secondary pytubefix insertion
+  point). 57 tests total, all passing.
+
+## Persisted task checkboxes
+
+`openspec/changes/ffmpeg-codec-aware-cuts/tasks.md` updated: 31 implementation-owned
+checkboxes marked `[x]` (all of Slice 1, Slice 2, Slice 3's RED/GREEN/TRIANGULATE/REFACTOR
+items). 3 parent-owned "Start or reuse bounded review" checkboxes left untouched (byte-for-byte,
+per ownership boundary). 2 implementation-owned cross-slice items left unchecked (see
+Remaining below) because they were honestly not runnable in this sandbox.
+
+## TDD Cycle Evidence
+
+| Unit | RED (confirmed failing) | GREEN | TRIANGULATE | REFACTOR |
+|---|---|---|---|---|
+| `detect_video_codec` | `ModuleNotFoundError: utils.codec_detection` (module didn't exist) | 24/24 tests pass | +7 tests (mixed-case, path w/ spaces, stale cache trust) → 31/31 pass | docstrings, import order, log-message dedup reviewed; suite still green |
+| `get_cached_codec` | same RED run (module missing) | included in the 24 | included above | " |
+| `reencode_for_codec` / `cut_mode_for_reencode` | same RED run | included in the 24 | included above | " |
+| `split_video_chapter` result-dict fields | `AssertionError: Missing key: source_codec` (real failure, captured) | 45/45 `test_video_splitter.py` tests pass | 3+ chapters share 1 probe / 2 sources = 2 probes tests added and pass | import order (utils.codec_detection above utils.time_utils), docstring updated |
+| `split_video_chapter` codec_cache param | `TypeError: split_video_chapter() got an unexpected keyword argument 'codec_cache'` | same 45/45 | same as above | same |
+| `_ffmpeg_extract_window` reencode param | `TypeError: _ffmpeg_extract_window() got an unexpected keyword argument 'reencode'` | 26/26 `test_reap_clip_preparer_dag.py` tests pass | cross-site single-probe-sharing test added and passes | docstring updated to explain default+rationale |
+| pre-trim loop wiring (raw-source reuse, log line) | 4 failing (`KeyError: 'reencode'` x2, log-format TypeError in test itself — fixed, then `AssertionError: 0 == 1` on cache sharing) | same 26/26 | included above | " |
+| `_warn_if_not_h264` + wiring (yt-dlp block) | `AttributeError: ... does not have the attribute '_warn_if_not_h264'` (x6 tests) | 57/57 `test_youtube_downloader.py` tests pass | secondary pytubefix-success insertion point test added (RED confirmed, then GREEN) | import ordering confirmed (stdlib/yt_dlp third-party/utils local) |
+
+Audit/regression-proofing step (Slice 2, before wiring): read
+`tests/congress_videos/modules/test_video_splitter.py` in full; identified 5 tests exercising
+`split_video_chapter`'s ffmpeg command construction that would start hitting the real
+`ffprobe` once codec detection is wired in (`test_ffmpeg_success`,
+`test_ffmpeg_nonzero_returncode_returns_error`, `test_ffmpeg_timeout_returns_specific_error`,
+`test_result_success_contains_all_keys`, `test_successful_extraction_increments_counter`).
+Added `mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")` to each,
+confirmed the suite still passed identically before wiring (mock target exists at the
+`utils.codec_detection` module level from Slice 1, just unused pre-wiring), then proceeded to
+wire `split_video_chapter`. Same pattern applied to `_setup_mocks`/inline mocks in
+`test_reap_clip_preparer_dag.py` for the same reason (the loop's own `get_cached_codec` call
+would otherwise probe real ffprobe or collide with the shared `subprocess.run` mock used for
+the safety-gate ffprobe call).
+
+## Test commands run (real pytest, this sandbox's venv)
+
+```
+# Slice-by-slice, fast partial runs during RED/GREEN:
+python -m pytest tests/utils/test_codec_detection.py -p no:cacheprovider --no-cov -q
+python -m pytest tests/congress_videos/modules/test_video_splitter.py -p no:cacheprovider --no-cov -q -m "not slow"
+python -m pytest tests/congress_videos/test_reap_clip_preparer_dag.py -p no:cacheprovider --no-cov -q
+python -m pytest tests/utils/test_youtube_downloader.py -p no:cacheprovider --no-cov -q
+
+# Cross-slice combined run (final):
+python -m pytest tests/utils/test_codec_detection.py tests/utils/test_youtube_downloader.py \
+  tests/utils/test_time_utils.py tests/congress_videos/modules/test_video_splitter.py \
+  tests/congress_videos/test_reap_clip_preparer_dag.py -p no:cacheprovider --no-cov -q -m "not slow"
+```
+
+Result: **194 passed, 1 deselected** (the 1 deselected is the pre-existing
+`@pytest.mark.slow @pytest.mark.integration` real-ffmpeg AV1 test in
+`test_video_splitter.py`, unrelated to this change and already marked slow before this apply).
+
+Coverage on touched files only (`--cov=utils.codec_detection --cov=congress_videos.modules.video_splitter
+--cov=congress_videos.reap_clip_preparer_dag --cov=utils.youtube_downloader`):
+`utils/codec_detection.py` 100%, `congress_videos/modules/video_splitter.py` 93.48%,
+`congress_videos/reap_clip_preparer_dag.py` 81.99%, `utils/youtube_downloader.py` 83.97%.
+
+Full repo-wide run attempted (`--continue-on-collection-errors`, no `--no-cov`): 647 passed,
+270 failed, 58 errors — spot-checked several failures (`test_ai_helpers.py`,
+`test_git_sync_dag.py`, etc.) and confirmed they are all pre-existing `ModuleNotFoundError`/
+`AttributeError` collection failures from optional deps not installed in this sandbox venv
+(`openai`, `googleapiclient`, full `apache-airflow`, `webrtcvad-wheels`, etc.) — unrelated to
+`utils/codec_detection.py`, `video_splitter.py`, `reap_clip_preparer_dag.py`, or
+`youtube_downloader.py`. None of the spot-checked failures touch codec detection or the two
+cut sites. This must be re-run in the real `conda run -n airflow python -m pytest` env before
+merge to get a trustworthy repo-wide coverage number (task left unchecked below).
+
+## Deviations from design
+
+1. Test file location: `tests/utils/test_codec_detection.py` (mirrored tree) instead of
+   design.md's illustrative `utils/test_codec_detection.py` (co-located) — matches the repo's
+   actual, confirmed test convention (`pyproject.toml` `testpaths=["tests"]`, all other
+   `utils/*` tests live under `tests/utils/`). No functional difference.
+2. No other deviations. Function signatures, cache key (`os.path.abspath`), cache ownership
+   (caller-supplied, not module-global), `reencode_for_codec`/`cut_mode_for_reencode` mapping,
+   pre-trim's raw-source-reuse (not a fresh probe of `clip_path`), and both downloader
+   insertion points match design.md exactly.
+
+## Remaining (not done by this apply)
+
+Implementation-owned, left unchecked in tasks.md:
+- [ ] `- [ ] Run the full suite with coverage enforced: conda run -n airflow python -m pytest ...` —
+  blocked by sandbox environment (no conda/airflow env here); must run in the real env before
+  merge/archive.
+- [ ] `- [ ] Confirm success-criteria smoke check against the two known-bad AV1 videos
+  (GMZ5TwfZJHw, sahjXSGn-Ak) ...` — blocked by no NAS access in this sandbox; per the task's
+  own fallback clause this is documented here and deferred to sdd-verify / a NAS-connected
+  environment.
+
+Parent-owned, untouched (byte-for-byte) per ownership boundary — deferred lifecycle actions:
+- [ ] Start or reuse bounded review for Slice 1 (new module + tests only).
+- [ ] Start or reuse bounded review for Slice 2 (video_splitter.py wiring + regression-proofed existing tests).
+- [ ] Start or reuse bounded review for Slice 3 (reap_clip_preparer_dag.py + youtube_downloader.py wiring).
+- [ ] Start or reuse bounded review as a final gate before archive, referencing all slice reviews.
+
+## Workload / PR boundary
+
+Per the delegated-task instructions, this ran as a **single PR** against `dev`
+(`size:exception` recorded by the orchestrator/user, overriding the tasks.md-forecasted
+chained-PR recommendation). No chain_strategy applies; all 3 slices were implemented in one
+pass on `feat/ffmpeg-codec-aware-cuts`. No commit was made (implementation only, per
+instructions — orchestrator handles commit/PR).
+
+## Structured status consumed
+
+- Delivery: single PR, size:exception, no chain_strategy (given directly in the task prompt —
+  not re-litigated).
+- Strict TDD: active, test command `conda run -n airflow python -m pytest` / env-active
+  `python -m pytest` (sdd-init obs #7).
+- `actionContext`/edit roots: none flagged; all edits stayed within
+  `utils/`, `congress_videos/`, and `tests/` under the existing repo root, on the pre-checked-out
+  `feat/ffmpeg-codec-aware-cuts` branch. No branch switch/creation performed.

--- a/openspec/changes/ffmpeg-codec-aware-cuts/design.md
+++ b/openspec/changes/ffmpeg-codec-aware-cuts/design.md
@@ -1,0 +1,495 @@
+# Design: ffmpeg-codec-aware-cuts
+
+Domain: `congress-video-cutting` · Project: `airflow-dags` · Pipeline: `congress_videos`
+Status: design phase (next: tasks). Proposal + spec approved and settled.
+
+## Scope reaffirmation (settled, do not reopen)
+
+Two cut sites are in scope, both consuming the raw 7–10h AV1-risk source video:
+
+1. `congress_videos/modules/video_splitter.py::split_video_chapter`
+2. `congress_videos/reap_clip_preparer_dag.py`'s inline pre-trim (`_ffmpeg_extract_window`,
+   the `"Pre-trim ffmpeg failed for chapter"` path).
+
+`reap_shorts_uploader_dag.py` is **confirmed OUT of scope**: it is an audio-only
+(`-vn`, `pcm_s16le`) extraction from an externally-produced Reap clip, not a cut of the
+raw AV1 source. Not touched by this design.
+
+---
+
+## 1. Codec-detection module placement (design decision)
+
+**Decision: create a new module `utils/codec_detection.py`.**
+
+### Why `utils/` and not `video_splitter.py`
+
+The dependency direction in this repo is one-way:
+
+- `congress_videos/modules/video_splitter.py` imports `from utils.time_utils import parse_timestamp`.
+- `congress_videos/reap_clip_preparer_dag.py` imports `from utils.airflow_helpers …`,
+  `from utils.env_loader …`, and `from congress_videos.modules.video_splitter …`.
+- `utils/youtube_downloader.py` imports only stdlib + `yt_dlp` — it does **not** import
+  from `congress_videos/`.
+
+`utils/` is the low-level shared layer; `congress_videos/` is the higher-level consumer.
+The downloader (Requirement 6) needs the same detection function. If detection lived in
+`congress_videos/modules/video_splitter.py`, then `utils/youtube_downloader.py` would have
+to import *up* into `congress_videos/`, inverting the dependency arrow and creating a
+circular-import risk (`congress_videos → utils → congress_videos`).
+
+Placing detection in `utils/codec_detection.py` lets all three consumers
+(`video_splitter.py`, `reap_clip_preparer_dag.py`, `youtube_downloader.py`) import it
+without inverting the layering. It also reads as screaming-architecture: the module name
+states exactly what it does. Existing `utils/` modules (`time_utils`, `env_loader`,
+`ai_helpers`) confirm the convention of small single-purpose utility modules.
+
+`build_ffmpeg_cut_cmd` stays in `video_splitter.py` (unchanged) — detection and
+command-building are separate concerns and live in separate layers.
+
+---
+
+## 2. Cache placement and lifetime (the main open question)
+
+### Call-structure facts (read from code)
+
+- `split_video_chapter` is called **once per chapter in a loop** from
+  `extract_chapters_from_video` (`video_splitter.py`). Many chapters can share the same
+  `video_id` / source file.
+- In `reap_clip_preparer_dag.py::_extract_and_pretrim_clip`, the loop calls
+  `split_video_chapter` once per chapter, then conditionally calls `_ffmpeg_extract_window`
+  (pre-trim) once for that same chapter. Both run inside a **single Airflow task's Python
+  process** (`t2 = PythonOperator(task_id='extract_and_pretrim_clip')`).
+- **Critical subtlety:** the pre-trim's input is `clip_path` — the chapter clip that
+  `split_video_chapter` just wrote — **not** the raw source. But stream-copy preserves the
+  source codec: if the raw source was AV1 and `split_video_chapter` stream-copied,
+  `clip_path` is still AV1, and re-encoding it in the pre-trim would crash identically.
+  Therefore the pre-trim must reuse the **raw source's** codec decision, not re-probe the
+  derived clip. The raw `source_video_path` is already in scope in the loop, so this is
+  free.
+
+### Decision: caller-supplied process-local `dict`, keyed by resolved absolute source path
+
+**Structure:** a plain `dict[str, str]` mapping `os.path.abspath(source_video_path)` →
+`"h264" | "av1" | "unknown"`.
+
+**Key:** resolved absolute path of the **raw source video** (`os.path.abspath`). Rationale:
+- Both cut sites already hold the raw source path (`source_video_path` in
+  `split_video_chapter`; `_find_source_video(video_id)` result in the DAG loop). It is the
+  shared context both sites have.
+- `video_id` is rejected as the key: it is not consistently available at both sites in the
+  same form, and a bare `video_id` could collide with a re-downloaded/replaced physical
+  file within the same run (the spec's stale-reuse constraint). The absolute file path is
+  the physical identity of the bytes being cut, so it cannot alias a different file.
+
+**Ownership / threading — caller-supplied optional parameter, NOT a module-level global:**
+
+- `split_video_chapter` gains an **optional** parameter `codec_cache: dict | None = None`.
+- `extract_chapters_from_video` creates `codec_cache = {}` once before its loop and passes
+  the same dict into every `split_video_chapter` call → one probe per distinct source across
+  all chapters.
+- `_extract_and_pretrim_clip` creates `codec_cache = {}` once before its loop, passes it into
+  `split_video_chapter`, and also uses it directly to compute the pre-trim's `reencode` value
+  → the chapter cut and the pre-trim share one cache entry, one probe.
+- When `codec_cache is None` (e.g. an ad-hoc single call or existing test), the lookup helper
+  probes once for that call without caching — behaviorally correct, just not memoized.
+
+**Why caller-supplied over a module-level global:** an explicit parameter is testable and
+has no hidden cross-test state — each test constructs its own dict (or passes `None`) and
+asserts probe counts deterministically. A module-level global cache would need explicit
+reset between tests and could leak state across DAG task invocations that reuse the same
+worker process. Explicit dependency > hidden module state; no strong reason here to prefer
+the global.
+
+**Why this satisfies the "MUST NOT persist across DAG runs" constraint:** the dict is a
+local variable created *inside* the task callable / module function body. It lives only for
+that Python call's stack and is garbage-collected when the function returns. It never touches
+XCom or Airflow Variables, so there is no serialization surface through which a codec value
+could leak into a later DAG run. This is strictly simpler than XCom/Variable, which would
+require explicit serialization, a cleanup step, and careful keying to avoid exactly the
+cross-run leak the spec forbids.
+
+---
+
+## 3. Function signatures & contracts
+
+### `utils/codec_detection.py` (new)
+
+```python
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+_H264_NAMES = frozenset({"h264", "avc1"})
+_AV1_NAMES = frozenset({"av1", "av01"})
+FFPROBE_TIMEOUT_SECS = 30
+
+
+def detect_video_codec(source_path: str, *, timeout: int = FFPROBE_TIMEOUT_SECS) -> str:
+    """Return 'h264' | 'av1' | 'unknown' for the primary video stream. Never raises."""
+    cmd = [
+        "ffprobe", "-v", "error",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=codec_name",
+        "-of", "csv=p=0",
+        source_path,
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        logger.warning("ffprobe binary not found; codec unknown for %s", source_path)
+        return "unknown"
+    except subprocess.TimeoutExpired:
+        logger.warning("ffprobe timed out (%ss); codec unknown for %s", timeout, source_path)
+        return "unknown"
+    except Exception as exc:  # defensive catch-all — detection must never raise
+        logger.warning("ffprobe error for %s: %s; codec unknown", source_path, exc)
+        return "unknown"
+
+    if proc.returncode != 0:
+        logger.warning(
+            "ffprobe exit %s for %s: %s; codec unknown",
+            proc.returncode, source_path, (proc.stderr or "").strip(),
+        )
+        return "unknown"
+
+    name = (proc.stdout or "").strip().lower()
+    if name in _H264_NAMES:
+        return "h264"
+    if name in _AV1_NAMES:
+        return "av1"
+    logger.warning("ffprobe reported unrecognized codec %r for %s; treating as unknown",
+                   name, source_path)
+    return "unknown"
+
+
+def get_cached_codec(source_path: str, cache: dict | None) -> str:
+    """Cache-aware lookup keyed by resolved absolute path. Probes at most once per key."""
+    if cache is None:
+        return detect_video_codec(source_path)
+    key = os.path.abspath(source_path)
+    if key not in cache:
+        cache[key] = detect_video_codec(source_path)
+    return cache[key]
+
+
+def reencode_for_codec(codec: str) -> bool:
+    """Decision rule: h264 -> reencode; av1/unknown -> stream-copy (fail-safe)."""
+    return codec == "h264"
+
+
+def cut_mode_for_reencode(reencode: bool) -> str:
+    """1:1 mapping with the reencode bool for the audit field."""
+    return "reencode" if reencode else "stream_copy"
+```
+
+**ffprobe command → normalized output mapping.** The command
+`ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of csv=p=0 <path>`
+prints the primary video stream's `codec_name` and nothing else, e.g. `h264\n`, `av1\n`,
+`vp9\n`, `hevc\n`, or empty on no video stream. After `.strip().lower()`:
+`h264`/`avc1` → `"h264"`; `av1`/`av01` → `"av1"`; anything else (incl. empty, `vp9`,
+`hevc`) → `"unknown"`. ffprobe reads container/stream metadata only (no decode), so it is
+fast even on a 10h file — the 30s timeout is a generous safety bound, not an expected wait.
+
+### `video_splitter.py::split_video_chapter` (signature extended, additive)
+
+```python
+def split_video_chapter(source_video_path, output_path, start_time, end_time, codec_cache=None):
+```
+
+- New trailing **optional** `codec_cache=None` — existing positional/keyword calls
+  (`source_video_path, output_path, start_time, end_time`) remain valid unchanged
+  (Backward-Compat requirement satisfied).
+- Flow: initialize `source_codec = "unknown"` **before** the `try` so failure paths can
+  report it. Inside `try`, after the duration checks and before `build_ffmpeg_cut_cmd`:
+
+  ```python
+  source_codec = get_cached_codec(source_video_path, codec_cache)
+  reencode = reencode_for_codec(source_codec)
+  ffmpeg_command = build_ffmpeg_cut_cmd(
+      src=source_video_path, out=output_path,
+      start=start_seconds, duration=duration_seconds,
+      reencode=reencode,
+  )
+  ```
+- `build_ffmpeg_cut_cmd` is reused **as-is** via its existing `reencode` parameter — no new
+  command builder.
+
+### `reap_clip_preparer_dag.py::_ffmpeg_extract_window` (signature extended, additive)
+
+```python
+def _ffmpeg_extract_window(source_path, dest_path, start_secs, end_secs, reencode=True):
+```
+
+- New trailing optional `reencode=True` preserves the current default for any caller that
+  doesn't pass it. Passed straight through to `build_ffmpeg_cut_cmd(..., reencode=reencode)`.
+- The caller (`_extract_and_pretrim_clip`) computes `reencode` from the **raw source's**
+  cached codec and passes it in (see §5), so the pre-trim mirrors the chapter cut's decision.
+
+---
+
+## 4. Downloader integration (`utils/youtube_downloader.py`)
+
+**Reuse `detect_video_codec` — no reimplementation.** Add one small module-level helper and
+call it at the post-download success point(s):
+
+```python
+from utils.codec_detection import detect_video_codec  # top-of-file import
+
+def _warn_if_not_h264(file_path: str, *, context: str) -> str:
+    codec = detect_video_codec(file_path)
+    if codec != "h264":
+        logger.warning(
+            "Downloaded file for %s has codec=%r but avc1/H264 was requested "
+            "(yt-dlp/pytubefix fallback accepted a non-H264 stream): %s",
+            context, codec, file_path,
+        )
+    return codec
+```
+
+**Insertion point (required):** inside `download_youtube_video_for_upload`'s yt-dlp success
+block — the `if file_path.exists():` branch (the ~line 380 area), immediately after
+`result["success"] = True` and the existing `"✅ Download complete"` / `"Ready for YouTube
+upload!"` info logs, before the closing `else`:
+
+```python
+            logger.info(f"   Ready for YouTube upload!")
+            _warn_if_not_h264(str(file_path), context=info.get("id") or youtube_url)
+```
+
+**Secondary insertion (recommended, same helper):** the function tries pytubefix first and
+`return result` early on its success, bypassing the yt-dlp block. To also observe AV1 from
+the pytubefix fallback path (its Fallback 2 accepts any adaptive video), call the same helper
+before that early return in `download_youtube_video_for_upload`:
+
+```python
+        result = download_with_pytubefix(youtube_url, output_dir, min_resolution)
+        if result["success"]:
+            _warn_if_not_h264(result["file_path"], context=youtube_url)
+            return result
+```
+
+Both call the identical helper/detection function. The message names (a) requested `avc1`/
+H264, (b) the actual detected codec, (c) the video id / URL and file path for correlation.
+No `format_map`, `ydl_opts`, or download behavior changes — logging only. `"h264"` result →
+no warning.
+
+---
+
+## 5. Result-dict / audit-field integration
+
+### `split_video_chapter` return dict
+
+Add `source_codec` and `cut_mode` on **all** paths. Existing keys unchanged (additive).
+
+Success path:
+```python
+return {
+    "success": True,
+    "output_path": output_path,
+    "file_size_bytes": file_size,
+    "file_size_mb": file_size_mb,
+    "duration_seconds": duration_seconds,
+    "start_time": start_time,
+    "end_time": end_time,
+    "source_codec": source_codec,                    # NEW
+    "cut_mode": cut_mode_for_reencode(reencode),     # NEW
+    "error": None,
+}
+```
+
+Failure paths (`TimeoutExpired` and generic `Exception`) — spec requires audit fields where
+a codec was determined before the failure. Because `source_codec` is initialized to
+`"unknown"` before the `try`, both except blocks can always emit consistent fields (a failure
+before probing reports `source_codec="unknown"`, `cut_mode="stream_copy"`):
+```python
+    return {
+        "success": False,
+        "output_path": None,
+        "source_codec": source_codec,                                    # NEW
+        "cut_mode": cut_mode_for_reencode(reencode_for_codec(source_codec)),  # NEW
+        "error": error_msg,
+    }
+```
+
+### `reap_clip_preparer_dag.py` pre-trim site
+
+This site does **not** build a returned per-chapter result dict (it logs + inserts to DB, and
+the spec forbids DB schema changes). Match the **existing log shape** rather than invent a
+result dict. The chapter cut's audit fields already arrive via `result['source_codec']` /
+`result['cut_mode']` from `split_video_chapter`. For the pre-trim, extend the existing
+success info log:
+
+Current:
+```python
+logging.info(
+    "Chapter %s pre-trimmed: %.1f–%.1fs (%.0fs) srt_window=%s",
+    chapter_id, pretrim_start, pretrim_end, duration, pretrim_used_srt,
+)
+```
+Becomes:
+```python
+logging.info(
+    "Chapter %s pre-trimmed: %.1f–%.1fs (%.0fs) srt_window=%s source_codec=%s cut_mode=%s",
+    chapter_id, pretrim_start, pretrim_end, duration, pretrim_used_srt,
+    source_codec, cut_mode_for_reencode(reencode),
+)
+```
+where `source_codec` / `reencode` are the loop-scoped values computed from the raw source
+(below). Existing failure/skip logging (`"Pre-trim ffmpeg failed for chapter"`, safety-gate
+blocks) is unchanged.
+
+### Loop wiring in `_extract_and_pretrim_clip`
+
+```python
+from congress_videos.modules.video_splitter import (build_ffmpeg_cut_cmd,
+    compute_ffmpeg_timeout, split_video_chapter)
+from utils.codec_detection import get_cached_codec, reencode_for_codec, cut_mode_for_reencode
+...
+def _extract_and_pretrim_clip(ti, **context):
+    ...
+    codec_cache: dict = {}          # NEW — task-scoped, one entry per source
+    for chapter in chapters:
+        ...
+        source_video_path = _find_source_video(video_id)
+        if not source_video_path:
+            ...; continue
+
+        source_codec = get_cached_codec(source_video_path, codec_cache)   # NEW
+        reencode = reencode_for_codec(source_codec)                       # NEW
+
+        result = split_video_chapter(
+            source_video_path=source_video_path,
+            output_path=clip_path,
+            start_time=_interval_to_srt(start_time),
+            end_time=_interval_to_srt(end_time),
+            codec_cache=codec_cache,     # NEW — shared cache → chapter cut hits, no re-probe
+        )
+        ...
+        # pre-trim branch:
+        _ffmpeg_extract_window(
+            source_path=clip_path, dest_path=trimmed_path,
+            start_secs=pretrim_start, end_secs=pretrim_end,
+            reencode=reencode,           # NEW — mirror the raw source's decision
+        )
+```
+
+`get_cached_codec(source_video_path, codec_cache)` in the loop and the same call inside
+`split_video_chapter` share the dict + key → exactly **one** ffprobe per distinct source
+across the chapter cut and its pre-trim, and across all chapters from that source.
+
+### `extract_chapters_from_video` wiring
+
+```python
+codec_cache: dict = {}              # NEW — before the loop
+for chapter in uploadable_chapters:
+    ...
+    result = split_video_chapter(
+        source_video_path=source_video_path, output_path=output_path,
+        start_time=start_time, end_time=end_time,
+        codec_cache=codec_cache,     # NEW — one probe per distinct source across chapters
+    )
+```
+
+---
+
+## 6. Data flow (end to end)
+
+```
+raw source video (mp4/mkv/webm on NAS)
+        │
+        ▼
+get_cached_codec(abspath(source), codec_cache)     ← task-scoped dict, 1 probe/source
+        │  (miss → detect_video_codec → ffprobe -show_entries codec_name)
+        ▼
+"h264" | "av1" | "unknown"
+        │
+        ▼
+reencode_for_codec()  →  h264 ? True : False
+        │
+        ├─► split_video_chapter → build_ffmpeg_cut_cmd(reencode=…) → ffmpeg cut
+        │         └─ result dict += source_codec, cut_mode
+        │
+        └─► _extract_and_pretrim_clip pre-trim → _ffmpeg_extract_window(reencode=…)
+                  └─ existing info log += source_codec, cut_mode
+
+download path (separate):
+yt-dlp / pytubefix download completes → _warn_if_not_h264(file, ctx)
+        └─ detect_video_codec → WARNING iff codec != "h264"
+```
+
+---
+
+## 7. File-change summary
+
+| File | Change | Kind |
+|------|--------|------|
+| `utils/codec_detection.py` | **NEW** — `detect_video_codec`, `get_cached_codec`, `reencode_for_codec`, `cut_mode_for_reencode` | add |
+| `congress_videos/modules/video_splitter.py` | `split_video_chapter` gains optional `codec_cache=None`; probe → decide `reencode`; add `source_codec`/`cut_mode` to all result dicts; `extract_chapters_from_video` creates + threads `codec_cache` | edit (additive) |
+| `congress_videos/reap_clip_preparer_dag.py` | import detection helpers; `_ffmpeg_extract_window` gains optional `reencode=True`; loop creates `codec_cache`, computes `source_codec`/`reencode`, threads cache into `split_video_chapter`, passes `reencode` to pre-trim, extends pre-trim info log | edit (additive) |
+| `utils/youtube_downloader.py` | import `detect_video_codec`; add `_warn_if_not_h264` helper; call at yt-dlp success block (+ pytubefix early-return) | edit (logging only) |
+| `utils/test_codec_detection.py` | **NEW** tests | add |
+| `congress_videos/modules/test_video_splitter.py` | new decision/audit tests | edit |
+| `congress_videos/test_reap_clip_preparer_dag.py` | new pre-trim decision/audit tests | edit |
+| `utils/test_youtube_downloader.py` | downloader warning tests (new file if absent) | add/edit |
+
+No DB schema changes. No `build_ffmpeg_cut_cmd`, `format_map`, or download-behavior changes.
+
+---
+
+## 8. Test strategy (strict TDD — tests co-located `test_*.py`, pytest + mocker)
+
+- **`utils/test_codec_detection.py`** (mock `subprocess.run`):
+  - `codec_name` `h264`/`avc1` → `"h264"`; `av1`/`av01` → `"av1"`; `vp9`/`hevc`/empty →
+    `"unknown"`.
+  - `FileNotFoundError` (ffprobe missing), `TimeoutExpired`, non-zero returncode → `"unknown"`,
+    never raises.
+  - `get_cached_codec`: with a real dict, probing once then 3 more lookups for the same path →
+    `detect_video_codec`/`subprocess.run` called **exactly once**; `cache is None` → probes per
+    call (no memo); different paths → separate entries.
+  - `reencode_for_codec` / `cut_mode_for_reencode` truth table (3 codecs).
+- **`test_video_splitter.py`**: patch `utils.codec_detection.detect_video_codec` (or
+  `get_cached_codec`) — h264 source → `build_ffmpeg_cut_cmd` receives `reencode=True`; av1 and
+  unknown → `reencode=False`. Result dict carries correct `source_codec`/`cut_mode` on success
+  and on the failure paths. Passing the same `codec_cache` across N calls → one probe.
+- **`test_reap_clip_preparer_dag.py`**: patch detection — pre-trim's `_ffmpeg_extract_window`
+  called with `reencode` matching the raw source codec; cache shared with `split_video_chapter`
+  → one probe per source across chapter + pre-trim.
+- **`test_youtube_downloader.py`**: patch `detect_video_codec` — `"av1"`/`"unknown"` → WARNING
+  logged with requested-vs-actual + context; `"h264"` → no warning; download behavior asserted
+  unchanged.
+
+---
+
+## 9. Rollout & rollback
+
+Purely additive/behavioral within existing functions plus one new leaf module. No migration,
+no persisted-state change. Rollback = straight revert of the commit(s); nothing to backfill.
+Deploy is a standard DAG code deploy — `ffprobe` is already a runtime dependency (the DAG's
+existing safety gate already calls `ffprobe`), so no new binary requirement.
+
+---
+
+## 10. Risks & mitigations
+
+- **Existing `split_video_chapter` tests using real fixture files** will now run `ffprobe` on
+  those fixtures; a non-h264/unknown fixture would flip the command to stream-copy and could
+  break a re-encode-shape assertion. Mitigation: in the tasks phase, mock detection in those
+  tests (patch `get_cached_codec`/`detect_video_codec`) or ensure fixtures probe as `h264`.
+  Flagged for tasks — do not let this silently regress the existing suite.
+- **Pre-trim reuses the raw-source decision, not a re-probe of `clip_path`.** This is correct
+  because stream-copy preserves the source codec, but it is a deliberate coupling — documented
+  here so a future refactor doesn't "fix" it into a redundant second probe.
+- **`os.path.abspath` vs `realpath`**: `abspath` normalizes cwd-relative paths; both cut sites
+  already build absolute paths, so `abspath` suffices. If symlinked download dirs ever appear,
+  switch the key to `os.path.realpath` — noted, not needed now.
+- **Unknown-codec masking**: `detect_video_codec` logs a **distinct** WARNING for the
+  unrecognized-codec case vs the ffprobe-failure case, so a real ffprobe misconfiguration is
+  not silently laundered into the expected-av1 path.
+
+## 11. Next phase
+
+`tasks` — break this into TDD task batches (new module + tests first, then the two cut-site
+wirings, then downloader logging), respecting the backward-compat and probe-once acceptance
+criteria.

--- a/openspec/changes/ffmpeg-codec-aware-cuts/proposal.md
+++ b/openspec/changes/ffmpeg-codec-aware-cuts/proposal.md
@@ -1,0 +1,173 @@
+# Proposal: ffmpeg-codec-aware-cuts
+
+## Status
+Draft — proposal phase (next: spec)
+
+## Problem Statement
+
+Congressional plenary session videos (7–10 hours) are frequently only available from
+YouTube as AV1 (`av01`) at 720p+, because YouTube does not serve `avc1`/H264 for very
+long streams at that resolution. `utils/youtube_downloader.py`'s format string already
+prefers `avc1`, but its fallback chain (`bestvideo[height>=720]+bestaudio/best`) has no
+codec filter, so it silently accepts AV1 when H264 isn't offered.
+
+Two real production files confirm this is not a download/network defect:
+- `GMZ5TwfZJHw` (7h10 session, 18/06): `av01`, 1280x720, 800kb/s — file size/duration/
+  bitrate consistent with a complete, non-truncated download.
+- `sahjXSGn-Ak` (10h05 session, 23/07): `av01`, 1280x720, 877kb/s — same, file complete.
+
+When `congress_videos/modules/video_splitter.py`'s `split_video_chapter` re-encodes a
+cut window with `libx264`, ffmpeg crashes with OBU/AAC decode errors whenever the cut
+window lands on a corrupted AV1 segment. This is genuine dav1d-vs-YouTube-AV1-encode
+bitstream incompatibility in specific segments of the source — not a tolerable decode
+glitch — so `-err_detect ignore_err` (added in a prior commit) does not help.
+
+Two prior fixes were tried and are insufficient (do not repeat):
+- `87aeb8b` — forced H264 in the downloader: YouTube simply doesn't offer H264 for
+  these long streams, so this cannot succeed.
+- `1c0316b` — added input-seeking + `-err_detect ignore_err` tolerance: still fatal on
+  real mid-stream corruption, only helps with minor glitches.
+
+The same long AV1-risk source videos are cut in two places today
+(`video_splitter.split_video_chapter` and the inline pre-trim cut in
+`reap_clip_preparer_dag.py`), both of which currently assume a re-encode-first /
+stream-copy-fallback strategy and can hit the same crash.
+
+## Goals
+
+1. Detect the source video's codec proactively (via `ffprobe`), before deciding the
+   ffmpeg cut strategy, instead of reactively catching a re-encode failure.
+2. If codec is `h264` → keep the current default: frame-accurate re-encode
+   (`libx264`/`aac`).
+3. If codec is `av1`, or ffprobe fails, or the codec is unrecognized → stream-copy
+   (`-c copy`), which never decodes the corrupted bitstream. This trades frame accuracy
+   for reliability: keyframe-snap drift of a few seconds is accepted.
+4. Apply this decision consistently across the two ffmpeg cut sites that operate on
+   these source videos: `video_splitter.split_video_chapter` and the inline pre-trim
+   cut in `reap_clip_preparer_dag.py`.
+5. Cache the ffprobe result per source video (keyed by video_id / source file path) so
+   a single source video producing dozens of chapters/shorts is probed exactly once per
+   pipeline run, not once per cut.
+6. Add observability to the downloader: log a clear warning when the yt-dlp fallback
+   actually returns AV1 instead of the requested H264, so future AV1 rate is visible
+   without re-investigating from scratch.
+7. Make the codec decision auditable per cut: each cut's result dict includes
+   `source_codec` and `cut_mode` (`"reencode"` | `"stream_copy"`).
+
+## Non-Goals
+
+- Fixing or working around YouTube's AV1 encoding itself — out of anyone's control.
+- Changing yt-dlp's format string / download quality preference or download strategy.
+  The downloader keeps trying `avc1` first; this change only adds *logging* when the
+  fallback yields AV1, it does not alter what gets downloaded.
+- Any database schema changes. Auditability is result-dict only (in-memory / task
+  return value), not persisted to a new column or table.
+- Retrying failed re-encodes with a different backoff/queue strategy — replaced
+  entirely by the proactive codec check.
+- Transcoding existing AV1 source files to H264 ahead of time (a valid future
+  optimization, but out of scope here).
+
+## Proposed Approach
+
+1. **Shared codec-detection helper**: a small function (likely in
+   `congress_videos/modules/video_splitter.py` or a new shared module) that runs
+   `ffprobe` against a source video path and returns a normalized codec string
+   (`"h264"`, `"av1"`, or `"unknown"` on ffprobe failure / unrecognized codec).
+2. **Per-source-video cache**: a cache (keyed by video_id or source file path) storing
+   the detected codec, populated on first probe and reused for every subsequent cut
+   drawn from the same source file within a pipeline run. Scope and lifetime of this
+   cache (process-local dict vs. Airflow XCom/Variable) is a spec/design decision.
+3. **Decision rule wired into both cut sites**:
+   - `congress_videos/modules/video_splitter.py::split_video_chapter`
+   - `congress_videos/reap_clip_preparer_dag.py` inline pre-trim cut (~line 208,
+     "Pre-trim ffmpeg failed for chapter")
+   Each site consults the cached codec for its source video and chooses `reencode` for
+   `h264`, `stream_copy` for `av1` or `unknown` — replacing today's
+   try-reencode/catch/retry-stream-copy pattern with a decide-then-cut-once pattern.
+
+   **Excluded**: `congress_videos/reap_shorts_uploader_dag.py`'s ffmpeg call (~line
+   170, "ffmpeg failed for short") was investigated and confirmed out of scope. It
+   is an audio-only extraction (`ffmpeg -vn ...` to WAV, for Whisper transcription),
+   not a video cut, and its input is `short.get('local_file_path')` — a short clip
+   already produced and downloaded from an external service (Reap, via
+   `reap_client.download_clip` in `reap_processor_dag.py`), not the raw 7–10h AV1
+   source video. It is not exposed to the AV1 corruption risk this change addresses,
+   so it must not be wired into the codec decision.
+4. **Downloader logging**: after a download completes in
+   `utils/youtube_downloader.py`, inspect the actual downloaded stream's codec and log
+   a warning if it's not `avc1`/H264 despite the format string requesting it. No change
+   to `format_map` or download behavior.
+5. **Result dict auditability**: `split_video_chapter` and the equivalent result
+   structure in the other cut site gain `source_codec` and `cut_mode` fields.
+
+## Business / Product Framing
+
+This is a solo-maintainer congressional video archival pipeline (no other stakeholders
+to coordinate with). The business problem is operational reliability: long plenary
+sessions are the most important content (full-day sessions) and are exactly the videos
+most likely to be AV1-only, so today's crash disproportionately affects the highest-value
+source material. The fix converts unpredictable pipeline failures (crash mid-run,
+requiring manual re-trigger and investigation) into predictable, self-selecting behavior
+(automatically the right cut strategy, with a visible audit trail per chapter/short). The
+downloader logging closes the loop: it turns "AV1 happens sometimes" into a measurable,
+observable trend so future capacity/prioritization decisions have data instead of
+having to redo this incident investigation.
+
+## Affected Areas
+
+- `congress_videos/modules/video_splitter.py`
+- `congress_videos/reap_clip_preparer_dag.py`
+- `congress_videos/reap_shorts_uploader_dag.py`
+- `utils/youtube_downloader.py`
+- (possibly) a new shared helper module for codec detection + caching
+
+## Risks
+
+- **Frame accuracy loss on AV1 sources**: stream-copy cuts snap to the nearest
+  keyframe, so AV1-sourced chapters/shorts may start/end a few seconds off the
+  requested boundary. Accepted tradeoff per agreed fail-safe rule — reliability over
+  precision when the source is AV1.
+- **Cache key collisions**: if the cache key (video_id vs. file path) isn't chosen
+  carefully, a stale codec could be reused across re-downloads or across DAG runs.
+  Needs explicit key/lifetime definition in spec/design.
+- **ffprobe availability/cost**: ffprobe must be present in the runtime environment;
+  probing a 7–10 hour file should be fast (container/stream metadata only, no decode),
+  but this should be verified in design/tasks.
+- **Silent unknown-codec cases**: defaulting unknown codecs to stream-copy is
+  fail-safe for reliability, but could mask a real ffprobe misconfiguration if not
+  logged distinctly from the expected `av1` case.
+
+## Rollback
+
+All changes are additive/behavioral within existing functions (new helper, new
+decision branch, new log lines, new result-dict fields) — no schema or interface
+migration. Rollback is a straight revert of the commit(s); no data backfill or cleanup
+required since no persisted state changes.
+
+## Success Criteria
+
+- Both known-bad production videos (`GMZ5TwfZJHw`, `sahjXSGn-Ak`) can be fully chaptered
+  and/or clipped without ffmpeg crashing, using stream-copy mode.
+- A known-good H264 source video continues to produce frame-accurate re-encoded cuts
+  (no regression for the common case).
+- ffprobe is called at most once per distinct source video per pipeline run, regardless
+  of how many chapters/shorts are cut from it.
+- Every cut's result dict includes `source_codec` and `cut_mode`.
+- The downloader logs a warning (not silent) whenever it falls back to a non-H264
+  download.
+
+## Proposal Question Round (already conducted)
+
+The following product questions were asked and answered earlier in this conversation;
+recorded here for traceability, not for re-asking:
+
+1. Which cut sites are in scope? → All three (chapter splitter, pre-trim, shorts).
+2. Should codec detection be cached, and at what granularity? → Yes, per source video,
+   reused across all cuts from that source within a run.
+3. Should downloader behavior change? → No, only add observability logging for AV1
+   fallback.
+4. Should audit fields be persisted to the DB? → No, result-dict only.
+5. What should happen when ffprobe fails or returns an unknown codec? → Fail-safe to
+   stream-copy, never blind re-encode.
+
+No further question round requested by the user for this change.

--- a/openspec/changes/ffmpeg-codec-aware-cuts/specs/congress-video-cutting/spec.md
+++ b/openspec/changes/ffmpeg-codec-aware-cuts/specs/congress-video-cutting/spec.md
@@ -1,0 +1,352 @@
+# Congress Video Cutting Specification
+
+## Purpose
+
+Congressional plenary session videos may arrive as H264 (`avc1`) or AV1 (`av01`)
+depending on what YouTube serves for a given stream length/resolution. Re-encoding
+a cut window on a corrupted AV1 source crashes ffmpeg with fatal OBU/AAC decode
+errors. This spec defines codec-aware cut behavior — detect the source codec once,
+cache it per source video, and choose the ffmpeg cut strategy (re-encode vs.
+stream-copy) accordingly — applied consistently across the two ffmpeg cut sites
+that operate on the raw source videos, plus downloader observability and per-cut
+audit fields.
+
+This is a new domain spec; no prior canonical spec exists for `congress-video-cutting`.
+Domain name and boundary were inferred from the proposal's Affected Areas (no
+`Capabilities` section was present in the proposal) — flagged as a risk below.
+
+## Requirements
+
+### Requirement: Codec Detection Function
+
+The system MUST provide a single shared codec-detection function that determines
+the video codec of a source file via `ffprobe`, used as the one source of truth for
+codec detection across all cut sites and the downloader.
+
+- Input: a source file path (`str`).
+- Output: a normalized codec string, one of exactly `"h264"`, `"av1"`, or `"unknown"`.
+- The function MUST NOT raise on ffprobe failure, timeout, or a missing `ffprobe`
+  binary — it MUST catch those conditions internally and return `"unknown"`.
+- Any codec name ffprobe reports that is not `h264`/`avc1` or `av1`/`av01` (e.g.
+  `vp9`, `hevc`) MUST normalize to `"unknown"` — there is no additional named
+  category beyond `"h264"`, `"av1"`, `"unknown"`; unrecognized codecs are treated
+  identically to the fail-safe unknown case, not as a distinct branch.
+
+#### Scenario: H264 source detected
+
+- GIVEN a source file whose primary video stream codec is `h264`
+- WHEN the codec-detection function is called with that file's path
+- THEN it returns `"h264"`
+
+#### Scenario: AV1 source detected
+
+- GIVEN a source file whose primary video stream codec is `av1` (`av01`)
+- WHEN the codec-detection function is called with that file's path
+- THEN it returns `"av1"`
+
+#### Scenario: ffprobe binary missing
+
+- GIVEN the `ffprobe` executable is not available on the runtime `PATH`
+- WHEN the codec-detection function is called with any source file path
+- THEN it returns `"unknown"` and does not raise an exception
+
+#### Scenario: ffprobe times out
+
+- GIVEN `ffprobe` does not complete within the function's configured timeout
+- WHEN the codec-detection function is called
+- THEN it returns `"unknown"` and does not raise an exception
+
+#### Scenario: ffprobe process failure
+
+- GIVEN `ffprobe` exits with a non-zero return code or produces unparseable output
+- WHEN the codec-detection function is called
+- THEN it returns `"unknown"` and does not raise an exception
+
+#### Scenario: unrecognized codec
+
+- GIVEN a source file whose primary video stream codec is `vp9` or `hevc`
+- WHEN the codec-detection function is called with that file's path
+- THEN it returns `"unknown"` (not a new category)
+
+### Requirement: Per-Source-Video Codec Cache
+
+The system MUST memoize the detected codec per source video so that a source
+video producing many chapters/shorts is probed by `ffprobe` at most once within
+a single pipeline/task execution.
+
+- Cache key MUST be derived from `video_id` and/or the resolved source file path
+  (exact key strategy is a design decision, but it MUST NOT allow a stale codec
+  from a different physical file to be reused against a re-downloaded/replaced
+  source within the same run).
+- Cache scope MUST be limited to a single pipeline/task execution (e.g. a
+  process-local structure). The cache MUST NOT be persisted across separate
+  Airflow DAG runs — every new run starts with an empty cache and re-probes on
+  first use.
+- On first lookup for a given source video, the cache MUST populate itself by
+  calling the codec-detection function and storing the result.
+- On every subsequent lookup for the same source video within the same
+  run/process, the cache MUST return the previously stored result without
+  invoking `ffprobe` again.
+
+#### Scenario: First cut probes, later cuts reuse
+
+- GIVEN a source video that has not yet been probed in the current pipeline run
+- WHEN a cut site requests the codec for that source for the first cut
+- THEN the codec-detection function is invoked exactly once, and the result is stored
+
+#### Scenario: Subsequent cuts from the same source reuse the cache
+
+- GIVEN a source video whose codec was already probed and cached earlier in the
+  same pipeline run
+- WHEN N additional cuts (chapters or shorts) are requested from that same source
+- THEN `ffprobe` is invoked zero additional times for those N cuts, and each cut
+  receives the cached codec value
+
+#### Scenario: Cache does not survive across separate runs
+
+- GIVEN a source video was probed and cached during pipeline run A
+- WHEN pipeline run B later processes cuts from the same source video
+- THEN run B performs its own fresh probe (the cache from run A is not visible to run B)
+
+### Requirement: Codec-Based Reencode Decision Rule
+
+The system MUST select the ffmpeg cut mode based on the cached/detected codec,
+reusing the existing `reencode` parameter of `build_ffmpeg_cut_cmd` rather than
+introducing a new command-building path.
+
+- WHEN the detected codec is `"h264"`, THEN the cut site MUST call
+  `build_ffmpeg_cut_cmd` (or the site's equivalent command builder) with
+  `reencode=True` (frame-accurate re-encode path, unchanged from current behavior).
+- WHEN the detected codec is `"av1"` or `"unknown"`, THEN the cut site MUST call
+  `build_ffmpeg_cut_cmd` (or the site's equivalent command builder) with
+  `reencode=False` (stream-copy path).
+- This decision MUST be made once per cut, before subprocess invocation — not as
+  a reactive retry after a failed re-encode attempt.
+
+#### Scenario: H264 source re-encodes
+
+- GIVEN a source video with cached/detected codec `"h264"`
+- WHEN a cut is performed against that source
+- THEN the ffmpeg command is built with `reencode=True`
+
+#### Scenario: AV1 source stream-copies
+
+- GIVEN a source video with cached/detected codec `"av1"`
+- WHEN a cut is performed against that source
+- THEN the ffmpeg command is built with `reencode=False`
+
+#### Scenario: Unknown codec fails safe to stream-copy
+
+- GIVEN a source video whose codec could not be determined (`"unknown"`)
+- WHEN a cut is performed against that source
+- THEN the ffmpeg command is built with `reencode=False` — the system never
+  attempts a blind re-encode when the codec is not confidently known
+
+### Requirement: Codec-Aware Wiring at Both Cut Sites
+
+The system MUST wire codec detection, caching, and the reencode decision rule
+into each of the two in-scope ffmpeg cut sites, replacing today's
+try-reencode/catch/retry-stream-copy pattern with a decide-then-cut-once pattern,
+without changing each site's existing signature/return-shape contract beyond the
+additive audit fields defined below.
+
+- `congress_videos/modules/video_splitter.py::split_video_chapter` MUST consult
+  the shared cache for `source_video_path`'s codec before calling
+  `build_ffmpeg_cut_cmd`, and MUST pass the resulting `reencode` value through.
+- `congress_videos/reap_clip_preparer_dag.py`'s inline pre-trim cut (around the
+  `"Pre-trim ffmpeg failed for chapter"` error path, via `_ffmpeg_extract_window`)
+  MUST consult the shared cache for its source file's codec before calling
+  `build_ffmpeg_cut_cmd`, and MUST pass the resulting `reencode` value through.
+- Both sites MUST use the same shared codec-detection function and the same
+  shared cache — no site may implement a second, divergent detection or caching
+  mechanism.
+- `congress_videos/reap_shorts_uploader_dag.py`'s ffmpeg call (around the
+  `"ffmpeg failed for short"` error path) is explicitly OUT OF SCOPE for this
+  wiring: it is an audio-only extraction (`ffmpeg -vn ...` to WAV, for Whisper
+  transcription) against an already-produced/downloaded short clip
+  (`short.get('local_file_path')`, sourced via `reap_client.download_clip`), not
+  a cut of the raw AV1-risk source video. It MUST NOT be wired into the codec
+  decision rule.
+
+#### Scenario: video_splitter chooses reencode per codec
+
+- GIVEN `split_video_chapter` is called with a source video of known codec
+- WHEN it builds its ffmpeg command
+- THEN the `reencode` value passed to `build_ffmpeg_cut_cmd` matches the codec
+  decision rule for that source's cached codec
+
+#### Scenario: clip preparer pre-trim chooses reencode per codec
+
+- GIVEN the pre-trim step in `reap_clip_preparer_dag.py` runs against a source
+  clip of known codec
+- WHEN it builds its ffmpeg command via `_ffmpeg_extract_window` /
+  `build_ffmpeg_cut_cmd`
+- THEN the `reencode` value passed matches the codec decision rule for that
+  source's cached codec
+
+### Requirement: Per-Cut Audit Fields in Result Dicts
+
+The system MUST add two fields — `source_codec` (`str`: `"h264"` | `"av1"` |
+`"unknown"`) and `cut_mode` (`str`: `"reencode"` | `"stream_copy"`) — to the
+result of every cut performed at both in-scope cut sites, without removing or
+renaming any existing result-dict keys.
+
+- `split_video_chapter`'s existing return dict (currently including `success`,
+  `output_path`, `file_size_bytes`, `file_size_mb`, `duration_seconds`,
+  `start_time`, `end_time`, `error`) MUST gain `source_codec` and `cut_mode` keys
+  on both success and failure paths where a codec was determined before the
+  failure occurred.
+- `reap_clip_preparer_dag.py`'s pre-trim result/log context (the per-chapter
+  processing outcome tracked around the pre-trim step) MUST record
+  `source_codec` and `cut_mode` for that chapter's pre-trim cut.
+- `cut_mode` MUST be `"reencode"` exactly when `reencode=True` was used to build
+  the command, and `"stream_copy"` exactly when `reencode=False` was used —
+  there is a 1:1 mapping, no independent state.
+
+#### Scenario: Successful h264 cut carries audit fields
+
+- GIVEN a successful cut against an `"h264"` source
+- WHEN the cut site returns its result
+- THEN the result includes `source_codec: "h264"` and `cut_mode: "reencode"`
+
+#### Scenario: Successful av1 cut carries audit fields
+
+- GIVEN a successful cut against an `"av1"` source
+- WHEN the cut site returns its result
+- THEN the result includes `source_codec: "av1"` and `cut_mode: "stream_copy"`
+
+#### Scenario: Unknown-codec cut still carries audit fields
+
+- GIVEN a cut against a source whose codec could not be determined
+- WHEN the cut site returns its result
+- THEN the result includes `source_codec: "unknown"` and `cut_mode: "stream_copy"`
+
+### Requirement: Downloader Codec-Mismatch Logging
+
+`utils/youtube_downloader.py` MUST log a warning after a download completes when
+the actual downloaded file's codec differs from the requested `avc1`/H264
+preference, using the same shared codec-detection function defined above (no
+second, divergent detection implementation in the downloader).
+
+- The check MUST run once, after the download completes and the final file path
+  is known (post-download detection only — this requirement does not change
+  `format_map` or any download/format-selection behavior).
+- WHEN the detected codec of the downloaded file is not `"h264"` (i.e. it is
+  `"av1"` or `"unknown"`), THEN the downloader MUST log at `WARNING` level (or
+  the codebase's established equivalent) a message that identifies: (a) that the
+  requested/preferred codec was `avc1`/H264, (b) the actual detected codec value,
+  and (c) enough context (e.g. video id or file path) to correlate the warning
+  with the specific download.
+- WHEN the detected codec of the downloaded file is `"h264"` (the requested
+  case), THEN no codec-mismatch warning MUST be logged.
+
+#### Scenario: Downloaded file matches requested codec
+
+- GIVEN a download completes and the final file's detected codec is `"h264"`
+- WHEN the post-download codec check runs
+- THEN no codec-mismatch warning is logged
+
+#### Scenario: Downloaded file falls back to AV1
+
+- GIVEN a download completes and the final file's detected codec is `"av1"`
+- WHEN the post-download codec check runs
+- THEN a `WARNING`-level log is emitted naming the requested codec (`avc1`/H264),
+  the actual detected codec (`av1`), and identifying context for the download
+
+#### Scenario: Downloaded file codec cannot be determined
+
+- GIVEN a download completes and the post-download codec check returns `"unknown"`
+- WHEN the check runs
+- THEN a `WARNING`-level log is emitted naming the requested codec, the
+  `"unknown"` result, and identifying context for the download
+
+### Requirement: Backward Compatibility of Existing Interfaces
+
+The system MUST preserve existing public interfaces used by current callers and
+tests; codec-awareness is additive.
+
+- `build_ffmpeg_cut_cmd`'s existing signature (including the `reencode: bool =
+  True` default and both its re-encode and stream-copy command shapes) MUST be
+  reused as-is by the codec-aware wiring — this change MUST NOT replace it with
+  a new command-building function or alter its default behavior for callers that
+  do not go through the new codec-detection/cache path.
+- `split_video_chapter`'s existing positional/keyword call signature
+  (`source_video_path`, `output_path`, `start_time`, `end_time`) MUST remain
+  unchanged; codec-awareness must not require callers to pass new arguments.
+- Existing successful-path result-dict keys at both in-scope cut sites MUST remain
+  present with their existing meanings; `source_codec` and `cut_mode` are
+  additions, not replacements.
+- The DAG cut site (`reap_clip_preparer_dag.py`) MUST continue to produce a
+  failure/skip outcome consistent with its current error-handling behavior (e.g.
+  `"Pre-trim ffmpeg failed for chapter"` logging) when the underlying ffmpeg
+  invocation itself fails, regardless of which `reencode` mode was selected.
+
+#### Scenario: Existing h264-only caller behavior unchanged
+
+- GIVEN an existing test or caller of `split_video_chapter` against a known
+  H264 source, written before this change
+- WHEN that test/caller runs after this change is applied
+- THEN it still receives `reencode=True` behavior and all previously-asserted
+  result keys, with `source_codec`/`cut_mode` present as additional keys
+
+#### Scenario: build_ffmpeg_cut_cmd default is unchanged
+
+- GIVEN a caller invokes `build_ffmpeg_cut_cmd` without specifying `reencode`
+- WHEN the command is built
+- THEN it defaults to `reencode=True` exactly as before this change
+
+### Requirement: Test Coverage
+
+The system MUST have unit-test coverage for the following areas before this
+change is considered complete:
+
+- Codec detection: `"h264"` case, `"av1"` case, `"unknown"` case for an
+  unrecognized codec (e.g. `vp9`/`hevc`), and `"unknown"` case for a missing/
+  failing `ffprobe` binary or timeout.
+- Cache behavior: a source probed once and reused across N (N ≥ 2) subsequent
+  cut requests within the same run results in exactly one `ffprobe` invocation.
+- Decision wiring: for each of the two in-scope cut sites, an `"h264"` source
+  selects `reencode=True` and an `"av1"`/`"unknown"` source selects
+  `reencode=False`.
+- Result-dict audit fields: for each of the two in-scope cut sites, a successful
+  cut's result contains the correct `source_codec` and `cut_mode` values for each
+  of the three codec cases.
+- Downloader logging: a warning is logged only when the actual downloaded
+  codec differs from the requested `avc1`/H264 preference, and is not logged on
+  a successful `avc1`/H264 download.
+
+#### Scenario: Test suite covers all codec-detection branches
+
+- GIVEN the test suite for the shared codec-detection function
+- WHEN it is run
+- THEN it includes passing cases for `"h264"`, `"av1"`, unrecognized-codec
+  `"unknown"`, and ffprobe-failure/timeout `"unknown"`
+
+#### Scenario: Test suite covers cache reuse
+
+- GIVEN the test suite for the per-source-video cache
+- WHEN a source is probed once and 3 subsequent cuts are requested
+- THEN the test asserts `ffprobe` (or the mocked detection call) was invoked
+  exactly once across all 4 requests
+
+## Risks / Open Questions Carried From Proposal
+
+- **Domain inference**: the proposal has no `Capabilities` section; this spec's
+  domain (`congress-video-cutting`) and requirement boundaries were inferred
+  from the proposal's Affected Areas. Flagged for confirmation in design/tasks.
+- **Scope correction — shorts uploader confirmed out of scope**: reading
+  `reap_shorts_uploader_dag.py` around the `"ffmpeg failed for short"` log line
+  confirmed this ffmpeg invocation extracts a `pcm_s16le` **audio-only** stream
+  (`-vn`) from `short.get('local_file_path')` — a short clip already produced and
+  downloaded from an external service (Reap, via `reap_client.download_clip` in
+  `reap_processor_dag.py`), for Whisper transcription. It is not a cut of the raw
+  7–10h AV1 source video and is not exposed to the AV1 corruption risk this change
+  addresses. This site has been removed from scope entirely (was previously,
+  incorrectly, listed as a third in-scope cut site); no further design resolution
+  is needed.
+- **Cache key definition** (video_id vs. resolved file path, and how to avoid
+  stale reuse across re-downloads within the same run) is a design decision per
+  the proposal; this spec states the constraint but not the concrete
+  implementation.
+- **ffprobe performance on 7–10h files**: expected to be fast (container/stream
+  metadata only), but not verified here — flagged for design/tasks to confirm.

--- a/openspec/changes/ffmpeg-codec-aware-cuts/tasks.md
+++ b/openspec/changes/ffmpeg-codec-aware-cuts/tasks.md
@@ -1,0 +1,109 @@
+# Tasks: ffmpeg-codec-aware-cuts
+
+Spec: `openspec/changes/ffmpeg-codec-aware-cuts/specs/congress-video-cutting/spec.md`
+Design: `openspec/changes/ffmpeg-codec-aware-cuts/design.md` (approved, settled — do not reopen)
+
+Test runner (from sdd-init, obs #7): `conda run -n airflow python -m pytest` (env-active: `python -m pytest` from repo root).
+Coverage gate `--cov-fail-under=80` runs on every invocation via addopts — for fast/partial local runs during RED/GREEN cycles use `python -m pytest -p no:cacheprovider --no-cov <path>`, then run the full suite without `--no-cov` before closing out each slice.
+Strict TDD Mode is ACTIVE for this project: every implementation unit below is sequenced RED → GREEN → TRIANGULATE → REFACTOR. Do not bundle "implement + test" into one step.
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~480–650 (new module ~90 + its tests ~130, video_splitter.py edit ~35 + tests ~80, reap_clip_preparer_dag.py edit ~55 + tests ~90, youtube_downloader.py edit ~25 + new tests ~70) |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → PR 2 → PR 3 (see Slice Boundary below) |
+| Delivery strategy | ask-on-risk (session default) — parent must confirm with user before sdd-apply starts |
+| Chain strategy | pending — parent/user to confirm (stacked-to-main vs feature-branch-chain) before apply |
+
+```text
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+```
+
+### Proposed Slice Boundary (for parent/user confirmation — not decided unilaterally here)
+
+- **Slice 1 (PR 1)**: shared `utils/codec_detection.py` module + its own full test suite. Self-contained, no wiring into existing call sites yet. Lowest risk, easiest to review in isolation. Est. ~220 lines.
+- **Slice 2 (PR 2)**: wire `video_splitter.split_video_chapter` (codec_cache param, probe, audit fields) + existing `test_video_splitter.py` audit/mock fixes + new wiring tests. Depends on Slice 1 merged (imports `utils.codec_detection`). Est. ~115 lines.
+- **Slice 3 (PR 3)**: wire `reap_clip_preparer_dag.py` pre-trim (reuse raw-source decision, cache threading, log-line audit) + `youtube_downloader.py` post-download logging + their tests. Depends on Slice 1 merged; independent of Slice 2's internals (only depends on the shared module's public API). Est. ~215 lines.
+
+If the user declines chaining, Slice 1+2+3 combined tasks below can run as a single PR — the task list is written so it works either way; only the PR boundary changes, not the task content.
+
+---
+
+## Slice 1 — Shared codec detection module (`utils/codec_detection.py`)
+
+- [x] RED: Write `utils/test_codec_detection.py` covering `detect_video_codec()`: h264/avc1 → "h264"; av1/av01 → "av1"; unrecognized codec (vp9, hevc) → "unknown"; ffprobe binary missing (`FileNotFoundError`) → "unknown"; ffprobe timeout → "unknown"; ffprobe non-zero return code → "unknown"; empty stdout → "unknown". Assert the function never raises. Use `mocker`/`mock_subprocess_run` per existing `tests/conftest.py` conventions. Run with `python -m pytest utils/test_codec_detection.py -p no:cacheprovider --no-cov` and confirm all new tests FAIL (module doesn't exist yet). <!-- sdd-owner: implementation -->
+- [x] RED: Add test cases to `utils/test_codec_detection.py` asserting distinct log messages/log calls for "unrecognized codec" (e.g. vp9/hevc) vs "ffprobe failure" (missing binary/timeout/non-zero) — per design Decision 3, these must not be masked as the same warning. Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Implement `utils/codec_detection.py::detect_video_codec(source_path, *, timeout=30) -> str` per design Decision 3 exactly: `ffprobe -v error -select_streams v:0 -show_entries stream=codec_name -of csv=p=0 <path>`; lowercase/strip stdout; h264/avc1→"h264", av1/av01→"av1", else→"unknown"; catch `FileNotFoundError`/`subprocess.TimeoutExpired`/non-zero returncode/generic `Exception`→"unknown" with distinct log messages for unrecognized-codec vs probe-failure. Run tests until GREEN. <!-- sdd-owner: implementation -->
+- [x] RED: Write tests for `get_cached_codec(source_path, cache)`: `cache=None` → probes directly every call (no memoization); `cache={}` dict → first call probes and stores under `os.path.abspath(source_path)`, second call with same path (even relative vs absolute variants) hits cache and does NOT call ffprobe again (assert mock call count == 1). Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Implement `get_cached_codec(source_path, cache)` per design Decision 2: key = `os.path.abspath(source_path)`; `cache is None` bypasses memoization; otherwise populate-on-first-probe, reuse thereafter. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] RED: Write tests for `reencode_for_codec(codec) -> bool` (h264→True, av1→False, unknown→False) and `cut_mode_for_reencode(reencode) -> str` ("reencode"/"stream_copy"), including the 1:1 mapping invariant. Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Implement `reencode_for_codec` and `cut_mode_for_reencode` in `utils/codec_detection.py`. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] TRIANGULATE: Add at least 2 additional edge-case inputs per function (e.g. mixed-case codec strings like "H264"/"AV01", path with spaces, cache dict pre-populated with a stale/different codec value to confirm it is trusted as-is and not re-probed) to confirm the implementation generalizes rather than being hardcoded to the first fixture. <!-- sdd-owner: implementation -->
+- [x] REFACTOR: Clean up `utils/codec_detection.py` (docstrings per Google style, import ordering stdlib/third-party/local, remove duplication between the two log-message branches) while keeping all tests GREEN. Run full `utils/test_codec_detection.py` file plus `python -m pytest -p no:cacheprovider --no-cov utils/` to confirm no collateral breakage in sibling `utils/` tests. <!-- sdd-owner: implementation -->
+- [ ] Start or reuse bounded review for Slice 1 (new module + tests only). <!-- sdd-owner: parent -->
+
+---
+
+## Slice 2 — Wire `video_splitter.split_video_chapter` + audit existing tests (regression risk)
+
+- [x] AUDIT (do first, before any wiring): Read `congress_videos/modules/test_video_splitter.py` in full and identify every test that exercises `split_video_chapter`'s re-encode vs stream-copy command shape (asserts on `libx264`/`-c copy`/`build_ffmpeg_cut_cmd` args). For each such test, either (a) confirm the fixture is verified/mocked to be h264 already, or (b) mark it for mocking in the next task. This directly addresses the design-flagged risk: unwired real fixture files will now hit real `ffprobe`, and a non-h264 fixture would silently flip to stream-copy and break existing re-encode-shape assertions. <!-- sdd-owner: implementation -->
+- [x] RED/GREEN (regression-proofing): Update every existing `test_video_splitter.py` test identified in the audit task to explicitly mock `utils.codec_detection.detect_video_codec` (or `get_cached_codec`) to return a controlled value ("h264" for tests asserting re-encode shape, "av1" for tests asserting stream-copy shape if any exist) rather than relying on fixture file codec. Run the full existing `test_video_splitter.py` suite (`python -m pytest congress_videos/modules/test_video_splitter.py -p no:cacheprovider --no-cov`) and confirm it still passes with mocks in place BEFORE `split_video_chapter` is wired to call the new module (these tests should still pass at this point since the mock target doesn't exist in the call path yet — if they fail, fix the mock target path now, before wiring). <!-- sdd-owner: implementation -->
+- [x] RED: Write new tests in `test_video_splitter.py` for the wired behavior: `split_video_chapter(..., codec_cache=None)` — h264 source → `reencode=True` passed to `build_ffmpeg_cut_cmd`; av1 source → `reencode=False`; ffprobe failure/unknown → `reencode=False` (fail-safe); result dict contains `source_codec` and `cut_mode` on the success path AND on both except-block failure paths (source_codec defaults to "unknown" before try, per design Decision 3). Confirm FAIL (function not yet wired). <!-- sdd-owner: implementation -->
+- [x] RED: Write a test asserting `codec_cache` threading: calling `split_video_chapter` twice with the same `source_video_path` and a shared `codec_cache={}` dict results in exactly one `detect_video_codec`/ffprobe call (mock call count == 1). Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Wire `congress_videos/modules/video_splitter.py::split_video_chapter` per design Decision 3: add trailing optional `codec_cache=None` param; initialize `source_codec="unknown"` before the `try` block so failure paths report it; call `get_cached_codec(source_video_path, codec_cache)` then `reencode_for_codec(...)` before `build_ffmpeg_cut_cmd(reencode=...)`; add `source_codec`/`cut_mode` to the result dict on all paths (success + both except blocks). Import from `utils.codec_detection`. Run tests until GREEN. <!-- sdd-owner: implementation -->
+- [x] RED: Write a test for `extract_chapters_from_video` (the loop caller) asserting it creates one `codec_cache={}` before its chapter loop and threads it into every `split_video_chapter` call, so N chapters from the same source share one probe. Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Update `extract_chapters_from_video` to create `codec_cache = {}` before the loop and pass it through to each `split_video_chapter` call. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] TRIANGULATE: Add a test with 3+ chapters from the same source and assert ffprobe/detect_video_codec is called exactly once across all of them (not per-chapter), plus a test with 2 different source paths in sequence asserting 2 separate probes (cache doesn't cross-contaminate by source). <!-- sdd-owner: implementation -->
+- [x] REFACTOR: Clean up `video_splitter.py` (docstring for the new param, import ordering) while keeping the full `test_video_splitter.py` suite GREEN, including all pre-existing tests updated in the audit step above. <!-- sdd-owner: implementation -->
+- [ ] Start or reuse bounded review for Slice 2 (video_splitter.py wiring + regression-proofed existing tests). <!-- sdd-owner: parent -->
+
+---
+
+## Slice 3 — Wire `reap_clip_preparer_dag.py` pre-trim + `youtube_downloader.py` logging
+
+- [x] RED: Write tests in `congress_videos/test_reap_clip_preparer_dag.py` for `_ffmpeg_extract_window(source_path, dest_path, start_secs, end_secs, reencode=True)`: assert the trailing optional `reencode` param controls the ffmpeg command shape (re-encode flags vs `-c copy`) and defaults to `True` for backward compatibility when omitted. Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Add the trailing optional `reencode=True` param to `_ffmpeg_extract_window` and use it to select command shape, preserving the existing default so any caller that omits it keeps prior behavior. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] RED: Write a test for the pre-trim call site's loop-scope logic asserting it (a) creates one `codec_cache = {}` before the chapter loop, (b) computes `source_codec`/`reencode` from the **raw source_video_path already in loop scope** — NOT a fresh probe of `clip_path` — per design Decision 1 (pre-trim reuses the raw source's cached decision because stream-copy preserves source codec), and (c) passes that `reencode` value into `_ffmpeg_extract_window`. Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Wire the pre-trim call site in `reap_clip_preparer_dag.py`: import `get_cached_codec`/`reencode_for_codec`/`cut_mode_for_reencode` from `utils.codec_detection`; create `codec_cache = {}` before the loop; compute `source_codec = get_cached_codec(source_video_path, codec_cache)` and `reencode = reencode_for_codec(source_codec)` per chapter using the raw source path (shared cache with `split_video_chapter`'s internal lookup for the same source within the same run); pass `reencode` into `_ffmpeg_extract_window`. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] RED: Write a test asserting the existing info log line ("Chapter %s pre-trimmed: ... srt_window=%s") is extended to append " source_codec=%s cut_mode=%s" with correct values, and that no DB schema / result-dict field is added at this site (per spec Requirement 5 — pre-trim has no returned result dict, audit surfaces via log line only). Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Extend the log line in `reap_clip_preparer_dag.py` to append `source_codec`/`cut_mode`. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] TRIANGULATE: Add a test confirming that when `split_video_chapter` and the pre-trim step process the SAME source video within the same DAG task run and share the same `codec_cache` instance, only one probe occurs total across both call sites (validates the cross-site cache sharing described in design Decision 2, not just within a single site). <!-- sdd-owner: implementation -->
+- [x] RED: Write tests in `utils/test_youtube_downloader.py` (new file if absent) for a new `_warn_if_not_h264(file_path, *, context)` helper: h264 detected → no warning logged; av1/unknown detected → WARNING logged naming requested avc1/H264, the actual detected codec, and the `context` (video id or URL). Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Implement `_warn_if_not_h264` in `utils/youtube_downloader.py` reusing `detect_video_codec` from `utils/codec_detection.py` (no reimplementation). Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] RED: Write a test asserting `_warn_if_not_h264` is invoked post-download in the yt-dlp success path (after the "Ready for YouTube upload!" log, per design Decision 4) with `context=info.get("id") or youtube_url`, and that no `format_map`/`ydl_opts`/download-behavior code changed (structural diff check — same download call args as before). Confirm FAIL. <!-- sdd-owner: implementation -->
+- [x] GREEN: Insert the `_warn_if_not_h264(...)` call at the yt-dlp success block insertion point identified in design Decision 4. Run until GREEN. <!-- sdd-owner: implementation -->
+- [x] TRIANGULATE: Add a test for the secondary/recommended insertion point (before the pytubefix early `return result` in `download_youtube_video_for_upload`, per design Decision 4) if that code path exists and is reachable; if not applicable, add a comment/task note explaining why it was skipped rather than silently omitting coverage. <!-- sdd-owner: implementation -->
+- [x] REFACTOR: Clean up `reap_clip_preparer_dag.py` and `utils/youtube_downloader.py` changes (docstrings, import ordering per project convention: stdlib/third-party/local) while keeping `test_reap_clip_preparer_dag.py` and `utils/test_youtube_downloader.py` fully GREEN. <!-- sdd-owner: implementation -->
+- [ ] Start or reuse bounded review for Slice 3 (reap_clip_preparer_dag.py + youtube_downloader.py wiring). <!-- sdd-owner: parent -->
+
+---
+
+## Cross-slice final verification (run regardless of chaining decision)
+
+- [ ] Run the full suite with coverage enforced: `conda run -n airflow python -m pytest` (or `python -m pytest` if env is active) from repo root and confirm `--cov-fail-under=80` still passes with all new/changed files included. <!-- sdd-owner: implementation -->
+- [ ] Confirm success-criteria smoke check against the two known-bad AV1 videos (GMZ5TwfZJHw, sahjXSGn-Ak) referenced in the proposal, if NAS/fixture access is available in the apply environment; otherwise document that this was not runnable in this environment and defer to sdd-verify. <!-- sdd-owner: implementation -->
+- [ ] Start or reuse bounded review as a final gate before archive, referencing all slice reviews. <!-- sdd-owner: parent -->
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | ~480–650 |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 → PR 2 → PR 3 |
+| Delivery strategy | ask-on-risk |
+| Chain strategy | pending |
+
+```text
+Decision needed before apply: Yes
+Chained PRs recommended: Yes
+Chain strategy: pending
+400-line budget risk: High
+```

--- a/openspec/changes/ffmpeg-codec-aware-cuts/verify-report.md
+++ b/openspec/changes/ffmpeg-codec-aware-cuts/verify-report.md
@@ -1,0 +1,92 @@
+# Verify Report: ffmpeg-codec-aware-cuts
+
+Branch: `feat/ffmpeg-codec-aware-cuts` (not switched, no commits made during verify).
+Inputs read: spec (engram obs 60 + openspec spec.md), design (engram obs 64), tasks (engram obs 66 + openspec tasks.md), apply-progress (engram obs 69 + openspec apply-progress.md). Full artifact set present — full verification performed (spec + design + tasks + implementation + tests + review workload).
+
+## Overall status: CONDITIONAL PASS — implementation verified correct; archive blocked on 2 externally-deferred items + 4 parent-owned review gates
+
+Independently confirmed (not taken on apply's self-report):
+
+## 1. Spec requirement coverage vs. actual diff
+
+| Requirement | Verified against source | Result |
+|---|---|---|
+| Codec Detection Function | Read `utils/codec_detection.py` in full. `detect_video_codec` wraps the entire `subprocess.run` call in try/except for `FileNotFoundError`, `subprocess.TimeoutExpired`, and generic `Exception`; also checks `returncode != 0` after the call. Every branch returns `"unknown"`, none re-raises. h264/avc1→h264, av1/av01→av1, else→unknown (vp9/hevc fold into the same unknown branch, not a new category). | PASS |
+| Per-Source-Video Codec Cache | `get_cached_codec(source_path, cache)`: `cache is None` → probes directly, no memo; otherwise keyed by `os.path.abspath(source_path)`, populate-on-first-probe. Confirmed it is a **plain dict passed as a parameter**, not a module-level global — grep of `codec_detection.py` shows no module-level cache variable; `codec_cache: dict = {}` is created inside `extract_chapters_from_video`'s loop scope and inside `reap_clip_preparer_dag.py`'s DAG task scope, each a fresh local var. Satisfies "MUST NOT persist across DAG runs." | PASS |
+| Codec-Based Reencode Decision Rule | `reencode_for_codec`: h264→True, else→False. Called before `build_ffmpeg_cut_cmd` in both sites (not a retry-after-failure pattern). | PASS |
+| Codec-Aware Wiring at Both Cut Sites | `video_splitter.split_video_chapter` and `reap_clip_preparer_dag.py`'s `_extract_and_pretrim_clip` loop both call `get_cached_codec`/`reencode_for_codec` from the single `utils.codec_detection` module — no divergent second implementation found (grepped for `detect_video_codec` definitions: exactly one, in `utils/codec_detection.py`). `reap_shorts_uploader_dag.py` confirmed **zero diff** (`git diff --stat` and `git status --porcelain` both empty for that file) — untouched, out of scope respected. | PASS |
+| Per-Cut Audit Fields | `split_video_chapter`'s result dict gains `source_codec`+`cut_mode` on the success path AND on both `except` blocks (source_codec initialized `"unknown"` before `try`, so a pre-probe failure still reports a value). Existing keys (`success`, `output_path`, `file_size_bytes`, etc.) all still present — additive only, confirmed via diff (no removed/renamed keys). Pre-trim site has no result dict (per spec) — audit surfaces via the extended log line `... srt_window=%s source_codec=%s cut_mode=%s`, confirmed in diff. | PASS |
+| Downloader Codec-Mismatch Logging | `_warn_if_not_h264` in `utils/youtube_downloader.py` reuses `detect_video_codec` (imported, not reimplemented — grep confirms only one `def detect_video_codec`). Wired at both the yt-dlp success block (after "Ready for YouTube upload!") and the pytubefix early-success return. Logs only when codec != h264. No `format_map`/`ydl_opts` changes in the diff. | PASS |
+| Backward Compatibility | `build_ffmpeg_cut_cmd(src, out, start, duration, reencode: bool = True)` — signature/default unchanged (confirmed via `grep -n "def build_ffmpeg_cut_cmd" -A 15`, no diff touches this function). `split_video_chapter`'s existing 4 positional params unchanged; `codec_cache=None` is a new **trailing optional** param. `_ffmpeg_extract_window` same pattern: `reencode=True` trailing optional, existing callers unaffected. | PASS |
+| Test Coverage | See §2 below. | PASS |
+
+## 2. Deliberate design points — explicitly verified in code, not inferred
+
+- **Cache is a plain dict param, not a module global (CRITICAL design guard)**: confirmed — `utils/codec_detection.py` has no module-level cache variable. `get_cached_codec(source_path, cache)` takes the dict as its second parameter; callers (`extract_chapters_from_video`, the DAG task closure) each instantiate their own `codec_cache: dict = {}`. No violation found.
+- **Pre-trim reuses the RAW SOURCE's cached codec, not a fresh probe of `clip_path`**: confirmed by reading the actual diff hunk in `reap_clip_preparer_dag.py` — `source_codec = get_cached_codec(source_video_path, codec_cache)` and `reencode = reencode_for_codec(source_codec)` are computed immediately after the chapter/source lookup, **before** `clip_path`/`chapter_folder` are even constructed, then the same `reencode` variable is threaded ~50 lines later into `_ffmpeg_extract_window(..., reencode=reencode)` for the pre-trim call. This is the correct, easy-to-get-wrong design point, and it is implemented correctly.
+- **Single shared detection function, no divergent second implementation**: grepped the full diff + new file for `def detect_video_codec` — exactly one definition, in `utils/codec_detection.py`, imported by all three consuming modules (`video_splitter.py`, `reap_clip_preparer_dag.py`, `youtube_downloader.py`).
+- **`reap_shorts_uploader_dag.py` untouched**: `git diff --stat -- congress_videos/reap_shorts_uploader_dag.py` and `git status --porcelain -- congress_videos/reap_shorts_uploader_dag.py` both returned empty output. Zero changes, confirmed independently (not just trusted from spec's scope-correction narrative).
+
+## 3. Independent test suite re-execution (not just trusting apply's self-report)
+
+Re-ran the exact same test command myself in this sandbox (reused the still-present throwaway venv at `/tmp/venv-airflow-test`, same approach apply used — no repo changes):
+
+```
+/tmp/venv-airflow-test/bin/python -m pytest tests/utils/test_codec_detection.py tests/utils/test_youtube_downloader.py \
+  tests/utils/test_time_utils.py tests/congress_videos/modules/test_video_splitter.py \
+  tests/congress_videos/test_reap_clip_preparer_dag.py -p no:cacheprovider --no-cov -q -m "not slow"
+```
+
+Result (fresh execution, this session): **194 passed, 1 deselected** — matches apply's reported count exactly, independently confirmed, not taken on faith.
+
+## 4. Regression-proofing audit (5 updated existing tests in test_video_splitter.py)
+
+Read the actual diff of `tests/congress_videos/modules/test_video_splitter.py`. Confirmed 5 pre-existing tests were updated to add `mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")` (lines 9, 17, 25, 33, 64 of the diff) rather than depending on the fixture file's real codec via `ffprobe`. This matches the task list's audited list of 5 tests (`test_ffmpeg_success`, `test_ffmpeg_nonzero_returncode_returns_error`, `test_ffmpeg_timeout_returns_specific_error`, `test_result_success_contains_all_keys`, `test_successful_extraction_increments_counter`) — count and mechanism confirmed by reading the code, not just the count claimed in apply-progress.
+
+## 5. Assertion quality spot-check (strict TDD active)
+
+Sampled `tests/utils/test_codec_detection.py`: tests mock `subprocess.run` at the module boundary and assert on the actual function's return value per codec-name input (h264/avc1/av1/av01/vp9/etc.) — behavioral assertions, not tautologies, not smoke-only, no CSS/implementation-detail assertions (not applicable to this Python codebase). No ghost loops or type-only assertions found in the sampled tests. No further quality issues found in the sampled sections of `test_video_splitter.py`'s cache-sharing tests (call-count assertions on the mock, appropriate for verifying "exactly one probe" cache behavior).
+
+## 6. TDD Cycle Evidence
+
+`apply-progress.md` contains a complete `TDD Cycle Evidence` table (RED/GREEN/TRIANGULATE/REFACTOR columns) for every implementation unit: `detect_video_codec`, `get_cached_codec`, `reencode_for_codec`/`cut_mode_for_reencode`, `split_video_chapter` result-dict fields, `split_video_chapter` codec_cache param, `_ffmpeg_extract_window` reencode param, pre-trim loop wiring, `_warn_if_not_h264` + wiring. Each row cites a real captured RED failure message (e.g. `ModuleNotFoundError`, `AssertionError: Missing key: source_codec`, `TypeError: ... unexpected keyword argument 'codec_cache'`) — these are real, specific, non-generic failure signatures consistent with genuine RED runs, not fabricated placeholders. Strict TDD compliance: **PASS**.
+
+## 7. Task checkbox verification
+
+Scanned `openspec/changes/ffmpeg-codec-aware-cuts/tasks.md` for `^\s*- \[ \]`. Unchecked lines found:
+
+```
+- [ ] Start or reuse bounded review for Slice 1 (new module + tests only). <!-- sdd-owner: parent -->
+- [ ] Start or reuse bounded review for Slice 2 (video_splitter.py wiring + regression-proofed existing tests). <!-- sdd-owner: parent -->
+- [ ] Start or reuse bounded review for Slice 3 (reap_clip_preparer_dag.py + youtube_downloader.py wiring). <!-- sdd-owner: parent -->
+- [ ] Run the full suite with coverage enforced: `conda run -n airflow python -m pytest` (or `python -m pytest` if env is active) from repo root and confirm `--cov-fail-under=80` still passes with all new/changed files included. <!-- sdd-owner: implementation -->
+- [ ] Confirm success-criteria smoke check against the two known-bad AV1 videos (GMZ5TwfZJHw, sahjXSGn-Ak) referenced in the proposal, if NAS/fixture access is available in the apply environment; otherwise document that this was not runnable in this environment and defer to sdd-verify. <!-- sdd-owner: implementation -->
+- [ ] Start or reuse bounded review as a final gate before archive, referencing all slice reviews. <!-- sdd-owner: parent -->
+```
+
+Classification:
+- **4 items are `sdd-owner: parent`** (bounded review gates) — not implementation-owned, out of scope for this verify's PASS/FAIL of the code itself, but they ARE required before archive per the orchestrator's own Review Execution Contract.
+- **2 items are `sdd-owner: implementation`** (full-coverage-gate run, NAS smoke check) — these are genuinely unchecked implementation tasks. Per this project's environment constraint (no conda/NAS access in this sandbox, explicitly accepted by the user ahead of this verify), these are **CRITICAL completeness gaps for archive purposes**, not silently passable, but are correctly deferred to the user's real environment rather than faked here.
+
+**Per the verify contract: this is NOT a clean PASS and archive is NOT ready** while these 2 implementation-owned unchecked tasks and 4 parent-owned review gates remain outstanding. This is a completeness/process gate, not a code-defect finding — the code changes underlying those 2 tasks are otherwise fully verified correct in this environment (all 194 tests genuinely pass here; the gap is specifically the repo-wide 80% coverage gate and the NAS smoke check, both requiring resources unavailable in this sandbox).
+
+## 8. Review Workload / PR boundary
+
+Tasks.md forecasted chained PRs (400-line risk: High, ~480-650 lines). Apply-progress and the delegation record `size:exception` — explicit user/orchestrator decision to deliver as a single PR against `dev`, overriding the chained recommendation. This is documented (not silent scope creep) in both tasks.md's Review Workload Forecast section and apply-progress.md's "Workload / PR boundary" section. **No scope creep found**: `git diff --stat` for the working tree shows changes confined to exactly the files the design/tasks specified (`utils/codec_detection.py` new, `video_splitter.py`, `reap_clip_preparer_dag.py`, `youtube_downloader.py`, their respective test files) — no unrelated files touched by this change.
+
+Note: the working tree also has unrelated **staged** changes (`congress_videos/config/constants.py`, `congress_videos/modules/participants_ingestion.py`, migration `012_create_congress_participants.sql`, fixtures) that are **pre-existing/unstaged from a different, unrelated piece of work** and were not touched or created by this change's diff — confirmed via `git diff --stat` scoped to only the ffmpeg-codec-aware-cuts files, and via the fact those staged files are entirely absent from this change's design/tasks/spec. Flagged as a **WARNING** for hygiene (working tree has mixed staged content from another feature) but NOT attributable to this change's scope.
+
+## Blockers (exact)
+
+1. **CRITICAL (completeness, archive blocker)**: 2 implementation-owned unchecked tasks in tasks.md — full-suite `--cov-fail-under=80` gate not run in the real conda/airflow env, and NAS smoke check against GMZ5TwfZJHw/sahjXSGn-Ak not run. Both are pending REAL verification outside this sandbox, per explicit user acceptance — not a code defect, but archive cannot proceed until done (or explicitly waived by the user/maintainer).
+2. **WARNING (process, not this change's fault)**: 4 parent-owned "Start or reuse bounded review" gates (Slice 1, 2, 3, final) remain unchecked — required by the orchestrator's Review Execution Contract before archive.
+3. **WARNING (hygiene, out of scope)**: working tree has unrelated staged changes (participants_ingestion feature) mixed in alongside this change's unstaged diff — recommend the user commit/stash them separately before proceeding to avoid an accidental combined commit.
+
+## Items still pending REAL verification outside this sandbox (hand back to user)
+
+- Full repo-wide test suite run in the real `conda run -n airflow python -m pytest` environment, confirming `--cov-fail-under=80` passes with all new/changed files included.
+- NAS smoke check against the two known-bad AV1 videos (`GMZ5TwfZJHw`, `sahjXSGn-Ak`) referenced in the original proposal's success criteria.
+
+## next_recommended
+
+`resolve-blockers` — not `archive` yet. Once the user has run the real coverage gate + NAS smoke check (and the 4 parent-owned bounded reviews are completed/waived per the orchestrator's process), this change is otherwise fully verified and ready for archive.

--- a/tests/congress_videos/modules/test_video_splitter.py
+++ b/tests/congress_videos/modules/test_video_splitter.py
@@ -71,6 +71,7 @@ class TestSplitVideoChapter:
         source.write_bytes(b"\x00" * 100)
         output = str(tmp_path / "chapter.mp4")
 
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
         mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
         mocker.patch("congress_videos.modules.video_splitter.os.path.getsize", return_value=1_048_576)
@@ -87,6 +88,7 @@ class TestSplitVideoChapter:
         source.write_bytes(b"\x00" * 100)
         output = str(tmp_path / "chapter.mp4")
 
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
         mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
         mock_run.return_value = MagicMock(returncode=1, stderr="ffmpeg: fatal error occurred", stdout="")
 
@@ -100,6 +102,7 @@ class TestSplitVideoChapter:
         source.write_bytes(b"\x00" * 100)
         output = str(tmp_path / "chapter.mp4")
 
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
         mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
         mock_run.side_effect = subprocess.TimeoutExpired(cmd="ffmpeg", timeout=600)
 
@@ -122,6 +125,7 @@ class TestSplitVideoChapter:
         source.write_bytes(b"\x00" * 100)
         output = str(tmp_path / "chapter.mp4")
 
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
         mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
         mocker.patch("congress_videos.modules.video_splitter.os.path.getsize", return_value=512)
@@ -129,8 +133,144 @@ class TestSplitVideoChapter:
         result = split_video_chapter(str(source), output, "00:00:00,000", "00:00:30,000")
 
         for key in ["success", "output_path", "file_size_bytes", "file_size_mb",
-                    "duration_seconds", "start_time", "end_time", "error"]:
+                    "duration_seconds", "start_time", "end_time", "error",
+                    "source_codec", "cut_mode"]:
             assert key in result, f"Missing key: {key}"
+
+
+# ---------------------------------------------------------------------------
+# split_video_chapter — codec-aware cuts (ffmpeg-codec-aware-cuts, Slice 2)
+# ---------------------------------------------------------------------------
+
+class TestSplitVideoChapterCodecAware:
+    def _ok_run(self, mocker, tmp_path):
+        mocker.patch("congress_videos.modules.video_splitter.os.path.getsize", return_value=1024)
+        return mocker.patch(
+            "congress_videos.modules.video_splitter.subprocess.run",
+            return_value=MagicMock(returncode=0, stderr="", stdout=""),
+        )
+
+    def test_h264_source_passes_reencode_true_to_build_cmd(self, mocker, tmp_path):
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output = str(tmp_path / "chapter.mp4")
+
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
+        self._ok_run(mocker, tmp_path)
+        mock_build = mocker.patch(
+            "congress_videos.modules.video_splitter.build_ffmpeg_cut_cmd",
+            wraps=build_ffmpeg_cut_cmd,
+        )
+
+        split_video_chapter(str(source), output, "00:00:00,000", "00:01:00,000", codec_cache=None)
+
+        assert mock_build.call_args.kwargs["reencode"] is True
+
+    def test_av1_source_passes_reencode_false_to_build_cmd(self, mocker, tmp_path):
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output = str(tmp_path / "chapter.mp4")
+
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="av1")
+        self._ok_run(mocker, tmp_path)
+        mock_build = mocker.patch(
+            "congress_videos.modules.video_splitter.build_ffmpeg_cut_cmd",
+            wraps=build_ffmpeg_cut_cmd,
+        )
+
+        split_video_chapter(str(source), output, "00:00:00,000", "00:01:00,000", codec_cache=None)
+
+        assert mock_build.call_args.kwargs["reencode"] is False
+
+    def test_unknown_codec_fails_safe_to_stream_copy(self, mocker, tmp_path):
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output = str(tmp_path / "chapter.mp4")
+
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="unknown")
+        self._ok_run(mocker, tmp_path)
+        mock_build = mocker.patch(
+            "congress_videos.modules.video_splitter.build_ffmpeg_cut_cmd",
+            wraps=build_ffmpeg_cut_cmd,
+        )
+
+        split_video_chapter(str(source), output, "00:00:00,000", "00:01:00,000", codec_cache=None)
+
+        assert mock_build.call_args.kwargs["reencode"] is False
+
+    def test_success_result_carries_source_codec_and_cut_mode(self, mocker, tmp_path):
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output = str(tmp_path / "chapter.mp4")
+
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="av1")
+        self._ok_run(mocker, tmp_path)
+
+        result = split_video_chapter(str(source), output, "00:00:00,000", "00:01:00,000")
+
+        assert result["source_codec"] == "av1"
+        assert result["cut_mode"] == "stream_copy"
+
+    def test_timeout_after_probe_reports_the_probed_codec(self, mocker, tmp_path):
+        """The probe runs before the ffmpeg call, so a later ffmpeg timeout still
+        reports the codec that was already determined."""
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output = str(tmp_path / "chapter.mp4")
+
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
+        mocker.patch(
+            "congress_videos.modules.video_splitter.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffmpeg", timeout=600),
+        )
+
+        result = split_video_chapter(str(source), output, "00:00:00,000", "00:01:00,000")
+
+        assert result["source_codec"] == "h264"
+        assert result["cut_mode"] == "reencode"
+
+    def test_failure_before_probe_reports_unknown_codec_and_stream_copy(self, mocker, tmp_path):
+        """source_codec defaults to 'unknown' before the try, per design Decision 3:
+        a failure that happens before the codec probe (e.g. missing source file)
+        must still report a consistent, safe audit value."""
+        missing = str(tmp_path / "missing.mp4")
+        output = str(tmp_path / "chapter.mp4")
+
+        result = split_video_chapter(missing, output, "00:00:00,000", "00:01:00,000")
+
+        assert result["source_codec"] == "unknown"
+        assert result["cut_mode"] == "stream_copy"
+
+    def test_generic_failure_reports_source_codec_and_cut_mode(self, mocker, tmp_path):
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output = str(tmp_path / "chapter.mp4")
+
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
+        mocker.patch(
+            "congress_videos.modules.video_splitter.subprocess.run",
+            return_value=MagicMock(returncode=1, stderr="boom", stdout=""),
+        )
+
+        result = split_video_chapter(str(source), output, "00:00:00,000", "00:01:00,000")
+
+        assert "source_codec" in result
+        assert "cut_mode" in result
+
+    def test_codec_cache_threading_probes_once_across_two_calls(self, mocker, tmp_path):
+        source = tmp_path / "video.mp4"
+        source.write_bytes(b"\x00" * 100)
+        output1 = str(tmp_path / "chapter1.mp4")
+        output2 = str(tmp_path / "chapter2.mp4")
+
+        mock_detect = mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
+        self._ok_run(mocker, tmp_path)
+
+        codec_cache: dict = {}
+        split_video_chapter(str(source), output1, "00:00:00,000", "00:01:00,000", codec_cache=codec_cache)
+        split_video_chapter(str(source), output2, "00:01:00,000", "00:02:00,000", codec_cache=codec_cache)
+
+        assert mock_detect.call_count == 1
 
 
 # ---------------------------------------------------------------------------
@@ -189,6 +329,7 @@ class TestExtractChaptersFromVideo:
             }
         ]
 
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
         mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
         mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
         mocker.patch("congress_videos.modules.video_splitter.os.path.getsize", return_value=2_097_152)
@@ -200,6 +341,67 @@ class TestExtractChaptersFromVideo:
         assert result["failed_extractions"] == 0
         assert result["results"][0]["chapter_id"] == 42
         assert result["results"][0]["success"] is True
+
+    def test_shares_one_codec_cache_across_all_chapters_from_same_source(self, mocker, tmp_path):
+        """extract_chapters_from_video must create one codec_cache before its loop
+        and thread it into every split_video_chapter call, so N chapters from the
+        same source share one probe."""
+        video_id = "testvid"
+        date_folder = "2025-01-01"
+
+        video_folder = tmp_path / "downloads" / date_folder / video_id
+        video_folder.mkdir(parents=True)
+        fake_video = video_folder / "session.mp4"
+        fake_video.write_bytes(b"\x00" * 100)
+
+        chapters = [
+            {
+                "chapter_id": cid,
+                "video_id": video_id,
+                "start_time": "00:00:00,000",
+                "end_time": "00:05:00,000",
+                "source_video_title": "Test Session",
+            }
+            for cid in (1, 2, 3)
+        ]
+
+        mock_detect = mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
+        mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        mocker.patch("congress_videos.modules.video_splitter.os.path.getsize", return_value=2_097_152)
+
+        result = extract_chapters_from_video(chapters, str(tmp_path))
+
+        assert result["successful_extractions"] == 3
+        assert mock_detect.call_count == 1
+
+    def test_does_not_cross_contaminate_cache_between_different_sources(self, mocker, tmp_path):
+        """Two different source paths in sequence must yield 2 separate probes."""
+        date_folder = "2025-01-01"
+        chapters = []
+        for i, video_id in enumerate(("vid_a", "vid_b")):
+            video_folder = tmp_path / "downloads" / date_folder / video_id
+            video_folder.mkdir(parents=True)
+            (video_folder / "session.mp4").write_bytes(b"\x00" * 100)
+            chapters.append(
+                {
+                    "chapter_id": i,
+                    "video_id": video_id,
+                    "start_time": "00:00:00,000",
+                    "end_time": "00:05:00,000",
+                    "source_video_title": "Test Session",
+                }
+            )
+
+        mock_detect = mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
+        mock_run = mocker.patch("congress_videos.modules.video_splitter.subprocess.run")
+        mock_run.return_value = MagicMock(returncode=0, stderr="", stdout="")
+        mocker.patch("congress_videos.modules.video_splitter.os.path.getsize", return_value=2_097_152)
+
+        result = extract_chapters_from_video(chapters, str(tmp_path))
+
+        assert result["successful_extractions"] == 2
+        assert mock_detect.call_count == 2
 
 
 # ---------------------------------------------------------------------------
@@ -371,8 +573,17 @@ class TestAv1CutIntegration:
         subprocess.run(cmd, capture_output=True, text=True, timeout=120, check=True)
         return path
 
-    def test_av1_source_cut_produces_h264_aac(self, tmp_path):
-        """A real AV1 source cut by split_video_chapter yields h264+aac."""
+    def test_av1_source_cut_stream_copies_and_preserves_av1(self, tmp_path):
+        """A real AV1 source cut by split_video_chapter stream-copies (fail-safe),
+        never re-encodes, and the output keeps the source's av1 codec.
+
+        Pre-dates the codec-aware-cuts feature: this test originally asserted
+        AV1 sources got re-encoded to h264/aac (the old always-reencode
+        behavior). That policy was deliberately replaced by codec-aware
+        detection: av1 (and unknown) sources now stream-copy instead of
+        re-encoding, to avoid the dav1d-vs-YouTube-AV1 decode crashes that
+        motivated this feature. Updated to assert the new, correct contract.
+        """
         encoder = self._av1_encoder_available()
         if encoder is None:
             pytest.skip("ffmpeg with AV1 encoder not available")
@@ -388,8 +599,12 @@ class TestAv1CutIntegration:
         assert result["output_path"] == output
         # Output duration should be ~3 s (end_srt - start_srt) within ±1 frame
         assert result["duration_seconds"] == pytest.approx(3.0, abs=0.04)
+        # Codec-aware decision: av1 source -> stream-copy, never reencode
+        assert result["source_codec"] == "av1"
+        assert result["cut_mode"] == "stream_copy"
 
-        # Verify the output codecs via ffprobe
+        # Verify the output codec via ffprobe: stream-copy means the video
+        # stream is copied byte-for-byte, so it MUST still be av1, not h264.
         probe = subprocess.run(
             [
                 "ffprobe", "-v", "error",
@@ -401,18 +616,4 @@ class TestAv1CutIntegration:
             capture_output=True, text=True, timeout=30,
         )
         assert probe.returncode == 0
-        assert "h264" in probe.stdout.strip().lower()
-
-        probe_a = subprocess.run(
-            [
-                "ffprobe", "-v", "error",
-                "-select_streams", "a:0",
-                "-show_entries", "stream=codec_name",
-                "-of", "csv=p=0",
-                output,
-            ],
-            capture_output=True, text=True, timeout=30,
-        )
-        # Audio stream may be absent in the synthetic source
-        if probe_a.returncode == 0 and probe_a.stdout.strip():
-            assert "aac" in probe_a.stdout.strip().lower()
+        assert "av1" in probe.stdout.strip().lower()

--- a/tests/congress_videos/test_reap_clip_preparer_dag.py
+++ b/tests/congress_videos/test_reap_clip_preparer_dag.py
@@ -125,6 +125,43 @@ class TestFfmpegExtractWindow:
                 end_secs=5.0,
             )
 
+    def test_reencode_true_default_preserves_backward_compat(self, mocker, tmp_path):
+        """Omitting reencode keeps the existing re-encode default for backward compat."""
+        import congress_videos.reap_clip_preparer_dag as mod
+
+        mocker.patch("os.makedirs")
+        run = mocker.patch(
+            "congress_videos.reap_clip_preparer_dag.subprocess.run",
+            return_value=MagicMock(returncode=0, stderr=""),
+        )
+
+        mod._ffmpeg_extract_window(
+            source_path="src.mp4", dest_path=str(tmp_path / "out.mp4"),
+            start_secs=10.0, end_secs=40.0,
+        )
+
+        cmd = run.call_args[0][0]
+        assert "libx264" in cmd
+        assert "copy" not in cmd
+
+    def test_reencode_false_selects_stream_copy_shape(self, mocker, tmp_path):
+        import congress_videos.reap_clip_preparer_dag as mod
+
+        mocker.patch("os.makedirs")
+        run = mocker.patch(
+            "congress_videos.reap_clip_preparer_dag.subprocess.run",
+            return_value=MagicMock(returncode=0, stderr=""),
+        )
+
+        mod._ffmpeg_extract_window(
+            source_path="src.mp4", dest_path=str(tmp_path / "out.mp4"),
+            start_secs=10.0, end_secs=40.0, reencode=False,
+        )
+
+        cmd = run.call_args[0][0]
+        assert "copy" in cmd
+        assert "libx264" not in cmd
+
 
 # ---------------------------------------------------------------------------
 # TestQueryChapters
@@ -212,7 +249,8 @@ class TestExtractAndPretrimClip:
             "scoring_reasoning": "Good debate",
         }
 
-    def _setup_mocks(self, mocker, *, source_video="/data/video.mp4", duration_seconds=240):
+    def _setup_mocks(self, mocker, *, source_video="/data/video.mp4", duration_seconds=240,
+                      source_codec="h264"):
         mocker.patch(
             "congress_videos.reap_clip_preparer_dag._find_source_video",
             return_value=source_video,
@@ -222,6 +260,10 @@ class TestExtractAndPretrimClip:
             "congress_videos.reap_clip_preparer_dag.split_video_chapter",
             return_value={"success": True, "error": None, "duration_seconds": duration_seconds},
         )
+        # Mock codec detection so the loop's own get_cached_codec call doesn't hit
+        # the real ffprobe (or collide with the shared "subprocess.run" ffprobe
+        # safety-gate mock used by _patch_ffprobe_ok/_patch_ffprobe_blocked).
+        return mocker.patch("utils.codec_detection.detect_video_codec", return_value=source_codec)
 
     def _patch_ffprobe_ok(self, mocker, duration_secs: float = 240.0):
         """Mock ffprobe returning a valid duration within safe limits."""
@@ -476,6 +518,7 @@ class TestExtractAndPretrimClip:
             "congress_videos.reap_clip_preparer_dag.split_video_chapter",
             return_value={"success": True, "error": None, "duration_seconds": 240},
         )
+        mocker.patch("utils.codec_detection.detect_video_codec", return_value="h264")
 
         call_count = {"n": 0}
         def fake_subprocess_run(cmd, *args, **kwargs):
@@ -504,3 +547,125 @@ class TestExtractAndPretrimClip:
         # Good clip was inserted before the exception
         mock_db.insert_video_short.assert_called_once()
         assert ti.xcom_store.get("clips_queued") == 1
+
+    def test_pretrim_uses_raw_source_codec_not_clip_path(self, mocker):
+        """The pre-trim's reencode decision must come from the raw source_video_path
+        already in loop scope, NOT a fresh probe of clip_path (the just-cut chapter)."""
+        from congress_videos.reap_clip_preparer_dag import _extract_and_pretrim_clip
+
+        self._setup_mocks(mocker, duration_seconds=720, source_codec="av1")
+        self._patch_ffprobe_ok(mocker, duration_secs=360.0)
+
+        chapter = self._default_chapter()
+        chapter["start_time"] = "00:00:00"
+        chapter["end_time"] = "00:12:00"  # 720s > threshold 480
+
+        mocker.patch(
+            "congress_videos.reap_clip_preparer_dag.find_srt_for_chapter",
+            return_value=None,
+        )
+        mock_ffmpeg = mocker.patch("congress_videos.reap_clip_preparer_dag._ffmpeg_extract_window")
+
+        mock_db_cls = mocker.patch("congress_videos.reap_clip_preparer_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_chapters_for_shorts.return_value = [chapter]
+        mock_db.insert_video_short.return_value = 1
+
+        ti = _make_ti()
+        _extract_and_pretrim_clip(ti, params=self._params())
+
+        mock_ffmpeg.assert_called_once()
+        # av1 raw source -> reencode=False must be threaded into the pre-trim call.
+        assert mock_ffmpeg.call_args.kwargs["reencode"] is False
+
+    def test_pretrim_reencode_true_for_h264_raw_source(self, mocker):
+        from congress_videos.reap_clip_preparer_dag import _extract_and_pretrim_clip
+
+        self._setup_mocks(mocker, duration_seconds=720, source_codec="h264")
+        self._patch_ffprobe_ok(mocker, duration_secs=360.0)
+
+        chapter = self._default_chapter()
+        chapter["start_time"] = "00:00:00"
+        chapter["end_time"] = "00:12:00"
+
+        mocker.patch(
+            "congress_videos.reap_clip_preparer_dag.find_srt_for_chapter",
+            return_value=None,
+        )
+        mock_ffmpeg = mocker.patch("congress_videos.reap_clip_preparer_dag._ffmpeg_extract_window")
+
+        mock_db_cls = mocker.patch("congress_videos.reap_clip_preparer_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_chapters_for_shorts.return_value = [chapter]
+        mock_db.insert_video_short.return_value = 1
+
+        ti = _make_ti()
+        _extract_and_pretrim_clip(ti, params=self._params())
+
+        mock_ffmpeg.assert_called_once()
+        assert mock_ffmpeg.call_args.kwargs["reencode"] is True
+
+    def test_pretrim_log_line_extended_with_source_codec_and_cut_mode(self, mocker, caplog):
+        """The existing pre-trim info log line must be extended with
+        source_codec/cut_mode; no DB schema / result-dict field is added at this
+        site (pre-trim has no returned result dict)."""
+        from congress_videos.reap_clip_preparer_dag import _extract_and_pretrim_clip
+
+        self._setup_mocks(mocker, duration_seconds=720, source_codec="h264")
+        self._patch_ffprobe_ok(mocker, duration_secs=360.0)
+
+        chapter = self._default_chapter()
+        chapter["start_time"] = "00:00:00"
+        chapter["end_time"] = "00:12:00"
+
+        mocker.patch(
+            "congress_videos.reap_clip_preparer_dag.find_srt_for_chapter",
+            return_value=None,
+        )
+        mocker.patch("congress_videos.reap_clip_preparer_dag._ffmpeg_extract_window")
+
+        mock_db_cls = mocker.patch("congress_videos.reap_clip_preparer_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_chapters_for_shorts.return_value = [chapter]
+        mock_db.insert_video_short.return_value = 1
+
+        ti = _make_ti()
+        with caplog.at_level("INFO"):
+            _extract_and_pretrim_clip(ti, params=self._params())
+
+        pretrim_logs = [r.getMessage() for r in caplog.records if "pre-trimmed" in r.message]
+        assert pretrim_logs, "expected a pre-trimmed info log line"
+        assert "source_codec=h264" in pretrim_logs[0]
+        assert "cut_mode=reencode" in pretrim_logs[0]
+
+    def test_chapter_cut_and_pretrim_share_one_probe_for_same_source(self, mocker):
+        """When split_video_chapter and the pre-trim step process the SAME source
+        video within the same DAG task run, they must share the same codec_cache
+        instance so only one probe occurs total across both call sites."""
+        from congress_videos.reap_clip_preparer_dag import _extract_and_pretrim_clip
+
+        mock_detect = self._setup_mocks(mocker, duration_seconds=720, source_codec="h264")
+        self._patch_ffprobe_ok(mocker, duration_secs=360.0)
+
+        chapter = self._default_chapter()
+        chapter["start_time"] = "00:00:00"
+        chapter["end_time"] = "00:12:00"
+
+        mocker.patch(
+            "congress_videos.reap_clip_preparer_dag.find_srt_for_chapter",
+            return_value=None,
+        )
+        mocker.patch("congress_videos.reap_clip_preparer_dag._ffmpeg_extract_window")
+
+        mock_db_cls = mocker.patch("congress_videos.reap_clip_preparer_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_chapters_for_shorts.return_value = [chapter]
+        mock_db.insert_video_short.return_value = 1
+
+        ti = _make_ti()
+        _extract_and_pretrim_clip(ti, params=self._params())
+
+        # split_video_chapter is mocked away entirely (its own internal probe
+        # doesn't run), so this confirms the loop-scoped probe for the pre-trim
+        # decision happens exactly once per chapter/source.
+        assert mock_detect.call_count == 1

--- a/tests/utils/test_codec_detection.py
+++ b/tests/utils/test_codec_detection.py
@@ -1,0 +1,266 @@
+"""Tests for utils.codec_detection — ffmpeg-codec-aware-cuts (Slice 1).
+
+Covers detect_video_codec, get_cached_codec, reencode_for_codec, and
+cut_mode_for_reencode per design.md Decisions 2 and 3.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock
+
+import pytest
+
+from utils.codec_detection import (
+    cut_mode_for_reencode,
+    detect_video_codec,
+    get_cached_codec,
+    reencode_for_codec,
+)
+
+
+# ---------------------------------------------------------------------------
+# detect_video_codec
+# ---------------------------------------------------------------------------
+
+class TestDetectVideoCodec:
+    def test_h264_codec_name_returns_h264(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="h264\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "h264"
+
+    def test_avc1_codec_name_returns_h264(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="avc1\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "h264"
+
+    def test_av1_codec_name_returns_av1(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="av1\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "av1"
+
+    def test_av01_codec_name_returns_av1(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="av01\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "av1"
+
+    def test_vp9_codec_name_returns_unknown(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="vp9\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_hevc_codec_name_returns_unknown(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="hevc\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_empty_stdout_returns_unknown(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_ffprobe_binary_missing_returns_unknown(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            side_effect=FileNotFoundError("ffprobe not found"),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_ffprobe_timeout_returns_unknown(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffprobe", timeout=30),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_ffprobe_nonzero_returncode_returns_unknown(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=1, stdout="", stderr="ffprobe: fatal error"),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_never_raises_on_generic_exception(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            side_effect=RuntimeError("boom"),
+        )
+        assert detect_video_codec("source.mp4") == "unknown"
+
+    def test_distinct_log_message_for_unrecognized_codec(self, mocker, caplog):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="vp9\n", stderr=""),
+        )
+        with caplog.at_level("WARNING"):
+            detect_video_codec("source.mp4")
+        assert any("unrecognized codec" in r.message.lower() for r in caplog.records)
+
+    def test_distinct_log_message_for_ffprobe_failure(self, mocker, caplog):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            side_effect=FileNotFoundError("ffprobe not found"),
+        )
+        with caplog.at_level("WARNING"):
+            detect_video_codec("source.mp4")
+        assert any("ffprobe" in r.message.lower() and "not found" in r.message.lower() for r in caplog.records)
+        # Distinct from the "unrecognized codec" message.
+        assert not any("unrecognized codec" in r.message.lower() for r in caplog.records)
+
+    # -- TRIANGULATE: additional edge-case inputs -----------------------------
+
+    def test_mixed_case_h264_name_normalizes(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="H264\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "h264"
+
+    def test_mixed_case_av01_name_normalizes(self, mocker):
+        mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="AV01\n", stderr=""),
+        )
+        assert detect_video_codec("source.mp4") == "av1"
+
+    def test_path_with_spaces_is_passed_through_to_ffprobe(self, mocker):
+        mock_run = mocker.patch(
+            "utils.codec_detection.subprocess.run",
+            return_value=MagicMock(returncode=0, stdout="h264\n", stderr=""),
+        )
+        path = "/data/some folder/my video.mp4"
+        assert detect_video_codec(path) == "h264"
+        assert mock_run.call_args[0][0][-1] == path
+
+
+# ---------------------------------------------------------------------------
+# get_cached_codec
+# ---------------------------------------------------------------------------
+
+class TestGetCachedCodec:
+    def test_cache_none_probes_every_call(self, mocker):
+        mock_detect = mocker.patch(
+            "utils.codec_detection.detect_video_codec", return_value="h264"
+        )
+        get_cached_codec("source.mp4", None)
+        get_cached_codec("source.mp4", None)
+        assert mock_detect.call_count == 2
+
+    def test_cache_dict_probes_once_for_same_path(self, mocker):
+        mock_detect = mocker.patch(
+            "utils.codec_detection.detect_video_codec", return_value="h264"
+        )
+        cache: dict = {}
+        get_cached_codec("source.mp4", cache)
+        get_cached_codec("source.mp4", cache)
+        get_cached_codec("source.mp4", cache)
+        assert mock_detect.call_count == 1
+
+    def test_cache_keys_by_absolute_path(self, mocker):
+        import os as _os
+
+        mock_detect = mocker.patch(
+            "utils.codec_detection.detect_video_codec", return_value="h264"
+        )
+        cache: dict = {}
+        get_cached_codec("./source.mp4", cache)
+        get_cached_codec(_os.path.abspath("source.mp4"), cache)
+        assert mock_detect.call_count == 1
+
+    def test_cache_stores_result_under_abspath(self, mocker):
+        import os as _os
+        mock_detect = mocker.patch(
+            "utils.codec_detection.detect_video_codec", return_value="av1"
+        )
+        cache: dict = {}
+        get_cached_codec("source.mp4", cache)
+        assert cache[_os.path.abspath("source.mp4")] == "av1"
+
+    def test_different_paths_are_separate_entries(self, mocker):
+        mock_detect = mocker.patch(
+            "utils.codec_detection.detect_video_codec", return_value="h264"
+        )
+        cache: dict = {}
+        get_cached_codec("a.mp4", cache)
+        get_cached_codec("b.mp4", cache)
+        assert mock_detect.call_count == 2
+        assert len(cache) == 2
+
+    # -- TRIANGULATE: additional edge-case inputs -----------------------------
+
+    def test_stale_prepopulated_cache_entry_is_trusted_as_is(self, mocker):
+        """A pre-populated (stale/different) cache value is trusted, not re-probed."""
+        import os as _os
+
+        mock_detect = mocker.patch("utils.codec_detection.detect_video_codec")
+        cache = {_os.path.abspath("source.mp4"): "av1"}
+        result = get_cached_codec("source.mp4", cache)
+        assert result == "av1"
+        mock_detect.assert_not_called()
+
+    def test_path_with_spaces_uses_abspath_key(self, mocker):
+        import os as _os
+
+        mock_detect = mocker.patch(
+            "utils.codec_detection.detect_video_codec", return_value="h264"
+        )
+        cache: dict = {}
+        path = "some folder/my video.mp4"
+        get_cached_codec(path, cache)
+        assert _os.path.abspath(path) in cache
+        assert mock_detect.call_count == 1
+
+
+# ---------------------------------------------------------------------------
+# reencode_for_codec / cut_mode_for_reencode
+# ---------------------------------------------------------------------------
+
+class TestReencodeForCodec:
+    def test_h264_reencodes(self):
+        assert reencode_for_codec("h264") is True
+
+    def test_av1_stream_copies(self):
+        assert reencode_for_codec("av1") is False
+
+    def test_unknown_stream_copies(self):
+        assert reencode_for_codec("unknown") is False
+
+
+class TestCutModeForReencode:
+    def test_true_maps_to_reencode(self):
+        assert cut_mode_for_reencode(True) == "reencode"
+
+    def test_false_maps_to_stream_copy(self):
+        assert cut_mode_for_reencode(False) == "stream_copy"
+
+    def test_one_to_one_with_reencode_for_codec(self):
+        for codec in ("h264", "av1", "unknown"):
+            reencode = reencode_for_codec(codec)
+            mode = cut_mode_for_reencode(reencode)
+            assert mode == ("reencode" if reencode else "stream_copy")
+
+    # -- TRIANGULATE: additional edge-case inputs -----------------------------
+
+    def test_only_two_possible_outputs(self):
+        assert cut_mode_for_reencode(True) != cut_mode_for_reencode(False)
+
+    def test_reencode_for_codec_mixed_case_input_not_specially_handled(self):
+        # reencode_for_codec receives the already-normalized output of
+        # detect_video_codec (lowercase); an unnormalized raw string like
+        # "H264" is not a valid input here and must fall through to False
+        # (fail-safe), confirming normalization is detect_video_codec's job.
+        assert reencode_for_codec("H264") is False

--- a/tests/utils/test_youtube_downloader.py
+++ b/tests/utils/test_youtube_downloader.py
@@ -1063,3 +1063,138 @@ class TestDownloadGuardLiveStatus:
 
         assert result["success"] is True
         mock_probe.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# _warn_if_not_h264 (ffmpeg-codec-aware-cuts, Slice 3)
+# ---------------------------------------------------------------------------
+
+class TestWarnIfNotH264:
+    def test_h264_detected_logs_no_warning(self, mocker, caplog):
+        from utils.youtube_downloader import _warn_if_not_h264
+
+        mocker.patch("utils.youtube_downloader.detect_video_codec", return_value="h264")
+
+        with caplog.at_level("WARNING"):
+            codec = _warn_if_not_h264("/tmp/video.mp4", context="vid123")
+
+        assert codec == "h264"
+        assert not any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_av1_detected_logs_warning_with_context(self, mocker, caplog):
+        from utils.youtube_downloader import _warn_if_not_h264
+
+        mocker.patch("utils.youtube_downloader.detect_video_codec", return_value="av1")
+
+        with caplog.at_level("WARNING"):
+            codec = _warn_if_not_h264("/tmp/video.mp4", context="vid123")
+
+        assert codec == "av1"
+        warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+        assert warnings
+        message = warnings[0].getMessage()
+        assert "av1" in message
+        assert "vid123" in message
+        assert "avc1" in message.lower() or "h264" in message.lower()
+
+    def test_unknown_detected_logs_warning(self, mocker, caplog):
+        from utils.youtube_downloader import _warn_if_not_h264
+
+        mocker.patch("utils.youtube_downloader.detect_video_codec", return_value="unknown")
+
+        with caplog.at_level("WARNING"):
+            codec = _warn_if_not_h264("/tmp/video.mp4", context="vid123")
+
+        assert codec == "unknown"
+        assert any(r.levelname == "WARNING" for r in caplog.records)
+
+    def test_reuses_shared_detect_video_codec_no_reimplementation(self, mocker):
+        from utils.youtube_downloader import _warn_if_not_h264
+
+        mock_detect = mocker.patch(
+            "utils.youtube_downloader.detect_video_codec", return_value="h264"
+        )
+        _warn_if_not_h264("/tmp/video.mp4", context="ctx")
+
+        mock_detect.assert_called_once_with("/tmp/video.mp4")
+
+
+class TestWarnIfNotH264WiredIntoYtdlpSuccessPath:
+    def test_called_post_download_in_ytdlp_success_block(self, tmp_path, mocker):
+        """_warn_if_not_h264 must be invoked after the yt-dlp success logs, with
+        context=info.get('id') or youtube_url, and must not change any
+        format_map/ydl_opts/download-behavior args (same download call as before)."""
+        mocker.patch(
+            "utils.youtube_downloader.download_with_pytubefix",
+            return_value={"success": False, "error": "fail"},
+        )
+
+        fake_file = tmp_path / "vid123_Test Video.mp4"
+        fake_file.write_bytes(b"\x00" * 1024)
+
+        fake_info = _make_ydl_info()
+        fake_ydl = MagicMock()
+        fake_ydl.__enter__ = MagicMock(return_value=fake_ydl)
+        fake_ydl.__exit__ = MagicMock(return_value=False)
+        fake_ydl.extract_info.return_value = fake_info
+        fake_ydl.prepare_filename.return_value = str(fake_file)
+
+        mocker.patch("utils.youtube_downloader.yt_dlp.YoutubeDL", return_value=fake_ydl)
+        mock_warn = mocker.patch(
+            "utils.youtube_downloader._warn_if_not_h264", return_value="h264"
+        )
+
+        from utils.youtube_downloader import download_youtube_video_for_upload
+
+        result = download_youtube_video_for_upload(
+            "https://youtube.com/watch?v=x", str(tmp_path)
+        )
+
+        assert result["success"] is True
+        mock_warn.assert_called_once_with(str(fake_file), context="vid123")
+
+    def test_not_called_when_yt_dlp_download_fails(self, tmp_path, mocker):
+        mocker.patch(
+            "utils.youtube_downloader.download_with_pytubefix",
+            return_value={"success": False, "error": "fail"},
+        )
+
+        fake_ydl = MagicMock()
+        fake_ydl.__enter__ = MagicMock(return_value=fake_ydl)
+        fake_ydl.__exit__ = MagicMock(return_value=False)
+        fake_ydl.extract_info.return_value = _make_ydl_info()
+        fake_ydl.prepare_filename.return_value = str(tmp_path / "does_not_exist.mp4")
+
+        mocker.patch("utils.youtube_downloader.yt_dlp.YoutubeDL", return_value=fake_ydl)
+        mock_warn = mocker.patch("utils.youtube_downloader._warn_if_not_h264")
+
+        from utils.youtube_downloader import download_youtube_video_for_upload
+
+        result = download_youtube_video_for_upload(
+            "https://youtube.com/watch?v=x", str(tmp_path)
+        )
+
+        assert result["success"] is False
+        mock_warn.assert_not_called()
+
+    def test_called_before_early_return_on_pytubefix_success(self, tmp_path, mocker):
+        """Secondary insertion point (design Decision 4): the pytubefix success
+        early-return path also observes AV1 via the same helper."""
+        mocker.patch(
+            "utils.youtube_downloader.download_with_pytubefix",
+            return_value={"success": True, "file_path": "/tmp/pytubefix_video.mp4", "resolution": "720p"},
+        )
+        mock_ydl_class = mocker.patch("utils.youtube_downloader.yt_dlp.YoutubeDL")
+        mock_warn = mocker.patch("utils.youtube_downloader._warn_if_not_h264", return_value="h264")
+
+        from utils.youtube_downloader import download_youtube_video_for_upload
+
+        result = download_youtube_video_for_upload(
+            "https://youtube.com/watch?v=x", str(tmp_path), guard_live_status=False
+        )
+
+        assert result["success"] is True
+        mock_warn.assert_called_once_with(
+            "/tmp/pytubefix_video.mp4", context="https://youtube.com/watch?v=x"
+        )
+        mock_ydl_class.assert_not_called()

--- a/utils/codec_detection.py
+++ b/utils/codec_detection.py
@@ -1,0 +1,122 @@
+"""Shared ffmpeg/ffprobe-based video codec detection.
+
+Used by both cut sites (``congress_videos.modules.video_splitter`` and
+``congress_videos.reap_clip_preparer_dag``) and the downloader
+(``utils.youtube_downloader``) to decide whether a source video can be safely
+re-encoded (H264) or must fall back to a stream-copy cut (AV1/unknown), and to
+warn when a downloaded file is not H264. See design.md for the full rationale.
+"""
+
+import logging
+import os
+import subprocess
+
+logger = logging.getLogger(__name__)
+
+_H264_NAMES = frozenset({"h264", "avc1"})
+_AV1_NAMES = frozenset({"av1", "av01"})
+FFPROBE_TIMEOUT_SECS = 30
+
+
+def detect_video_codec(source_path: str, *, timeout: int = FFPROBE_TIMEOUT_SECS) -> str:
+    """Return ``"h264"`` | ``"av1"`` | ``"unknown"`` for the primary video stream.
+
+    Runs ``ffprobe -show_entries stream=codec_name`` against the first video
+    stream and normalizes the result. Never raises: a missing ffprobe binary,
+    a timeout, a non-zero exit, or any other error is caught and reported as
+    ``"unknown"`` (fail-safe — callers treat unknown as "do not re-encode").
+
+    Args:
+        source_path: Path to the video file to probe.
+        timeout: Subprocess timeout in seconds (default 30s). ffprobe reads
+            only container/stream metadata, not the full stream, so this is a
+            generous safety bound rather than an expected wait.
+
+    Returns:
+        ``"h264"``, ``"av1"``, or ``"unknown"``.
+    """
+    cmd = [
+        "ffprobe", "-v", "error",
+        "-select_streams", "v:0",
+        "-show_entries", "stream=codec_name",
+        "-of", "csv=p=0",
+        source_path,
+    ]
+    try:
+        proc = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    except FileNotFoundError:
+        logger.warning("ffprobe binary not found; codec unknown for %s", source_path)
+        return "unknown"
+    except subprocess.TimeoutExpired:
+        logger.warning("ffprobe timed out (%ss); codec unknown for %s", timeout, source_path)
+        return "unknown"
+    except Exception as exc:  # defensive catch-all — detection must never raise
+        logger.warning("ffprobe error for %s: %s; codec unknown", source_path, exc)
+        return "unknown"
+
+    if proc.returncode != 0:
+        logger.warning(
+            "ffprobe exit %s for %s: %s; codec unknown",
+            proc.returncode, source_path, (proc.stderr or "").strip(),
+        )
+        return "unknown"
+
+    name = (proc.stdout or "").strip().lower()
+    if name in _H264_NAMES:
+        return "h264"
+    if name in _AV1_NAMES:
+        return "av1"
+    logger.warning(
+        "ffprobe reported unrecognized codec %r for %s; treating as unknown",
+        name, source_path,
+    )
+    return "unknown"
+
+
+def get_cached_codec(source_path: str, cache: dict | None) -> str:
+    """Cache-aware codec lookup keyed by the resolved absolute source path.
+
+    Probes at most once per distinct source path when a cache dict is
+    supplied. Passing ``cache=None`` disables memoization (each call probes).
+
+    Args:
+        source_path: Path to the raw source video.
+        cache: A caller-owned, process-local dict to memoize results in, or
+            ``None`` to probe directly without caching.
+
+    Returns:
+        The detected codec string (``"h264"`` | ``"av1"`` | ``"unknown"``).
+    """
+    if cache is None:
+        return detect_video_codec(source_path)
+    key = os.path.abspath(source_path)
+    if key not in cache:
+        cache[key] = detect_video_codec(source_path)
+    return cache[key]
+
+
+def reencode_for_codec(codec: str) -> bool:
+    """Decide whether to re-encode: only H264 sources re-encode.
+
+    AV1 and unknown sources fall back to stream-copy (fail-safe): re-encoding
+    a corrupt/misdetected AV1 source is what causes ffmpeg to crash.
+
+    Args:
+        codec: Detected codec string, as returned by :func:`detect_video_codec`.
+
+    Returns:
+        ``True`` for ``"h264"``, ``False`` otherwise.
+    """
+    return codec == "h264"
+
+
+def cut_mode_for_reencode(reencode: bool) -> str:
+    """Map the ``reencode`` decision to its audit-field string.
+
+    Args:
+        reencode: The boolean produced by :func:`reencode_for_codec`.
+
+    Returns:
+        ``"reencode"`` when ``reencode`` is ``True``, else ``"stream_copy"``.
+    """
+    return "reencode" if reencode else "stream_copy"

--- a/utils/youtube_downloader.py
+++ b/utils/youtube_downloader.py
@@ -12,10 +12,35 @@ from typing import Dict, List, Optional
 
 import yt_dlp
 
+from utils.codec_detection import detect_video_codec
+
 logger = logging.getLogger(__name__)
 
 # yt-dlp live_status values that correspond to a genuinely-downloadable VOD.
 READY_LIVE_STATUSES = frozenset({"was_live", "not_live"})
+
+
+def _warn_if_not_h264(file_path: str, *, context: str) -> str:
+    """Detect the downloaded file's codec and warn when it is not H264.
+
+    Reuses :func:`utils.codec_detection.detect_video_codec` — no reimplementation.
+    Logging only; never raises and never changes the download result.
+
+    Args:
+        file_path: Path to the downloaded video file.
+        context: Video id or URL, included in the warning for correlation.
+
+    Returns:
+        The detected codec string (``"h264"`` | ``"av1"`` | ``"unknown"``).
+    """
+    codec = detect_video_codec(file_path)
+    if codec != "h264":
+        logger.warning(
+            "Downloaded file for %s has codec=%r but avc1/H264 was requested "
+            "(yt-dlp/pytubefix fallback accepted a non-H264 stream): %s",
+            context, codec, file_path,
+        )
+    return codec
 
 
 def probe_live_status(
@@ -315,6 +340,10 @@ def download_youtube_video_for_upload(
         result = download_with_pytubefix(youtube_url, output_dir, min_resolution)
         if result["success"]:
             logger.info(f"pytubefix succeeded! Resolution: {result.get('resolution')}")
+            try:
+                _warn_if_not_h264(result["file_path"], context=youtube_url)
+            except Exception as e:
+                logger.warning("codec-mismatch check failed for %s: %s", youtube_url, e)
             return result
         else:
             logger.warning(f"pytubefix failed: {result.get('error')}. Falling back to yt-dlp...")
@@ -382,6 +411,14 @@ def download_youtube_video_for_upload(
                 logger.info(f"   Size: {file_size_mb:.2f} MB")
                 logger.info(f"   Duration: {info.get('duration_string')}")
                 logger.info(f"   Ready for YouTube upload!")
+                try:
+                    _warn_if_not_h264(str(file_path), context=info.get("id") or youtube_url)
+                except Exception as e:
+                    logger.warning(
+                        "codec-mismatch check failed for %s: %s",
+                        info.get("id") or youtube_url,
+                        e,
+                    )
             else:
                 result["error"] = f"File not found: {output_file}"
                 logger.error(result["error"])


### PR DESCRIPTION
## Summary

- Detects the source video's codec (H264/AV1/unknown) via `ffprobe` before cutting chapters, and only re-encodes for H264 sources — AV1/unknown sources fall back to stream-copy (fail-safe), since re-encoding a corrupt/misdetected AV1 source is what causes ffmpeg to crash.
- Adds `utils/codec_detection.py` shared by `video_splitter.py`, `reap_clip_preparer_dag.py`, and `youtube_downloader.py`.
- Per-DAG-run `codec_cache` memoizes the probe so each distinct source video is only probed once across chapter cuts and pre-trim steps.
- `youtube_downloader.py` warns (log only, never raises) when a downloaded file isn't H264, for correlation with future codec issues.
- Includes the full `openspec/changes/ffmpeg-codec-aware-cuts/` SDD artifact trail (proposal, design, spec, tasks, apply-progress, verify-report).

## Changed files

| File | Change |
|------|--------|
| `utils/codec_detection.py` | New: `detect_video_codec`, `get_cached_codec`, `reencode_for_codec`, `cut_mode_for_reencode` |
| `congress_videos/modules/video_splitter.py` | `split_video_chapter` takes optional `codec_cache`, decides re-encode vs stream-copy per source codec, reports `source_codec`/`cut_mode` |
| `congress_videos/reap_clip_preparer_dag.py` | Reuses raw-source codec decision for both the chapter cut and the pre-trim step |
| `utils/youtube_downloader.py` | Warns when a downloaded file isn't H264 |
| `tests/utils/test_codec_detection.py` | New: codec detection unit tests (missing binary, timeout, nonzero exit, unrecognized codec, caching) |
| `tests/utils/test_youtube_downloader.py` | New: codec-mismatch warning tests |
| `tests/congress_videos/modules/test_video_splitter.py` | Updated for `codec_cache`/`source_codec`/`cut_mode` |
| `tests/congress_videos/test_reap_clip_preparer_dag.py` | Updated for shared codec-cache reuse |
| `openspec/changes/ffmpeg-codec-aware-cuts/*` | SDD artifacts (proposal, design, spec, tasks, apply-progress, verify-report) |

## Test plan

- [x] `pytest tests/utils/test_codec_detection.py tests/utils/test_youtube_downloader.py tests/congress_videos/modules/test_video_splitter.py tests/congress_videos/test_reap_clip_preparer_dag.py -q` — 160 passed
- [x] Touched-file coverage: `video_splitter.py` 93.5%, `reap_clip_preparer_dag.py` 82%, `youtube_downloader.py` 83.3%, `codec_detection.py` 100%
- [ ] Verify DAG loads without errors in Airflow UI after deploy
