### PR TITLE
fix(congress-videos): guard corrupt AV1 sources + stop test-mode title clobber (#24, #25)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,8 +19,8 @@ RUN apt-get update && \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 
-# Verify installations
-RUN ffmpeg -version && node --version
+# Verify installations (ffprobe ships with the ffmpeg apt package)
+RUN ffmpeg -version && ffprobe -version && node --version
 
 # Switch back to airflow user
 USER airflow

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1243,10 +1243,53 @@ class CongressionalVideoDB:
                 row = cur.fetchone()
                 return dict(row) if row else None
 
-    def get_processed_video_ids(self, video_ids: list[str]) -> set[str]:
+    def record_source_integrity_failure(
+        self, video_id: str, retry_after_hours: int = 12
+    ) -> None:
+        """Early-upsert an integrity failure for a source video.
+
+        Sets ``download_retry_after = NOW() + retry_after_hours`` so the video is
+        excluded from ``filter_unprocessed_videos`` until the VOD has had time to
+        finalise on YouTube.
+
+        Rules:
+        - ``is_processed`` is intentionally NOT in the DO UPDATE SET clause so a
+          row that was already marked ``is_processed = TRUE`` never regresses to FALSE.
+        - ``GREATEST(...)`` ensures ``download_retry_after`` only ever advances forward;
+          a second call with a *smaller* window does not decrease an existing future
+          timestamp.
+        - On INSERT the row starts with ``is_processed = FALSE`` and the computed
+          retry timestamp.
+
+        Args:
+            video_id: YouTube video ID.
+            retry_after_hours: Hours to defer re-download (default 12).
         """
-        Return the subset of video_ids already fully processed
-        (is_processed = TRUE) in youtube_source_videos.
+        tbl = self.pg_conn.get_qualified_table('youtube_source_videos')
+        video_url = f'https://www.youtube.com/watch?v={video_id}'
+
+        with closing(self.pg_conn.get_connection()) as conn:
+            with conn:
+                with conn.cursor() as cur:
+                    cur.execute(
+                        f"""
+                        INSERT INTO {tbl} (video_id, video_url, is_processed, download_retry_after)
+                        VALUES (%s, %s, FALSE, NOW() + (%s || ' hours')::interval)
+                        ON CONFLICT (video_id) DO UPDATE SET
+                            download_retry_after = GREATEST(
+                                {tbl}.download_retry_after,
+                                EXCLUDED.download_retry_after),
+                            updated_at = CURRENT_TIMESTAMP
+                        """,
+                        (video_id, video_url, str(retry_after_hours)),
+                    )
+
+    def get_processed_video_ids(self, video_ids: list[str]) -> set[str]:
+        """Return the subset of video_ids that should be skipped for download.
+
+        A video is skipped when EITHER:
+        - ``is_processed = TRUE`` (already fully processed), OR
+        - ``download_retry_after > NOW()`` (deferred within the integrity retry window).
 
         Cheap pre-download idempotency check. Empty input -> empty set
         (no query executed). Read-only; raises on DB error (fail-closed).
@@ -1262,7 +1305,8 @@ class CongressionalVideoDB:
                     f"""
                     SELECT video_id
                     FROM {youtube_videos_table}
-                    WHERE video_id = ANY(%s) AND is_processed = TRUE
+                    WHERE video_id = ANY(%s)
+                      AND (is_processed = TRUE OR download_retry_after > NOW())
                     """,
                     (video_ids,),
                 )

--- a/congress_videos/modules/youtube/__init__.py
+++ b/congress_videos/modules/youtube/__init__.py
@@ -37,7 +37,7 @@ def __getattr__(name):
         return locals()[name]
 
     # download functions
-    elif name in ['download_video_from_youtube', 'extract_audio_from_youtube', 'create_test_video_data', 'transcribe_audio_with_whisper', 'merge_transcription_srt_files', 'identify_interesting_chapters', 'merge_interesting_chapters', 'try_download_subtitles_from_youtube', 'split_srt_by_silence', 'summarize_silence_chunks', 'summarize_one_chunk', 'aggregate_chunk_summaries', 'flatten_chunks_for_mapping', 'regroup_summarized_chunks']:
+    elif name in ['download_video_from_youtube', 'extract_audio_from_youtube', 'create_test_video_data', 'transcribe_audio_with_whisper', 'merge_transcription_srt_files', 'identify_interesting_chapters', 'merge_interesting_chapters', 'try_download_subtitles_from_youtube', 'split_srt_by_silence', 'summarize_silence_chunks', 'summarize_one_chunk', 'aggregate_chunk_summaries', 'flatten_chunks_for_mapping', 'regroup_summarized_chunks', 'check_source_video_integrity']:
         from .download import (
             download_video_from_youtube,
             extract_audio_from_youtube,
@@ -53,6 +53,7 @@ def __getattr__(name):
             aggregate_chunk_summaries,
             flatten_chunks_for_mapping,
             regroup_summarized_chunks,
+            check_source_video_integrity,
         )
         return locals()[name]
 
@@ -102,6 +103,7 @@ __all__ = [
     'aggregate_chunk_summaries',
     'flatten_chunks_for_mapping',
     'regroup_summarized_chunks',
+    'check_source_video_integrity',
     # youtube_ai functions
     'generate_youtube_title',
     'generate_youtube_description',

--- a/congress_videos/modules/youtube/download.py
+++ b/congress_videos/modules/youtube/download.py
@@ -24,6 +24,77 @@ from utils.youtube_downloader import (
 LARGE_SRT_THRESHOLD = 100_000
 
 
+def _run_ffprobe(file_path: str) -> bool:
+    """Run a fast container-level integrity probe against a downloaded source file.
+
+    Uses ``ffprobe -v error -i <file_path>`` (headers/index only — no full decode).
+    A clean probe is defined as: returncode 0 AND stderr contains no error-level output.
+
+    Fail-safe: any exception (FileNotFoundError, TimeoutExpired, or unexpected error)
+    returns False so a missing/broken binary never silently passes a corrupt source through.
+
+    Args:
+        file_path: Absolute path to the downloaded video file.
+
+    Returns:
+        True if the probe is clean; False on any error or exception.
+    """
+    import subprocess
+    try:
+        result = subprocess.run(
+            ['ffprobe', '-v', 'error', '-i', file_path],
+            capture_output=True,
+            text=True,
+            timeout=60,
+        )
+        if result.returncode != 0 or result.stderr.strip():
+            return False
+        return True
+    except (FileNotFoundError, subprocess.TimeoutExpired, Exception) as exc:
+        logging.error("ffprobe integrity check failed for %s: %s", file_path, exc)
+        return False
+
+
+def check_source_video_integrity(downloaded_videos: dict) -> dict:
+    """Run ffprobe against each downloaded source file and annotate the result.
+
+    Consumes the ``download_video_from_youtube`` return structure
+    (``{'total_downloaded', 'videos': [{video_id, file_path, ...}]}``) and returns
+    the same structure with a per-video ``integrity_ok: bool`` key and a top-level
+    ``failed_video_ids: list[str]``.
+
+    Entries that already have no ``file_path`` (download errors) are treated as
+    ``integrity_ok=False`` without attempting a probe.
+
+    Args:
+        downloaded_videos: Return value of ``download_video_from_youtube``.
+
+    Returns:
+        The same dict shape with added ``integrity_ok`` per video and
+        ``failed_video_ids`` at the top level.
+    """
+    videos = downloaded_videos.get('videos', [])
+    failed: list[str] = []
+    result_videos: list[dict] = []
+
+    for v in videos:
+        video_id = v.get('video_id', '')
+        file_path = v.get('file_path')
+
+        if not file_path:
+            # No file path means the download itself failed — treat as failed probe.
+            result_videos.append({**v, 'integrity_ok': False})
+            failed.append(video_id)
+            continue
+
+        ok = _run_ffprobe(file_path)
+        result_videos.append({**v, 'integrity_ok': ok})
+        if not ok:
+            failed.append(video_id)
+
+    return {**downloaded_videos, 'videos': result_videos, 'failed_video_ids': failed}
+
+
 def _chunk_text(chunk: dict) -> str:
     """Return a chunk's SRT text, reading from disk when stored as a path.
 

--- a/congress_videos/modules/youtube/youtube_channel.py
+++ b/congress_videos/modules/youtube/youtube_channel.py
@@ -318,7 +318,7 @@ def filter_finished_streams(
     return result
 
 
-def get_video_details(plenary_videos, min_hours_since_end: int = 2):
+def get_video_details(plenary_videos, min_hours_since_end: int = 12):
     """
     Get detailed information for videos (duration, timing, etc.).
 
@@ -406,6 +406,10 @@ def get_video_details(plenary_videos, min_hours_since_end: int = 2):
 
             enriched_video = {
                 **video,
+                # Issue #25: explicitly set title from the real API response so the
+                # actual snippet.title always wins over any placeholder from the input
+                # dict (e.g. the mock title injected by create_test_video_data()).
+                'title': video_details['snippet']['title'],
                 'duration_seconds': duration_seconds,
                 'duration_formatted': f"{hours}:{minutes:02d}:{seconds:02d}",
                 'actual_start_time': live_details.get('actualStartTime'),

--- a/congress_videos/sql/migrations/013_add_source_integrity_tracking.sql
+++ b/congress_videos/sql/migrations/013_add_source_integrity_tracking.sql
@@ -1,0 +1,17 @@
+-- Migration: Add source integrity deferred retry tracking
+-- Created: 2026-07-30
+-- Depends on: youtube_chapters_schema.sql (youtube_source_videos table)
+--
+-- Adds download_retry_after TIMESTAMP DEFAULT NULL to youtube_source_videos.
+-- When record_source_integrity_failure() is called after a failed ffprobe probe,
+-- this column is set to NOW()+12h so filter_unprocessed_videos skips the video
+-- until the VOD has had time to finalise on YouTube.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS is safe to re-run.
+-- Runner runs `SET search_path TO {schema}, public` first, so names are UNQUALIFIED.
+--
+-- Example (development): psql ... -c "SET search_path TO development, public;" -f 013_add_source_integrity_tracking.sql
+-- Example (production):  psql ... -c "SET search_path TO production, public;"  -f 013_add_source_integrity_tracking.sql
+
+ALTER TABLE youtube_source_videos
+    ADD COLUMN IF NOT EXISTS download_retry_after TIMESTAMP DEFAULT NULL;

--- a/congress_videos/sql/production_schema.sql
+++ b/congress_videos/sql/production_schema.sql
@@ -44,6 +44,11 @@ CREATE TABLE IF NOT EXISTS production.youtube_source_videos (
     is_processed BOOLEAN DEFAULT FALSE,
     total_chapters INTEGER DEFAULT 0,
 
+    -- Integrity gate: set to NOW()+12h when ffprobe detects a corrupt/incomplete download.
+    -- filter_unprocessed_videos skips rows where download_retry_after > NOW() so the video
+    -- is retried after the VOD has had time to finalise on YouTube.
+    download_retry_after TIMESTAMP DEFAULT NULL,
+
     -- Timestamps
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/congress_videos/sql/youtube_chapters_schema.sql
+++ b/congress_videos/sql/youtube_chapters_schema.sql
@@ -30,6 +30,11 @@ CREATE TABLE IF NOT EXISTS development.youtube_source_videos (
     is_processed BOOLEAN DEFAULT FALSE,
     total_chapters INTEGER DEFAULT 0,
 
+    -- Integrity gate: set to NOW()+12h when ffprobe detects a corrupt/incomplete download.
+    -- filter_unprocessed_videos skips rows where download_retry_after > NOW() so the video
+    -- is retried after the VOD has had time to finalise on YouTube.
+    download_retry_after TIMESTAMP DEFAULT NULL,
+
     -- Timestamps
     created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,

--- a/congress_videos/youtube_channel_monitor_dag.py
+++ b/congress_videos/youtube_channel_monitor_dag.py
@@ -67,7 +67,7 @@ with DAG(
     params={  # Default to today; lookback range covers yesterday too
         "target_date": today_str,
         "lookback_days": 1,  # Inclusive lookback window: target_date - lookback_days .. target_date
-        "min_hours_since_end": 2,  # Skip videos whose live broadcast ended less than this many hours ago
+        "min_hours_since_end": 12,  # Skip videos whose live broadcast ended less than this many hours ago
         "guard_enabled": True,  # Finished-stream guard: drop not-ready VODs before the branch (+ downloader guard)
         "guard_floor_minutes": 10,  # Cheap pre-probe skip: drop candidates that ended less than this ago
         "max_videos": 20,  # Maximum number of videos to check
@@ -191,7 +191,7 @@ with DAG(
             ti,
             lambda: yt_channel.get_video_details(
                 ti.xcom_pull(key='plenary_videos'),
-                min_hours_since_end=context["params"].get("min_hours_since_end", 2)
+                min_hours_since_end=context["params"].get("min_hours_since_end", 12)
             ),
             'video_details'
         ),
@@ -258,6 +258,38 @@ with DAG(
             'downloaded_videos'
         ),
         trigger_rule='none_failed_min_one_success'  # Run regardless of which branch
+    )
+
+    # Step 3c2b: Post-download container-level integrity gate (ffprobe)
+    # Runs after t3c2 (download_video_from_youtube). Probes each downloaded source
+    # file with ffprobe -v error -i <path>. Clean probe → video proceeds to t_trim.
+    # Failed probe → record_source_integrity_failure() defers the video 12h and the
+    # video is excluded from trim/split until it re-enters filter_unprocessed_videos.
+    # trigger_rule matches t3c2 (none_failed_min_one_success) so it runs regardless
+    # of which subtitle branch was taken.
+    def _check_source_integrity(ti, **context):
+        from congress_videos.modules.database import CongressionalVideoDB
+        downloaded = ti.xcom_pull(key='downloaded_videos')
+        if not downloaded:
+            logging.warning("No downloaded_videos XCom available for integrity check — passthrough.")
+            return {'total_downloaded': 0, 'videos': [], 'failed_video_ids': []}
+        enriched = yt_channel.check_source_video_integrity(downloaded)
+        failed_ids = enriched.get('failed_video_ids', [])
+        if failed_ids:
+            db = CongressionalVideoDB()
+            for video_id in failed_ids:
+                logging.warning("Integrity probe FAILED for %s — deferring 12h.", video_id)
+                db.record_source_integrity_failure(video_id, retry_after_hours=12)
+        return enriched
+
+    t3c2_integrity = PythonOperator(
+        task_id='check_source_integrity',
+        python_callable=lambda ti, **context: xcom_task(
+            ti,
+            lambda: _check_source_integrity(ti, **context),
+            'downloaded_videos'  # re-push enriched dict under the same key
+        ),
+        trigger_rule='none_failed_min_one_success',
     )
 
     # Step 3d: Extract audio from YouTube (only if subtitles not available)
@@ -576,14 +608,15 @@ with DAG(
     t7 >> t8
 
     # After scoring, run VAD chapter silence-trim (both edges) before persisting.
-    # t_trim ALSO waits on t3c2 (download_video_from_youtube): VAD reads the
-    # downloaded mp4 from disk via _find_source_video, so it must NOT start while
-    # the (multi-hour) video is still being written — otherwise ffmpeg hits
-    # "moov atom not found" on the half-written file. When subtitles are available
-    # the chunk/score pipeline races ahead of the parallel video download, so this
-    # join is required. trigger_rule='all_done' keeps VAD best-effort: a download
-    # failure must never block persisting the scored chapters.
-    [t8, t3c2] >> t_trim
+    # t_trim waits on BOTH t8 (scoring) and t3c2_integrity (integrity gate):
+    #   - t3c2 → t3c2_integrity: ffprobe integrity probe runs after download completes.
+    #   - [t8, t3c2_integrity] → t_trim: VAD reads the mp4 from disk so it must not
+    #     start while the file is still being written. The integrity gate sits between
+    #     download and trim so a corrupt source is deferred before reaching VAD.
+    # trigger_rule='all_done' keeps VAD best-effort: an integrity failure on the source
+    # must never block persisting the scored chapters.
+    t3c2 >> t3c2_integrity
+    [t8, t3c2_integrity] >> t_trim
 
     # After trimming the silence, save the chapters to the database
     # Note: session_number and session_date come from t5c and t5d tasks

--- a/tests/congress_videos/modules/test_database_integrity.py
+++ b/tests/congress_videos/modules/test_database_integrity.py
@@ -1,0 +1,212 @@
+"""B1/B3 [RED] Tests for source integrity DB operations.
+
+B1: record_source_integrity_failure — three scenarios (upsert idempotency)
+B3: get_processed_video_ids retry-window exclusion — three scenarios
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fixtures (mirrors test_database.py pattern)
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def set_pg_env(monkeypatch):
+    """Provide minimal env vars so PostgresConnection.__init__ does not raise."""
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "testuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "testpass")
+    monkeypatch.setenv("POSTGRES_SCHEMA", "public")
+
+
+@pytest.fixture
+def db(mocker):
+    """Return a (CongressionalVideoDB, mock_cursor) pair with DB fully mocked."""
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = None
+    mock_cursor.fetchall.return_value = []
+    mock_cursor.__enter__ = MagicMock(return_value=mock_cursor)
+    mock_cursor.__exit__ = MagicMock(return_value=False)
+
+    mock_conn = MagicMock()
+    mock_conn.cursor.return_value = mock_cursor
+    mock_conn.__enter__ = MagicMock(return_value=mock_conn)
+    mock_conn.__exit__ = MagicMock(return_value=False)
+
+    mocker.patch("psycopg2.connect", return_value=mock_conn)
+
+    from congress_videos.modules.database import CongressionalVideoDB
+    instance = CongressionalVideoDB()
+    return instance, mock_cursor
+
+
+# ---------------------------------------------------------------------------
+# B1: record_source_integrity_failure
+# ---------------------------------------------------------------------------
+
+class TestRecordSourceIntegrityFailure:
+
+    def test_method_exists_on_db_class(self, db):
+        """CongressionalVideoDB must have a record_source_integrity_failure method."""
+        instance, _ = db
+        assert hasattr(instance, "record_source_integrity_failure"), (
+            "CongressionalVideoDB must define record_source_integrity_failure()"
+        )
+
+    def test_executes_upsert_sql_for_video(self, db):
+        """The method must execute an INSERT … ON CONFLICT DO UPDATE statement."""
+        instance, mock_cursor = db
+        instance.record_source_integrity_failure("abc123")
+
+        executed_sqls = [c[0][0] for c in mock_cursor.execute.call_args_list]
+        assert any("INSERT" in sql and "ON CONFLICT" in sql for sql in executed_sqls), (
+            "record_source_integrity_failure must use INSERT … ON CONFLICT"
+        )
+
+    def test_sets_download_retry_after_in_upsert(self, db):
+        """The upsert must reference download_retry_after."""
+        instance, mock_cursor = db
+        instance.record_source_integrity_failure("vid_retry")
+
+        executed_sqls = [c[0][0] for c in mock_cursor.execute.call_args_list]
+        assert any("download_retry_after" in sql for sql in executed_sqls), (
+            "record_source_integrity_failure must set download_retry_after"
+        )
+
+    def test_uses_greatest_for_forward_only_semantics(self, db):
+        """Must use GREATEST(...) so retry_after never moves backwards."""
+        instance, mock_cursor = db
+        instance.record_source_integrity_failure("vid_greatest")
+
+        executed_sqls = [c[0][0] for c in mock_cursor.execute.call_args_list]
+        assert any("GREATEST" in sql.upper() for sql in executed_sqls), (
+            "record_source_integrity_failure must use GREATEST() for forward-only semantics"
+        )
+
+    def test_is_processed_not_in_update_set(self, db):
+        """The ON CONFLICT DO UPDATE must NOT reset is_processed to FALSE."""
+        instance, mock_cursor = db
+        instance.record_source_integrity_failure("vid_no_regression")
+
+        executed_sqls = [c[0][0] for c in mock_cursor.execute.call_args_list]
+        # Find the UPDATE SET clause
+        for sql in executed_sqls:
+            if "ON CONFLICT" in sql and "DO UPDATE" in sql:
+                update_set_portion = sql.split("DO UPDATE SET")[1] if "DO UPDATE SET" in sql else ""
+                assert "is_processed" not in update_set_portion, (
+                    "ON CONFLICT DO UPDATE must NOT include is_processed "
+                    "(would regress TRUE→FALSE)"
+                )
+
+    def test_default_retry_hours_is_12(self, db):
+        """Default retry_after_hours must be 12."""
+        import inspect
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        sig = inspect.signature(CongressionalVideoDB.record_source_integrity_failure)
+        param = sig.parameters.get("retry_after_hours")
+        assert param is not None, "must have retry_after_hours parameter"
+        assert param.default == 12, (
+            f"retry_after_hours default must be 12, got {param.default!r}"
+        )
+
+    def test_passes_video_id_and_hours_as_params(self, db):
+        """Must pass video_id and retry hours as SQL parameters (not f-string injection)."""
+        instance, mock_cursor = db
+        instance.record_source_integrity_failure("safe_vid", retry_after_hours=24)
+
+        # Collect all parameter tuples passed to execute
+        all_params = []
+        for c in mock_cursor.execute.call_args_list:
+            args = c[0]
+            if len(args) > 1:
+                all_params.extend(args[1] if isinstance(args[1], (list, tuple)) else [args[1]])
+
+        # video_id must appear in params
+        assert "safe_vid" in all_params, (
+            "video_id must be passed as a SQL parameter"
+        )
+
+
+# ---------------------------------------------------------------------------
+# B3: get_processed_video_ids retry-window exclusion
+# ---------------------------------------------------------------------------
+
+class TestGetProcessedVideoIdsRetryWindow:
+
+    def test_video_in_retry_window_is_in_excluded_set(self, db):
+        """Video with download_retry_after > NOW() and is_processed=FALSE must be
+        returned in the excluded set (treated as deferred / skip-for-now)."""
+        instance, mock_cursor = db
+        # Simulate DB returning the video_id (i.e. it matches the extended WHERE clause)
+        mock_cursor.fetchall.return_value = [{"video_id": "deferred_vid"}]
+
+        result = instance.get_processed_video_ids(["deferred_vid"])
+
+        assert "deferred_vid" in result, (
+            "Video inside retry window must be excluded (returned in processed set)"
+        )
+
+    def test_retry_window_predicate_in_sql(self, db):
+        """The SQL query must include the retry-window predicate."""
+        instance, mock_cursor = db
+        mock_cursor.fetchall.return_value = []
+
+        instance.get_processed_video_ids(["some_vid"])
+
+        executed_sqls = [c[0][0] for c in mock_cursor.execute.call_args_list]
+        assert any("download_retry_after" in sql for sql in executed_sqls), (
+            "get_processed_video_ids must filter by download_retry_after > NOW()"
+        )
+
+    def test_video_past_retry_window_not_in_excluded_set(self, db):
+        """Video with download_retry_after <= NOW() and is_processed=FALSE should NOT
+        be returned by the query (not in the excluded set — it's eligible again)."""
+        instance, mock_cursor = db
+        # DB returns empty (the video does NOT match the WHERE clause)
+        mock_cursor.fetchall.return_value = []
+
+        result = instance.get_processed_video_ids(["eligible_vid"])
+
+        assert "eligible_vid" not in result, (
+            "Video past retry window must NOT be in the excluded set (eligible for re-download)"
+        )
+
+    def test_video_with_null_retry_after_not_in_excluded_set(self, db):
+        """Video with download_retry_after = NULL and is_processed=FALSE should NOT
+        be in the excluded set (no integrity failure recorded)."""
+        instance, mock_cursor = db
+        # DB returns empty (NULL retry_after does not match download_retry_after > NOW())
+        mock_cursor.fetchall.return_value = []
+
+        result = instance.get_processed_video_ids(["null_retry_vid"])
+
+        assert "null_retry_vid" not in result
+
+    def test_empty_input_returns_empty_set_without_query(self, db):
+        """Empty input → empty set, no DB query executed."""
+        instance, mock_cursor = db
+
+        result = instance.get_processed_video_ids([])
+
+        assert result == set()
+        mock_cursor.execute.assert_not_called()
+
+    def test_sql_includes_is_processed_condition(self, db):
+        """The SQL must still include is_processed = TRUE as one branch."""
+        instance, mock_cursor = db
+        mock_cursor.fetchall.return_value = []
+
+        instance.get_processed_video_ids(["check_sql"])
+
+        executed_sqls = [c[0][0] for c in mock_cursor.execute.call_args_list]
+        assert any("is_processed" in sql for sql in executed_sqls), (
+            "get_processed_video_ids must still include is_processed condition"
+        )

--- a/tests/congress_videos/modules/youtube/test_download_integrity.py
+++ b/tests/congress_videos/modules/youtube/test_download_integrity.py
@@ -1,0 +1,240 @@
+"""C1 [RED] Test: subprocess threat matrix for check_source_video_integrity.
+
+Covers all 5 rows from the design threat matrix:
+  Row 1 — Clean source (rc=0, empty stderr) → integrity_ok=True
+  Row 2 — Corrupt source (rc!=0 OR non-empty stderr) → integrity_ok=False
+  Row 3 — Binary missing (FileNotFoundError) → integrity_ok=False (fail-safe)
+  Row 4 — Timeout / hung probe (TimeoutExpired) → integrity_ok=False (fail-safe)
+  Row 5 — Command injection via file_path (no shell=True) → single list element
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _downloaded(file_path: str = "/tmp/video.mp4", video_id: str = "vid001") -> dict:
+    """Build a minimal downloaded_videos dict for testing."""
+    return {
+        "total_downloaded": 1,
+        "videos": [
+            {
+                "video_id": video_id,
+                "file_path": file_path,
+                "file_size_mb": 100.0,
+                "duration": 3600,
+            }
+        ],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Row 1: Clean source
+# ---------------------------------------------------------------------------
+
+class TestRow1CleanSource:
+
+    def test_clean_probe_returns_integrity_ok_true(self):
+        """rc=0, empty stderr → integrity_ok=True for the video entry."""
+        clean_result = MagicMock()
+        clean_result.returncode = 0
+        clean_result.stderr = ""
+
+        with patch("subprocess.run", return_value=clean_result) as mock_run:
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(_downloaded())
+
+        assert result["videos"][0]["integrity_ok"] is True
+        assert result["failed_video_ids"] == []
+
+    def test_clean_probe_no_failed_video_ids(self):
+        """A clean probe must result in an empty failed_video_ids list."""
+        clean_result = MagicMock(returncode=0, stderr="")
+
+        with patch("subprocess.run", return_value=clean_result):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(_downloaded(video_id="clean_vid"))
+
+        assert "clean_vid" not in result["failed_video_ids"]
+
+
+# ---------------------------------------------------------------------------
+# Row 2: Corrupt source
+# ---------------------------------------------------------------------------
+
+class TestRow2CorruptSource:
+
+    def test_nonzero_returncode_returns_integrity_ok_false(self):
+        """rc=1, non-empty stderr → integrity_ok=False."""
+        corrupt_result = MagicMock(returncode=1, stderr="moov atom not found")
+
+        with patch("subprocess.run", return_value=corrupt_result):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(_downloaded(video_id="corrupt_rc1"))
+
+        assert result["videos"][0]["integrity_ok"] is False
+        assert "corrupt_rc1" in result["failed_video_ids"]
+
+    def test_zero_returncode_but_nonempty_stderr_returns_false(self):
+        """rc=0 BUT non-empty stderr ('moov atom not found') → integrity_ok=False."""
+        stderr_only_result = MagicMock(returncode=0, stderr="moov atom not found\n")
+
+        with patch("subprocess.run", return_value=stderr_only_result):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(_downloaded(video_id="corrupt_stderr"))
+
+        assert result["videos"][0]["integrity_ok"] is False
+        assert "corrupt_stderr" in result["failed_video_ids"]
+
+
+# ---------------------------------------------------------------------------
+# Row 3: Binary missing
+# ---------------------------------------------------------------------------
+
+class TestRow3BinaryMissing:
+
+    def test_file_not_found_returns_integrity_ok_false(self):
+        """FileNotFoundError (ffprobe absent) → integrity_ok=False (fail-safe)."""
+        with patch("subprocess.run", side_effect=FileNotFoundError("ffprobe not found")):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(_downloaded(video_id="no_ffprobe"))
+
+        assert result["videos"][0]["integrity_ok"] is False
+        assert "no_ffprobe" in result["failed_video_ids"]
+
+
+# ---------------------------------------------------------------------------
+# Row 4: Timeout / hung probe
+# ---------------------------------------------------------------------------
+
+class TestRow4Timeout:
+
+    def test_timeout_expired_returns_integrity_ok_false(self):
+        """TimeoutExpired → integrity_ok=False (fail-safe, defer 12h)."""
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd="ffprobe", timeout=60),
+        ):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(_downloaded(video_id="timeout_vid"))
+
+        assert result["videos"][0]["integrity_ok"] is False
+        assert "timeout_vid" in result["failed_video_ids"]
+
+
+# ---------------------------------------------------------------------------
+# Row 5: Command injection via file_path (no shell=True)
+# ---------------------------------------------------------------------------
+
+class TestRow5NoShellInjection:
+
+    def test_file_path_with_special_chars_passed_as_single_list_element(self):
+        """file_path containing spaces and special chars must reach subprocess.run
+        as a single list element (not a shell string). shell kwarg must be absent
+        or explicitly False.
+        """
+        dangerous_path = "/tmp/vid o & rm -rf foo.mp4"
+
+        clean_result = MagicMock(returncode=0, stderr="")
+
+        with patch("subprocess.run", return_value=clean_result) as mock_run:
+            from congress_videos.modules.youtube.download import _run_ffprobe
+            _run_ffprobe(dangerous_path)
+
+        call_args, call_kwargs = mock_run.call_args
+        cmd_list = call_args[0]
+
+        # The file path must appear as a single element in the argv list
+        assert dangerous_path in cmd_list, (
+            f"dangerous_path must appear as a single argv element, got: {cmd_list}"
+        )
+        # shell=True must NOT be passed
+        assert call_kwargs.get("shell", False) is False, (
+            "subprocess.run must NOT use shell=True (injection risk)"
+        )
+
+    def test_subprocess_command_structure_is_list_not_string(self):
+        """subprocess.run must receive a list, not a string."""
+        clean_result = MagicMock(returncode=0, stderr="")
+
+        with patch("subprocess.run", return_value=clean_result) as mock_run:
+            from congress_videos.modules.youtube.download import _run_ffprobe
+            _run_ffprobe("/tmp/safe_video.mp4")
+
+        call_args, _ = mock_run.call_args
+        cmd = call_args[0]
+        assert isinstance(cmd, list), (
+            f"subprocess.run must receive a list command, got {type(cmd).__name__}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Integration: check_source_video_integrity return shape
+# ---------------------------------------------------------------------------
+
+class TestCheckSourceVideoIntegrityShape:
+
+    def test_returns_same_structure_with_integrity_ok_and_failed_video_ids(self):
+        """The return dict must pass through all original keys plus add
+        integrity_ok per video and a top-level failed_video_ids list."""
+        clean_result = MagicMock(returncode=0, stderr="")
+
+        with patch("subprocess.run", return_value=clean_result):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            downloaded = _downloaded(file_path="/tmp/v.mp4", video_id="v1")
+            result = check_source_video_integrity(downloaded)
+
+        # Top-level keys preserved
+        assert "total_downloaded" in result
+        assert "failed_video_ids" in result
+        # Per-video integrity_ok key added
+        v = result["videos"][0]
+        assert "integrity_ok" in v
+        assert v["video_id"] == "v1"
+        assert v["file_path"] == "/tmp/v.mp4"
+
+    def test_video_without_file_path_is_marked_failed(self):
+        """A video entry missing file_path must be treated as integrity_ok=False."""
+        downloaded = {
+            "total_downloaded": 0,
+            "videos": [{"video_id": "no_file", "error": "download failed"}],
+        }
+
+        from congress_videos.modules.youtube.download import check_source_video_integrity
+        result = check_source_video_integrity(downloaded)
+
+        assert result["videos"][0]["integrity_ok"] is False
+        assert "no_file" in result["failed_video_ids"]
+
+    def test_multiple_videos_mixed_results(self):
+        """clean video → integrity_ok=True; corrupt video → integrity_ok=False."""
+        def mock_run(cmd, **kwargs):
+            path = cmd[-1]
+            if "good" in path:
+                return MagicMock(returncode=0, stderr="")
+            return MagicMock(returncode=1, stderr="error")
+
+        downloaded = {
+            "total_downloaded": 2,
+            "videos": [
+                {"video_id": "good_vid", "file_path": "/tmp/good.mp4"},
+                {"video_id": "bad_vid", "file_path": "/tmp/bad.mp4"},
+            ],
+        }
+
+        with patch("subprocess.run", side_effect=mock_run):
+            from congress_videos.modules.youtube.download import check_source_video_integrity
+            result = check_source_video_integrity(downloaded)
+
+        by_id = {v["video_id"]: v for v in result["videos"]}
+        assert by_id["good_vid"]["integrity_ok"] is True
+        assert by_id["bad_vid"]["integrity_ok"] is False
+        assert "bad_vid" in result["failed_video_ids"]
+        assert "good_vid" not in result["failed_video_ids"]

--- a/tests/congress_videos/modules/youtube/test_freshness_default.py
+++ b/tests/congress_videos/modules/youtube/test_freshness_default.py
@@ -1,0 +1,196 @@
+"""E1 [RED] Test: min_hours_since_end default is 12 everywhere.
+
+Verifies three sites:
+1. get_video_details() function signature default = 12
+2. DAG param default = 12
+3. DAG callsite .get("min_hours_since_end", N) fallback = 12
+"""
+
+from __future__ import annotations
+
+import inspect
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "fake-api-key")
+
+
+class TestGetVideoDetailsFunctionSignatureDefault:
+
+    def test_min_hours_since_end_default_is_12(self):
+        """get_video_details() must have min_hours_since_end default = 12."""
+        from congress_videos.modules.youtube.youtube_channel import get_video_details
+
+        sig = inspect.signature(get_video_details)
+        param = sig.parameters.get("min_hours_since_end")
+        assert param is not None, "get_video_details must have min_hours_since_end parameter"
+        assert param.default == 12, (
+            f"min_hours_since_end default must be 12, got {param.default!r}"
+        )
+
+    def test_video_ended_3h_ago_is_excluded_with_default(self):
+        """With the default 12h margin, a video that ended 3h ago is skipped."""
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import MagicMock, patch
+
+        video_id = "EXCLUDED_3H"
+        end_time = (datetime.now(timezone.utc) - timedelta(hours=3)).isoformat().replace("+00:00", "Z")
+
+        api_response = {
+            "items": [
+                {
+                    "snippet": {"title": "Test"},
+                    "contentDetails": {"duration": "PT3H"},
+                    "liveStreamingDetails": {
+                        "actualStartTime": "2025-01-15T08:00:00Z",
+                        "actualEndTime": end_time,
+                    },
+                }
+            ]
+        }
+        mock_yt = MagicMock()
+        mock_yt.videos.return_value.list.return_value.execute.return_value = api_response
+
+        plenary = {
+            "total_matches": 1,
+            "videos": [{"video_id": video_id, "title": "T", "url": "u",
+                        "published_at": "2025-01-15T08:00:00Z",
+                        "is_live": False, "is_upcoming": False}],
+        }
+
+        with patch("congress_videos.modules.youtube.youtube_channel.build", return_value=mock_yt):
+            from congress_videos.modules.youtube.youtube_channel import get_video_details
+            result = get_video_details(plenary)  # no explicit min_hours_since_end — use default
+
+        assert result["total_videos"] == 0, (
+            "Video ended 3h ago must be excluded with the 12h default"
+        )
+
+    def test_video_ended_13h_ago_is_included_with_default(self):
+        """With the default 12h margin, a video that ended 13h ago is included."""
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import MagicMock, patch
+
+        video_id = "INCLUDED_13H"
+        end_time = (datetime.now(timezone.utc) - timedelta(hours=13)).isoformat().replace("+00:00", "Z")
+
+        api_response = {
+            "items": [
+                {
+                    "snippet": {"title": "Session 13h ago"},
+                    "contentDetails": {"duration": "PT3H"},
+                    "liveStreamingDetails": {
+                        "actualStartTime": "2025-01-14T06:00:00Z",
+                        "actualEndTime": end_time,
+                    },
+                }
+            ]
+        }
+        mock_yt = MagicMock()
+        mock_yt.videos.return_value.list.return_value.execute.return_value = api_response
+
+        plenary = {
+            "total_matches": 1,
+            "videos": [{"video_id": video_id, "title": "T", "url": "u",
+                        "published_at": "2025-01-14T06:00:00Z",
+                        "is_live": False, "is_upcoming": False}],
+        }
+
+        with patch("congress_videos.modules.youtube.youtube_channel.build", return_value=mock_yt):
+            from congress_videos.modules.youtube.youtube_channel import get_video_details
+            result = get_video_details(plenary)  # default = 12h
+
+        assert result["total_videos"] == 1, (
+            "Video ended 13h ago must be included with the 12h default"
+        )
+
+    def test_custom_override_of_6_still_honored(self):
+        """When min_hours_since_end=6, a video that ended 7h ago is eligible."""
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import MagicMock, patch
+
+        video_id = "CUSTOM_7H"
+        end_time = (datetime.now(timezone.utc) - timedelta(hours=7)).isoformat().replace("+00:00", "Z")
+
+        api_response = {
+            "items": [
+                {
+                    "snippet": {"title": "Session 7h ago"},
+                    "contentDetails": {"duration": "PT3H"},
+                    "liveStreamingDetails": {
+                        "actualStartTime": "2025-01-15T00:00:00Z",
+                        "actualEndTime": end_time,
+                    },
+                }
+            ]
+        }
+        mock_yt = MagicMock()
+        mock_yt.videos.return_value.list.return_value.execute.return_value = api_response
+
+        plenary = {
+            "total_matches": 1,
+            "videos": [{"video_id": video_id, "title": "T", "url": "u",
+                        "published_at": "2025-01-15T00:00:00Z",
+                        "is_live": False, "is_upcoming": False}],
+        }
+
+        with patch("congress_videos.modules.youtube.youtube_channel.build", return_value=mock_yt):
+            from congress_videos.modules.youtube.youtube_channel import get_video_details
+            result = get_video_details(plenary, min_hours_since_end=6)
+
+        assert result["total_videos"] == 1, (
+            "Video ended 7h ago must be included when min_hours_since_end=6"
+        )
+
+
+class TestDAGFreshnessDefault:
+
+    def test_dag_param_default_is_12(self):
+        """The DAG min_hours_since_end param default must be 12."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        assert int(dag.params["min_hours_since_end"]) == 12, (
+            f"DAG param min_hours_since_end must default to 12, "
+            f"got {dag.params['min_hours_since_end']!r}"
+        )
+
+    def test_dag_callsite_fallback_is_12(self):
+        """The .get('min_hours_since_end', N) fallback in t3a must be 12.
+
+        We verify this by calling the python_callable with a context where
+        min_hours_since_end is absent from params, and confirming get_video_details
+        is called with min_hours_since_end=12 (not 2).
+        """
+        import importlib, sys
+        # Ensure the DAG module is freshly loaded
+        for mod in list(sys.modules.keys()):
+            if "youtube_channel_monitor_dag" in mod:
+                del sys.modules[mod]
+
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t3a = tasks_by_id["get_video_details"]
+
+        captured = {}
+
+        def fake_get_video_details(plenary_videos, min_hours_since_end):
+            captured["min_hours_since_end"] = min_hours_since_end
+            return {"total_videos": 0, "videos": []}
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = {"total_videos": 0, "videos": []}
+
+        with patch(
+            "congress_videos.modules.youtube.youtube_channel.get_video_details",
+            side_effect=fake_get_video_details,
+        ), patch("utils.airflow_helpers.xcom_task", side_effect=lambda ti, fn, key: fn()):
+            # params dict WITHOUT min_hours_since_end → .get() must return 12
+            t3a.python_callable(ti, params={})
+
+        assert captured.get("min_hours_since_end") == 12, (
+            f"t3a callsite fallback must be 12, got {captured.get('min_hours_since_end')!r}"
+        )

--- a/tests/congress_videos/modules/youtube/test_youtube_channel_title.py
+++ b/tests/congress_videos/modules/youtube/test_youtube_channel_title.py
@@ -1,0 +1,117 @@
+"""D1 [RED] Test: get_video_details propagates the real API snippet.title.
+
+Issue #25: in test mode the mock dict spread (**video) was setting 'title'
+from the placeholder in create_test_video_data(), and that placeholder
+overwrote the real API title via ON CONFLICT upsert.
+
+The fix is to explicitly set 'title': video_details['snippet']['title'] in
+the enriched_video dict so the API value always wins.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_api_key(monkeypatch):
+    monkeypatch.setenv("YOUTUBE_API_KEY", "fake-api-key")
+
+
+def _make_api_response(video_id: str, api_title: str):
+    """Build a minimal youtube.videos().list() response."""
+    return {
+        "items": [
+            {
+                "snippet": {
+                    "title": api_title,
+                },
+                "contentDetails": {
+                    "duration": "PT2H30M15S",
+                },
+                "liveStreamingDetails": {
+                    "actualStartTime": "2025-01-15T08:00:00Z",
+                    "actualEndTime": "2025-01-15T20:00:00Z",
+                },
+            }
+        ]
+    }
+
+
+def _plenary_videos(video_id: str, mock_title: str):
+    """Input dict as produced by create_test_video_data / filter_plenary_session_videos."""
+    return {
+        "total_matches": 1,
+        "videos": [
+            {
+                "video_id": video_id,
+                "title": mock_title,         # placeholder / mock title
+                "url": f"https://www.youtube.com/watch?v={video_id}",
+                "published_at": "2025-01-15T08:00:00Z",
+                "is_live": False,
+                "is_upcoming": False,
+            }
+        ],
+    }
+
+
+class TestGetVideoDetailsPropagatesRealTitle:
+
+    def test_enriched_video_contains_real_api_title(self):
+        """The 'title' key in the enriched video dict must come from snippet.title,
+        NOT from the placeholder title in the input mock dict."""
+        video_id = "ZBU0bVpYXM4"
+        mock_placeholder_title = "Test Video - Sesión Plenaria"
+        real_api_title = "Sesión Plenaria 15 enero 2025"
+
+        api_response = _make_api_response(video_id, real_api_title)
+        mock_yt_service = MagicMock()
+        mock_yt_service.videos.return_value.list.return_value.execute.return_value = api_response
+
+        with patch(
+            "congress_videos.modules.youtube.youtube_channel.build",
+            return_value=mock_yt_service,
+        ):
+            from congress_videos.modules.youtube.youtube_channel import get_video_details
+
+            result = get_video_details(
+                _plenary_videos(video_id, mock_placeholder_title),
+                min_hours_since_end=0,
+            )
+
+        assert result["total_videos"] == 1
+        enriched = result["videos"][0]
+        # The real API title must win over the placeholder
+        assert enriched["title"] == real_api_title, (
+            f"Expected real API title '{real_api_title}', got '{enriched['title']}'"
+        )
+
+    def test_placeholder_title_does_not_appear_when_api_returns_different_title(self):
+        """Regression: the old spread (**video) allowed placeholder to propagate."""
+        video_id = "ABCDEFGHIJK"
+        mock_placeholder_title = "Test Video - Sesión Plenaria"
+        real_api_title = "Sesión Extraordinaria 20 febrero 2025"
+
+        api_response = _make_api_response(video_id, real_api_title)
+        mock_yt_service = MagicMock()
+        mock_yt_service.videos.return_value.list.return_value.execute.return_value = api_response
+
+        with patch(
+            "congress_videos.modules.youtube.youtube_channel.build",
+            return_value=mock_yt_service,
+        ):
+            from congress_videos.modules.youtube.youtube_channel import get_video_details
+
+            result = get_video_details(
+                _plenary_videos(video_id, mock_placeholder_title),
+                min_hours_since_end=0,
+            )
+
+        enriched = result["videos"][0]
+        assert enriched["title"] != mock_placeholder_title, (
+            "Placeholder title must NOT appear in the enriched video dict"
+        )
+        assert enriched["title"] == real_api_title

--- a/tests/congress_videos/sql/test_migration_013.py
+++ b/tests/congress_videos/sql/test_migration_013.py
@@ -1,0 +1,76 @@
+"""A1 [RED] Test: migration 013 column presence.
+
+Tests that the migration SQL file contains the correct column definition.
+We parse the SQL directly rather than spinning up a real DB, which keeps
+the test fast and infrastructure-free while still verifying the intended
+schema change.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).parent.parent.parent.parent
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "013_add_source_integrity_tracking.sql"
+)
+
+
+class TestMigration013ColumnPresence:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), (
+            f"Migration file not found: {MIGRATION_PATH}"
+        )
+
+    def test_migration_adds_download_retry_after_column(self):
+        """Migration must add download_retry_after TIMESTAMP DEFAULT NULL."""
+        sql = MIGRATION_PATH.read_text(encoding="utf-8")
+        # The ALTER TABLE line must include the column name with TIMESTAMP type
+        assert "download_retry_after" in sql, (
+            "Migration must define the download_retry_after column"
+        )
+        assert "TIMESTAMP" in sql.upper(), (
+            "download_retry_after must be of type TIMESTAMP"
+        )
+
+    def test_migration_uses_add_column_if_not_exists(self):
+        """Migration must be idempotent (ADD COLUMN IF NOT EXISTS)."""
+        sql = MIGRATION_PATH.read_text(encoding="utf-8").upper()
+        assert "ADD COLUMN IF NOT EXISTS" in sql, (
+            "Migration must use ADD COLUMN IF NOT EXISTS for idempotency"
+        )
+
+    def test_migration_targets_youtube_source_videos(self):
+        """Migration must target the youtube_source_videos table."""
+        sql = MIGRATION_PATH.read_text(encoding="utf-8")
+        assert "youtube_source_videos" in sql, (
+            "Migration must ALTER TABLE youtube_source_videos"
+        )
+
+    def test_migration_has_search_path_header(self):
+        """Migration must use SET search_path (runner-driven, unqualified names)."""
+        sql = MIGRATION_PATH.read_text(encoding="utf-8")
+        assert "search_path" in sql.lower(), (
+            "Migration must include SET search_path directive"
+        )
+
+    def test_migration_default_is_null(self):
+        """download_retry_after column must DEFAULT to NULL."""
+        sql = MIGRATION_PATH.read_text(encoding="utf-8").upper()
+        # Check that DEFAULT NULL appears near the column definition
+        assert "DEFAULT NULL" in sql, (
+            "download_retry_after must DEFAULT NULL"
+        )
+
+    def test_migration_has_no_comment_on_column(self):
+        """Migration must NOT include COMMENT ON COLUMN (chapters convention)."""
+        sql = MIGRATION_PATH.read_text(encoding="utf-8").upper()
+        assert "COMMENT ON COLUMN" not in sql, (
+            "Migration must NOT use COMMENT ON COLUMN (matches 011 chapters convention)"
+        )

