### PR TITLE
fix(chapter-uploader): ensure upload failures are always recorded (no more infinite retry)

### DIFF
--- a/congress_videos/reap_shorts_uploader_dag.py
+++ b/congress_videos/reap_shorts_uploader_dag.py
@@ -336,9 +336,32 @@ with DAG(
 
         logging.info(f"Upload summary: {successful} successful, {failed} failed")
 
+    def _check_short_upload_failures(ti, **context):
+        upload_results = ti.xcom_pull(key='upload_results')
+        if upload_results is None:
+            raise Exception("Upload results XCom missing — data integrity unknown")
+        upload_details = upload_results.get('upload_details', [])
+        if not upload_details:
+            logging.info("No upload results to check")
+            return
+        failed = [
+            d for d in upload_details
+            if not (d.get('success') and d.get('reap_clip_id') and d.get('youtube_video_id'))
+        ]
+        if failed:
+            raise Exception(
+                f"{len(failed)} short(s) failed to upload (DB writes already committed)"
+            )
+        logging.info("All shorts uploaded successfully")
+
     t4 = PythonOperator(
         task_id='mark_shorts_uploaded',
         python_callable=_mark_shorts_uploaded,
     )
 
-    t1 >> t2 >> t3 >> t4
+    t5 = PythonOperator(
+        task_id='check_short_upload_failures',
+        python_callable=_check_short_upload_failures,
+    )
+
+    t1 >> t2 >> t3 >> t4 >> t5

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -244,10 +244,29 @@ with DAG(
                         })
                     ti.xcom_push(key='upload_results', value={'upload_details': upload_details})
 
-                if dag_run.state == 'failed':
-                    raise Exception(f"Upload DAG failed: {dag_run.run_id}")
-
                 return dag_run.run_id