--- a/tests/congress_videos/test_integrity_dag_wiring.py
+++ b/tests/congress_videos/test_integrity_dag_wiring.py
@@ -1,0 +1,91 @@
+"""F1 [RED] Test: DAG task dependency graph for integrity gate.
+
+Scenarios (from spec — DAG Task Wiring for Integrity Gate):
+- t3c2_integrity is a direct downstream of t3c2
+- t3c2_integrity is a direct upstream of t_trim
+- t3c2 is NOT a direct upstream of t_trim
+- DAG loads without import errors (catches missing __init__.py registration from C3)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestIntegrityTaskExistsInDAG:
+
+    def test_dag_loads_without_import_errors(self):
+        """DAG must load cleanly — catches missing __init__ registration for
+        check_source_video_integrity (task C3 is a prerequisite)."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        assert dag is not None
+        assert dag.dag_id == "congress_youtube_channel_monitor"
+
+    def test_check_source_integrity_task_exists(self):
+        """A task with task_id='check_source_integrity' must be present in the DAG."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        task_ids = {t.task_id for t in dag.tasks}
+        assert "check_source_integrity" in task_ids, (
+            "DAG must contain a 'check_source_integrity' task (t3c2_integrity)"
+        )
+
+
+class TestIntegrityTaskTopology:
+
+    def test_t3c2_integrity_is_direct_downstream_of_t3c2(self):
+        """check_source_integrity must be a direct downstream of download_video_from_youtube."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+
+        t3c2 = tasks_by_id["download_video_from_youtube"]
+        t3c2_integrity = tasks_by_id["check_source_integrity"]
+
+        direct_downstream_ids = {t.task_id for t in t3c2.downstream_list}
+        assert t3c2_integrity.task_id in direct_downstream_ids, (
+            "check_source_integrity must be a direct downstream of download_video_from_youtube"
+        )
+
+    def test_t3c2_integrity_is_direct_upstream_of_t_trim(self):
+        """check_source_integrity must be a direct upstream of trim_chapter_silence."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+
+        t3c2_integrity = tasks_by_id["check_source_integrity"]
+        t_trim = tasks_by_id["trim_chapter_silence"]
+
+        direct_upstream_of_trim = {t.task_id for t in t_trim.upstream_list}
+        assert t3c2_integrity.task_id in direct_upstream_of_trim, (
+            "check_source_integrity must be a direct upstream of trim_chapter_silence"
+        )
+
+    def test_t3c2_is_not_direct_upstream_of_t_trim(self):
+        """download_video_from_youtube must NOT be a direct upstream of trim_chapter_silence
+        (the integrity gate now sits between them)."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+
+        t3c2 = tasks_by_id["download_video_from_youtube"]
+        t_trim = tasks_by_id["trim_chapter_silence"]
+
+        direct_upstream_of_trim = {t.task_id for t in t_trim.upstream_list}
+        assert t3c2.task_id not in direct_upstream_of_trim, (
+            "download_video_from_youtube must NOT be a direct upstream of trim_chapter_silence "
+            "(check_source_integrity gates that edge)"
+        )
+
+    def test_t_trim_trigger_rule_is_all_done(self):
+        """trim_chapter_silence must keep trigger_rule='all_done' (best-effort VAD)."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        t_trim = dag.get_task("trim_chapter_silence")
+        assert str(t_trim.trigger_rule) == "all_done", (
+            f"t_trim trigger_rule must be 'all_done', got {t_trim.trigger_rule!r}"
+        )
+
+    def test_integrity_task_trigger_rule_is_none_failed_min_one_success(self):
+        """check_source_integrity must use trigger_rule='none_failed_min_one_success'."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        t3c2_integrity = dag.get_task("check_source_integrity")
+        assert str(t3c2_integrity.trigger_rule) == "none_failed_min_one_success", (
+            f"check_source_integrity trigger_rule must be 'none_failed_min_one_success', "
+            f"got {t3c2_integrity.trigger_rule!r}"
+        )

--- a/tests/congress_videos/test_youtube_channel_monitor_dag.py
+++ b/tests/congress_videos/test_youtube_channel_monitor_dag.py
@@ -154,9 +154,10 @@ class TestFilterFinishedStreamsTopology:
         assert bool(params["guard_enabled"]) is True
         assert int(params["guard_floor_minutes"]) == 10
 
-    def test_min_hours_since_end_param_unchanged(self):
+    def test_min_hours_since_end_param_default_is_12(self):
+        """min_hours_since_end raised from 2 to 12 (fix-video-integrity #24)."""
         from congress_videos.youtube_channel_monitor_dag import dag
-        assert int(dag.params["min_hours_since_end"]) == 2
+        assert int(dag.params["min_hours_since_end"]) == 12
 
     def test_empty_guard_result_routes_to_no_plenary_sessions(self):
         """When the guard drops every candidate (total_matches == 0), the


### PR DESCRIPTION
## Summary

Fixes **#24** and **#25** as one cohesive change to the congress-videos pipeline.

### #24 — Corrupted AV1 sources silently uploaded, YouTube "processing abandoned"
- **Freshness margin 2h → 12h** at all three sites (DAG param, callsite fallback, `get_video_details` default) so long (7–10h) plenary VODs finish finalizing before download.
- **Fast integrity gate** `check_source_video_integrity` / `_run_ffprobe` in `download.py` — `ffprobe -v error -i <src>` (headers/index only, no shell, timeout). Fail-safe: `FileNotFoundError` / `TimeoutExpired` / any exception → treat as failure and defer.
- **Deferred re-download** via new `download_retry_after` column (migration `013` + dev/prod base schemas). `record_source_integrity_failure` early-upserts with forward-only `GREATEST(...)`, never regressing `is_processed`. `get_processed_video_ids` skips videos still inside their retry window (delay, not permanent skip).
- **DAG wiring**: new `t3c2_integrity` task after download; `[t8, t3c2] >> t_trim` rewired to `[t8, t3c2_integrity] >> t_trim` (VAD keeps `all_done` best-effort semantics).

> Note: chapter splitting runs in a **separate** DAG (`youtube_upload_dag_v2`, driven by `uploadable_chapters`). The real gate against splitting a corrupt source is the retry-aware `filter_unprocessed_videos` on the next run — a deferred video is simply not re-selected until its 12h window elapses.

### #25 — Test-mode overwrote real `video_title` with placeholder
- `get_video_details` now sets `title` from the real `snippet.title`, so the API title wins in both production and test paths. The `create_test_video_data` placeholder can no longer reach `save_youtube_chapters_to_db`.

## Test plan
- [x] `uv run pytest` — **1235 passed / 1 skipped** (baseline +50), coverage **83.77%**
- [x] Strict TDD: 50 new tests incl. 5-row subprocess threat matrix (no-shell-injection covered)
- [x] DAG parses cleanly (`__init__.py` lazy-import registration verified)
- [x] Docker e2e smoke (`scripts/test-airflow-e2e.sh`) — **PASS**, zero DAG import errors
- [ ] Apply migration 013 to dev/prod DBs before deploy

## Scope
~213 lines production + ~937 lines tests (strict TDD). Single cohesive bugfix.