+
+    def _check_upload_failures(ti):
+        """Raise after DB writes so failures are visible in the Airflow UI."""
+        updates = ti.xcom_pull(key='chapter_upload_updates')
+        if updates is None:
+            raise Exception(
+                "chapter_upload_updates XCom missing after mark_chapters_uploaded succeeded"
+            )
+
+        recorded = updates.get('recorded_failures', 0)
+        failed = updates.get('failed_updates', 0)
+        if recorded > 0 or failed > 0:
+            bad = [
+                d for d in updates.get('details', [])
+                if d.get('status') in ('failure_recorded', 'failed')
+            ]
+            raise Exception(
+                f"Chapter upload failures: {recorded} recorded, {failed} "
+                f"DB-update failures. Chapters: {[d.get('chapter_id') for d in bad]}"
+            )
+
+        logging.info("No chapter upload failures recorded")
 
     t7 = PythonOperator(
         task_id='trigger_youtube_upload',
@@ -262,5 +281,11 @@ with DAG(
         output_xcom_key='chapter_upload_updates'
     )
 
+    # Step 9: Alert when chapter upload failures were recorded (after DB write)
+    t9 = PythonOperator(
+        task_id='check_upload_failures',
+        python_callable=_check_upload_failures,
+    )
+
     # Task dependencies
-    t0 >> t1_quota >> t1_skip >> t1_db >> t2 >> t3 >> t4 >> t5 >> t6 >> t7 >> t8_db
+    t0 >> t1_quota >> t1_skip >> t1_db >> t2 >> t3 >> t4 >> t5 >> t6 >> t7 >> t8_db >> t9

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -18,8 +18,9 @@ class TestReapShortsUploaderDAGLoads:
 
     def test_dag_has_correct_task_count(self):
         from congress_videos.reap_shorts_uploader_dag import dag
-        # Tasks: get_pending_shorts, generate_metadata, trigger_youtube_upload, mark_shorts_uploaded
-        assert len(dag.tasks) == 4
+        # Tasks: get_pending_shorts, generate_metadata, trigger_youtube_upload,
+        # mark_shorts_uploaded, check_short_upload_failures
+        assert len(dag.tasks) == 5
 
     def test_dag_schedule(self):
         from congress_videos.reap_shorts_uploader_dag import dag
@@ -32,6 +33,7 @@ class TestReapShortsUploaderDAGLoads:
         assert "generate_metadata" in task_ids
         assert "trigger_youtube_upload" in task_ids
         assert "mark_shorts_uploaded" in task_ids
+        assert "check_short_upload_failures" in task_ids
 
     def test_dag_correct_dependency_chain(self):
         from congress_videos.reap_shorts_uploader_dag import dag
@@ -40,10 +42,12 @@ class TestReapShortsUploaderDAGLoads:
         t2 = tasks_by_id["generate_metadata"]
         t3 = tasks_by_id["trigger_youtube_upload"]
         t4 = tasks_by_id["mark_shorts_uploaded"]
+        t5 = tasks_by_id["check_short_upload_failures"]
 
         assert t2.task_id in {t.task_id for t in t1.downstream_list}
         assert t3.task_id in {t.task_id for t in t2.downstream_list}
         assert t4.task_id in {t.task_id for t in t3.downstream_list}
+        assert t5.task_id in {t.task_id for t in t4.downstream_list}
 
 
 # ---------------------------------------------------------------------------
@@ -590,3 +594,61 @@ class TestGenerateMetadataSessionLine:
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
         assert "🏛️ Sesión" not in description, f"Unexpected session suffix in: {description!r}"
+
+
+# ---------------------------------------------------------------------------
+# _check_short_upload_failures (t5) — post-DB monitoring task
+# ---------------------------------------------------------------------------
+
+
+class TestCheckShortUploadFailures:
+
+    def test_raises_on_failed_details(self):
+        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+
+        upload_results = {
+            "upload_details": [
+                {"reap_clip_id": "c-ok", "youtube_video_id": "yt-ok", "success": True},
+                {"reap_clip_id": "c-fail", "youtube_video_id": None, "success": False, "error": "Upload failed"},
+            ]
+        }
+        ti = _make_ti({"upload_results": upload_results})
+        with pytest.raises(Exception, match=r"short\(s\) failed to upload"):
+            _check_short_upload_failures(ti, params={})
+
+    def test_raises_on_success_with_missing_youtube_id(self):
+        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+
+        upload_results = {
+            "upload_details": [
+                {"reap_clip_id": "c-ok", "youtube_video_id": None, "success": True},
+            ]
+        }
+        ti = _make_ti({"upload_results": upload_results})
+        with pytest.raises(Exception, match=r"short\(s\) failed to upload"):
+            _check_short_upload_failures(ti, params={})
+
+    def test_all_success_does_not_raise(self):
+        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+
+        upload_results = {
+            "upload_details": [
+                {"reap_clip_id": "c-1", "youtube_video_id": "yt-a", "success": True},
+                {"reap_clip_id": "c-2", "youtube_video_id": "yt-b", "success": True},
+            ]
+        }
+        ti = _make_ti({"upload_results": upload_results})
+        _check_short_upload_failures(ti, params={})
+
+    def test_empty_details_noop(self):
+        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+
+        ti = _make_ti({"upload_results": {"upload_details": []}})
+        _check_short_upload_failures(ti, params={})
+
+    def test_missing_xcom_raises(self):
+        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+
+        ti = _make_ti({})
+        with pytest.raises(Exception, match="Upload results XCom missing"):
+            _check_short_upload_failures(ti, params={})

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -1,0 +1,136 @@
+"""Tests for congress_youtube_chapter_uploader DAG (congress_videos.youtube_upload_dag)."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+def _make_ti(xcom_store: dict | None = None):
+    """Return a TaskInstance double with an in-memory XCom store."""
+    store: dict = xcom_store or {}
+    ti = MagicMock(name="TaskInstance")
+    ti.xcom_store = store
+
+    def _push(key: str, value, **_kw) -> None:
+        store[key] = value
+
+    def _pull(key: str | None = None, **_kw):
+        if key is None:
+            return None
+        return store.get(key)
+
+    ti.xcom_push.side_effect = _push
+    ti.xcom_pull.side_effect = _pull
+    return ti
+
+
+# ---------------------------------------------------------------------------
+# DAG load + dependency chain
+# ---------------------------------------------------------------------------
+
+class TestYoutubeUploadDagLoads:
+
+    def test_dag_loads(self):
+        from congress_videos.youtube_upload_dag import dag
+        assert dag is not None
+        assert dag.dag_id == "congress_youtube_chapter_uploader"
+
+    def test_dag_has_twelve_tasks(self):
+        from congress_videos.youtube_upload_dag import dag
+        assert len(dag.tasks) == 12
+
+    def test_expected_task_ids_present(self):
+        from congress_videos.youtube_upload_dag import dag
+        task_ids = {t.task_id for t in dag.tasks}
+        assert "trigger_youtube_upload" in task_ids
+        assert "mark_chapters_uploaded" in task_ids
+        assert "check_upload_failures" in task_ids
+
+    def test_chain_t7_t8_t9(self):
+        from congress_videos.youtube_upload_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t7 = tasks_by_id["trigger_youtube_upload"]
+        t8 = tasks_by_id["mark_chapters_uploaded"]
+        t9 = tasks_by_id["check_upload_failures"]
+
+        assert t8.task_id in {t.task_id for t in t7.downstream_list}
+        assert t9.task_id in {t.task_id for t in t8.downstream_list}
+
+
+# ---------------------------------------------------------------------------
+# _check_upload_failures
+# ---------------------------------------------------------------------------
+
+class TestCheckUploadFailures:
+
+    def test_raises_on_recorded_failures(self):
+        from congress_videos.youtube_upload_dag import _check_upload_failures
+
+        ti = _make_ti({"chapter_upload_updates": {"recorded_failures": 1, "failed_updates": 0}})
+        with pytest.raises(Exception, match="Chapter upload failures"):
+            _check_upload_failures(ti)
+
+    def test_raises_on_failed_updates(self):
+        from congress_videos.youtube_upload_dag import _check_upload_failures
+
+        ti = _make_ti({"chapter_upload_updates": {"recorded_failures": 0, "failed_updates": 2}})
+        with pytest.raises(Exception, match="Chapter upload failures"):
+            _check_upload_failures(ti)
+
+    def test_raises_on_missing_xcom(self):
+        from congress_videos.youtube_upload_dag import _check_upload_failures
+
+        ti = _make_ti({})
+        with pytest.raises(Exception, match="chapter_upload_updates XCom missing"):
+            _check_upload_failures(ti)
+
+    def test_noop_on_zeros(self):
+        from congress_videos.youtube_upload_dag import _check_upload_failures
+
+        ti = _make_ti({"chapter_upload_updates": {"recorded_failures": 0, "failed_updates": 0}})
+        _check_upload_failures(ti)  # should not raise
+
+    def test_noop_on_empty_payload_lacking_recorded_failures(self):
+        from congress_videos.youtube_upload_dag import _check_upload_failures
+
+        ti = _make_ti({"chapter_upload_updates": {"updated_chapters": 0, "failed_updates": 0, "details": []}})
+        _check_upload_failures(ti)  # should not raise
+
+
+# ---------------------------------------------------------------------------
+# trigger_upload_with_config (t7)
+# ---------------------------------------------------------------------------
+
+class TestTriggerUploadWithConfig:
+
+    def test_no_raise_on_child_failure_and_pushes_fallback(self, mocker):
+        from congress_videos.youtube_upload_dag import trigger_upload_with_config
+
+        mock_run = MagicMock()
+        mock_run.run_id = "failed_run_001"
+        mock_run.state = "failed"
+        mock_run.execution_date = "2026-07-28T00:00:00+00:00"
+        mock_run.refresh_from_db = MagicMock()
+
+        mocker.patch("congress_videos.youtube_upload_dag.trigger_dag_api", return_value=mock_run)
+        mocker.patch("time.sleep")
+        mock_xcom = mocker.patch("airflow.models.XCom")
+        mock_xcom.get_many.return_value = []
+
+        ti = _make_ti({
+            "upload_config": {
+                "videos": [
+                    {"chapter_id": "c-1", "video_id": "v-1", "video_file": "/c1.mp4"},
+                    {"chapter_id": "c-2", "video_id": "v-2", "video_file": "/c2.mp4"},
+                ]
+            }
+        })
+
+        result = trigger_upload_with_config(ti, run_id="test_run")
+
+        assert result == "failed_run_001"
+        fallback = ti.xcom_store["upload_results"]
+        assert len(fallback["upload_details"]) == 2
+        assert all(d["success"] is False for d in fallback["upload_details"])

--- a/tests/utils/test_youtube_helpers_extended.py
+++ b/tests/utils/test_youtube_helpers_extended.py
@@ -212,8 +212,8 @@ class TestUploadVideosFromConfig:
 
         assert result["successful_uploads"] == 1
 
-    def test_failed_uploads_raises_exception(self, tmp_path, mocker):
-        """Any failed uploads raises Exception with count in message."""
+    def test_failed_uploads_returns_results(self, tmp_path, mocker):
+        """Failed uploads return the results dict instead of raising."""
         mocker.patch(
             "utils.youtube_helpers.upload_multiple_videos",
             return_value={
@@ -237,5 +237,10 @@ class TestUploadVideosFromConfig:
             ],
         }
 
-        with pytest.raises(Exception, match="1 video"):
-            upload_videos_from_config(conf)
+        result = upload_videos_from_config(conf)
+
+        assert result["total_videos"] == 2
+        assert result["successful_uploads"] == 1
+        assert result["failed_uploads"] == 1
+        assert len(result["upload_details"]) == 2
+        assert result["upload_details"][1]["error"] == "quota exceeded"

--- a/utils/youtube_helpers.py
+++ b/utils/youtube_helpers.py
@@ -435,8 +435,9 @@ def upload_videos_from_config(conf):
         - failed_uploads: Number of failed uploads
         - upload_details: List of detailed results per video
 
-    Raises:
-        Exception: If any uploads fail
+        The results dict is returned unconditionally, including when some or all
+        uploads fail. Callers are responsible for inspecting `failed_uploads` and
+        handling failures as needed.
     """
     token_file = conf['token_file']
     videos = conf['videos']
@@ -460,13 +461,12 @@ def upload_videos_from_config(conf):
     logging.info(f"Successful: {results['successful_uploads']}")
     logging.info(f"Failed: {results['failed_uploads']}")
 
-    # Raise error if any uploads failed
+    # Log any failed uploads for visibility; return results unconditionally
     if results['failed_uploads'] > 0:
         error_details = [
             detail for detail in results['upload_details']
             if not detail.get('success', False)
         ]
         logging.error(f"Failed uploads: {error_details}")
-        raise Exception(f"{results['failed_uploads']} video(s) failed to upload")
 
     return results


### PR DESCRIPTION
## Problem

Two cascading bugs caused `record_chapter_upload_failure` to never run when a YouTube upload failed, so `upload_attempts` never incremented and chapters were re-attempted forever daily.

### Bug 1 — `utils/youtube_helpers.py:463-470`
`upload_videos_from_config` raised when any upload failed → child DAG task `upload_videos` failed → XCom `return_value` with results never set → parent got no data.

### Bug 2 — `congress_videos/youtube_upload_dag.py:247-248`
t7 detected child `dag_run.state == 'failed'` and raised → Airflow cut downstream execution → t8_db (`mark_chapters_uploaded`) never ran → neither successes nor failures were recorded.

## Fix

1. **Helper returns results always**: `upload_videos_from_config` no longer raises on partial failure — the child DAG always succeeds and XCom carries real per-video results.
2. **t7 no longer raises**: parent completes regardless of child outcome; fallback XCom results preserved.
3. **t9 monitoring**: new task `check_upload_failures` runs AFTER t8_db and raises only when failures were recorded — alerting after DB writes commit.
4. **Reap shorts monitoring**: same post-DB monitoring pattern applied to `reap_shorts_uploader_dag.py` (t5 `check_short_upload_failures`) to prevent silent-green regression.

## Tests
- 64/64 targeted tests pass (19 chapter + 45 reap)
- Replaced `test_failed_uploads_raises_exception` with return-asserting test
- New DAG-level tests for chain structure and t9/t5 behavior

## SDD
Full SDD flow: explore → propose → spec → design → tasks → apply → verify → archive

## Files changed
- `utils/youtube_helpers.py`
- `congress_videos/youtube_upload_dag.py`
- `congress_videos/reap_shorts_uploader_dag.py`
- `tests/utils/test_youtube_helpers_extended.py`
- `tests/congress_videos/test_youtube_upload_dag.py` (new)
- `tests/congress_videos/test_reap_uploader_dag.py`
