### PR TITLE
fix(congress_participants): repoint ingestion to opendataExport portlet (dead 403 directory endpoint)

### DIFF
--- a/congress_videos/config/constants.py
+++ b/congress_videos/config/constants.py
@@ -44,11 +44,23 @@ VAD_SAMPLE_RATE = 16000  # mono WAV sample rate fed to the VAD backend
 VAD_MIN_CHAPTER_SECS = 5.0  # never trim an edge so far the chapter is shorter than this
 
 # -------------------------
-# Congress Participants Sync (Wikidata enrichment)
+# Congress Participants Sync (opendataExport portlet + Wikidata enrichment)
 # -------------------------
-# Index page listing DiputadosActivos__{timestamp}.json downloads; overridden by env
-# var CONGRESO_DEPUTIES_URL when set.
-CONGRESO_DEPUTIES_INDEX = "https://www.congreso.es/webpublica/opendata/diputados/"
+# Liferay opendataExport portlet — single POST replaces the old directory-scrape.
+# Use CONGRESO_DEPUTIES_URL env var to override with a static-file URL (escape hatch).
+CONGRESO_DEPUTIES_PORTLET_URL = (
+    "https://www.congreso.es/es/busqueda-de-diputados"
+    "?p_p_id=diputadomodule"
+    "&p_p_lifecycle=2"
+    "&p_p_state=normal"
+    "&p_p_mode=view"
+    "&p_p_resource_id=opendataExport"
+    "&p_p_cacheability=cacheLevelPage"
+)
+# Browser-grade User-Agent required by the portlet WAF; do not use the requests default.
+CONGRESO_BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64; rv:128.0) Gecko/20100101 Firefox/128.0"
+)
 WIKIDATA_SPARQL_URL = "https://query.wikidata.org/sparql"
 WIKIDATA_POSITION_QID = "Q18171345"  # member of the Congress of Deputies
 WIKIDATA_FUZZY_THRESHOLD = 0.90

--- a/congress_videos/modules/participants_db.py
+++ b/congress_videos/modules/participants_db.py
@@ -32,9 +32,19 @@ class CongressParticipantsDB:
         Insert or update a batch of ParticipantRecord rows.
 
         Uses ON CONFLICT (normalized_name) DO UPDATE so re-running the weekly
-        ingestion is idempotent. COALESCE preserves any previously enriched
-        photo_url: ingestion always sends photo_url=None, so without COALESCE
-        every run would blank out photos set by the enrichment step.
+        ingestion is idempotent.
+
+        COALESCE ordering rationale:
+        - ``photo_url`` uses **table-first** COALESCE
+          ``COALESCE(congress_participants.photo_url, EXCLUDED.photo_url)``:
+          the stored enriched value wins over the always-None ingest value.
+        - ``group_entry_date`` uses **EXCLUDED-first** COALESCE
+          ``COALESCE(EXCLUDED.group_entry_date, congress_participants.group_entry_date)``:
+          ingestion now always sends ``None`` because the opendataExport portlet
+          omits this field.  EXCLUDED-first means a fresh real value from a
+          future API run will still win when present; an incoming ``None``
+          preserves whatever was previously stored, avoiding silent data loss.
+          The asymmetry is deliberate — do not reorder these COALESCEs.
 
         Args:
             records: List of ParticipantRecord dicts from parse_deputies().
@@ -59,7 +69,7 @@ class CongressParticipantsDB:
                 biography            = EXCLUDED.biography,
                 full_membership_date = EXCLUDED.full_membership_date,
                 start_date           = EXCLUDED.start_date,
-                group_entry_date     = EXCLUDED.group_entry_date,
+                group_entry_date     = COALESCE(EXCLUDED.group_entry_date, congress_participants.group_entry_date),
                 photo_url            = COALESCE(congress_participants.photo_url, EXCLUDED.photo_url),
                 updated_at           = NOW()
         """

--- a/congress_videos/modules/participants_ingestion.py
+++ b/congress_videos/modules/participants_ingestion.py
@@ -1,9 +1,9 @@
 """
 Ingestion of active Spanish Congress of Deputies members.
 
-Downloads the official ``DiputadosActivos__{timestamp}.json`` feed from
-congreso.es, normalizes member names into a stable upsert key, and parses
-each entry into a JSON-serializable participant record.
+Downloads the official active-deputies JSON feed from congreso.es via a POST
+to the Liferay opendataExport portlet, normalizes member names into a stable
+upsert key, and parses each entry into a JSON-serializable participant record.
 """
 
 from __future__ import annotations
@@ -14,20 +14,37 @@ import re
 import unicodedata
 from datetime import datetime
 from typing import Any, TypedDict
-from urllib.parse import urljoin
 
 import requests
-from bs4 import BeautifulSoup
 
-from congress_videos.config.constants import CONGRESO_DEPUTIES_INDEX
+from congress_videos.config.constants import (
+    CONGRESO_BROWSER_USER_AGENT,
+    CONGRESO_DEPUTIES_PORTLET_URL,
+    LEGISLATURE_ID,
+)
 
 logger = logging.getLogger(__name__)
 
 _DEPUTIES_URL_ENV_VAR = "CONGRESO_DEPUTIES_URL"
-_INDEX_REQUEST_TIMEOUT = 30
-_DOWNLOAD_LINK_PATTERN = re.compile(r"DiputadosActivos__.*\.json", re.IGNORECASE)
+_REQUEST_TIMEOUT = 30
 _SOURCE_DATE_FORMAT = "%d/%m/%Y"
 _OUTPUT_DATE_FORMAT = "%Y-%m-%d"
+
+# Liferay portlet form-field template.  fileType MUST be lowercase "json";
+# "JSON" causes a 400 response from the portlet.
+_PORTLET_FORM_FIELDS: dict[str, Any] = {
+    "_diputadomodule_idLegislatura": LEGISLATURE_ID,
+    "_diputadomodule_filtroProvincias": "[]",
+    "_diputadomodule_fileIndex": 0,
+    "_diputadomodule_fileType": "json",
+    "_diputadomodule_genero": "",
+    "_diputadomodule_grupo": "",
+    "_diputadomodule_tipo": "",
+    "_diputadomodule_nombre": "",
+    "_diputadomodule_apellidos": "",
+    "_diputadomodule_formacion": "",
+    "_diputadomodule_nombreCircunscripcion": "",
+}
 
 
 class ParticipantRecord(TypedDict):
@@ -49,7 +66,7 @@ def normalize_member_name(name: str) -> str:
     """
     Build the stable, accent-insensitive upsert key for a deputy name.
 
-    Steps: strip -> reorder "surnames, given" (official NOMBRE order) ->
+    Steps: strip -> reorder "surnames, given" (official Nombre order) ->
     strip accents (NFKD, drop combining marks) -> casefold -> non-alphanumeric
     characters (including hyphens in compound surnames) become spaces ->
     collapse whitespace.
@@ -67,48 +84,59 @@ def normalize_member_name(name: str) -> str:
     return re.sub(r"\s+", " ", spaced).strip()
 
 
-def resolve_download_url() -> str:
-    """
-    Resolve the current ``DiputadosActivos__{timestamp}.json`` download URL.
-
-    ``CONGRESO_DEPUTIES_URL`` env var overrides discovery entirely (escape
-    hatch for when the index page HTML structure changes). Otherwise scrapes
-    ``CONGRESO_DEPUTIES_INDEX`` for the matching link.
-    """
-    override = os.environ.get(_DEPUTIES_URL_ENV_VAR)
-    if override:
-        return override
-
-    response = requests.get(CONGRESO_DEPUTIES_INDEX, timeout=_INDEX_REQUEST_TIMEOUT)
-    response.raise_for_status()
-
-    soup = BeautifulSoup(response.content, "html.parser")
-    for anchor in soup.find_all("a", href=True):
-        href = anchor["href"]
-        if _DOWNLOAD_LINK_PATTERN.search(href):
-            return urljoin(CONGRESO_DEPUTIES_INDEX, href)
-
-    raise ValueError(
-        f"Could not find a DiputadosActivos download link on {CONGRESO_DEPUTIES_INDEX}"
-    )
-
-
 def fetch_active_deputies() -> list[dict[str, Any]]:
     """
     Download the official active-deputies JSON feed.
 
-    HTTP errors propagate via ``raise_for_status`` and malformed JSON raises
-    ``ValueError`` — ingestion failures must fail the task visibly, never
-    silently proceed with stale data.
+    Default path: POST to the Liferay opendataExport portlet with a
+    browser-grade User-Agent and the required form fields.  The response is a
+    bare JSON array (~350 records) with TitleCase keys.
+
+    Env-override path: when CONGRESO_DEPUTIES_URL is set, perform a GET to
+    that URL instead (escape hatch for static-file local testing).
+
+    Error handling:
+    - HTTP 403: raises RuntimeError with a WAF-diagnostic message (URL +
+      response body snippet) so an endpoint change or WAF block is
+      distinguishable from a transient outage.
+    - Other HTTP errors: propagate via raise_for_status() as requests.HTTPError.
+    - Malformed JSON: raises ValueError with the request URL.
+    - Empty payload: raises ValueError (zero active deputies is anomalous).
     """
-    url = resolve_download_url()
-    response = requests.get(url, timeout=_INDEX_REQUEST_TIMEOUT)
+    override = os.environ.get(_DEPUTIES_URL_ENV_VAR)
+
+    if override:
+        response = requests.get(override, timeout=_REQUEST_TIMEOUT)
+        url = override
+    else:
+        response = requests.post(
+            CONGRESO_DEPUTIES_PORTLET_URL,
+            data=dict(_PORTLET_FORM_FIELDS),
+            headers={"User-Agent": CONGRESO_BROWSER_USER_AGENT},
+            timeout=_REQUEST_TIMEOUT,
+        )
+        url = CONGRESO_DEPUTIES_PORTLET_URL
+
+    if response.status_code == 403:
+        snippet = (response.text or "")[:500]
+        raise RuntimeError(
+            f"congreso.es returned 403 for {url} — likely WAF block or portlet endpoint"
+            f" change (not a transient outage). Response body snippet: {snippet!r}"
+        )
+
     response.raise_for_status()
 
     try:
-        return response.json()
+        payload = response.json()
     except ValueError as exc:
         raise ValueError(f"Malformed JSON response from {url}") from exc
+
+    if not payload:
+        raise ValueError(
+            f"Empty deputies payload from {url} — no active deputies is anomalous"
+        )
+
+    return payload
 
 
 def _parse_source_date(value: str | None) -> str | None:
@@ -124,14 +152,22 @@ def _parse_source_date(value: str | None) -> str | None:
 
 def parse_deputies(raw: list[dict[str, Any]]) -> list[ParticipantRecord]:
     """
-    Parse raw ``DiputadosActivos`` entries into ``ParticipantRecord`` dicts.
+    Parse raw opendataExport entries into ``ParticipantRecord`` dicts.
+
+    Expects TitleCase keys from the opendataExport portlet response:
+    ``Nombre``, ``Formacion``, ``GrupoParlamentario``, ``Circunscripcion``,
+    ``Biografia``, ``FechaAlta``, ``FechaCondicionPlena``.
+
+    ``group_entry_date`` is always ``None`` — the field
+    ``FECHAALTAENGRUPOPARLAMENTARIO`` is absent from the opendataExport
+    response.
 
     An empty payload raises ``ValueError`` — zero active deputies is
     anomalous and warrants alerting rather than silently upserting nothing.
-    A record missing ``NOMBRE`` is skipped and logged rather than aborting
+    A record missing ``Nombre`` is skipped and logged rather than aborting
     the whole batch — one malformed upstream entry should not block every
     other deputy from syncing. If every entry ends up skipped (e.g. an
-    upstream schema change dropping NOMBRE from every record), that is
+    upstream schema change dropping Nombre from every record), that is
     treated the same as an empty payload and raises ``ValueError`` — the
     batch must never silently degrade to zero parsed deputies.
     Duplicate normalized names within the batch are logged (first
@@ -144,9 +180,9 @@ def parse_deputies(raw: list[dict[str, Any]]) -> list[ParticipantRecord]:
     records: list[ParticipantRecord] = []
     seen_normalized: set[str] = set()
     for entry in raw:
-        display_name = entry.get("NOMBRE")
+        display_name = entry.get("Nombre")
         if not display_name:
-            logger.warning("Skipping deputy entry with missing NOMBRE: %r", entry)
+            logger.warning("Skipping deputy entry with missing Nombre: %r", entry)
             continue
 
         normalized_name = normalize_member_name(display_name)
@@ -162,20 +198,20 @@ def parse_deputies(raw: list[dict[str, Any]]) -> list[ParticipantRecord]:
             ParticipantRecord(
                 normalized_name=normalized_name,
                 display_name=display_name,
-                party=entry.get("FORMACIONELECTORAL"),
-                parliamentary_group=entry.get("GRUPOPARLAMENTARIO"),
-                constituency=entry.get("CIRCUNSCRIPCION"),
-                biography=entry.get("BIOGRAFIA"),
-                full_membership_date=_parse_source_date(entry.get("FECHACONDICIONPLENA")),
-                start_date=_parse_source_date(entry.get("FECHAALTA")),
-                group_entry_date=_parse_source_date(entry.get("FECHAALTAENGRUPOPARLAMENTARIO")),
+                party=entry.get("Formacion"),
+                parliamentary_group=entry.get("GrupoParlamentario"),
+                constituency=entry.get("Circunscripcion"),
+                biography=entry.get("Biografia"),
+                full_membership_date=_parse_source_date(entry.get("FechaCondicionPlena")),
+                start_date=_parse_source_date(entry.get("FechaAlta")),
+                group_entry_date=None,
                 photo_url=None,
             )
         )
 
     if not records:
         raise ValueError(
-            "All deputy entries were skipped (missing NOMBRE) — "
+            "All deputy entries were skipped (missing Nombre) — "
             "possible upstream schema change, treating as anomalous"
         )
 

--- a/tests/congress_videos/modules/test_participants_db.py
+++ b/tests/congress_videos/modules/test_participants_db.py
@@ -148,6 +148,20 @@ class TestUpsertBatch:
         assert "Smith, John" in params
         assert "PartyB" in params
 
+    def test_sql_preserves_group_entry_date_via_coalesce_excluded_first(self, db_fixture):
+        """SQL uses EXCLUDED-first COALESCE for group_entry_date.
+
+        Incoming None must not wipe out a previously stored group_entry_date.
+        EXCLUDED-first order means a fresh real value wins over stored; None
+        incoming falls through to the stored value.
+        """
+        instance, _conn, mock_cursor = db_fixture
+
+        instance.upsert_batch([_make_record()])
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "COALESCE(EXCLUDED.group_entry_date, congress_participants.group_entry_date)" in sql
+
 
 # ===========================================================================
 # T-03 RED: lookup functions

--- a/tests/congress_videos/modules/test_participants_ingestion.py
+++ b/tests/congress_videos/modules/test_participants_ingestion.py
@@ -204,6 +204,8 @@ class TestFetchActiveDeputies:
         assert "403" in message
         assert "congreso.es" in message or CONGRESO_DEPUTIES_PORTLET_URL.split("?")[0] in message
         assert "WAF" in message or "endpoint change" in message
+        # S-ERR-01(c): the response body snippet must be surfaced for diagnosis
+        assert "access denied by security policy" in message
         # Confirm raise_for_status was never the trigger (RuntimeError not HTTPError)
         assert exc_info.type is RuntimeError
 

--- a/tests/congress_videos/modules/test_participants_ingestion.py
+++ b/tests/congress_videos/modules/test_participants_ingestion.py
@@ -7,12 +7,10 @@ from pathlib import Path
 
 import pytest
 
-from congress_videos.config.constants import CONGRESO_DEPUTIES_INDEX
 from congress_videos.modules.participants_ingestion import (
     fetch_active_deputies,
     normalize_member_name,
     parse_deputies,
-    resolve_download_url,
 )
 
 FIXTURES_DIR = Path(__file__).parents[2] / "fixtures"
@@ -23,7 +21,63 @@ def _load_sample_deputies() -> list[dict]:
 
 
 # ---------------------------------------------------------------------------
-# normalize_member_name
+# TestConstants — A-1 RED → GREEN
+# ---------------------------------------------------------------------------
+
+
+class TestConstants:
+    def test_portlet_url_exists_and_has_expected_shape(self):
+        from congress_videos.config.constants import CONGRESO_DEPUTIES_PORTLET_URL
+
+        assert CONGRESO_DEPUTIES_PORTLET_URL.startswith("https://www.congreso.es/es/busqueda-de-diputados")
+        assert "opendataExport" in CONGRESO_DEPUTIES_PORTLET_URL
+
+    def test_browser_user_agent_is_non_empty_and_not_requests_default(self):
+        from congress_videos.config.constants import CONGRESO_BROWSER_USER_AGENT
+
+        assert CONGRESO_BROWSER_USER_AGENT
+        assert not CONGRESO_BROWSER_USER_AGENT.startswith("python-requests/")
+
+    def test_congreso_deputies_index_not_imported_in_participants_ingestion(self):
+        import congress_videos.modules.participants_ingestion as mod
+
+        assert not hasattr(mod, "CONGRESO_DEPUTIES_INDEX"), (
+            "CONGRESO_DEPUTIES_INDEX must not be an attribute of participants_ingestion"
+        )
+
+
+# ---------------------------------------------------------------------------
+# TestFixtureSchema — C-1 RED → GREEN
+# ---------------------------------------------------------------------------
+
+
+class TestFixtureSchema:
+    def test_fixture_uses_titlecase_nombre_key(self):
+        records = _load_sample_deputies()
+        assert len(records) >= 4
+        for r in records:
+            assert "Nombre" in r, f"Expected TitleCase 'Nombre' key, got keys: {list(r.keys())}"
+
+    def test_fixture_uses_titlecase_formacion_key(self):
+        records = _load_sample_deputies()
+        for r in records:
+            assert "Formacion" in r, f"Expected 'Formacion' key, got: {list(r.keys())}"
+
+    def test_fixture_uses_titlecase_grupo_parlamentario_key(self):
+        records = _load_sample_deputies()
+        for r in records:
+            assert "GrupoParlamentario" in r, f"Expected 'GrupoParlamentario' key, got: {list(r.keys())}"
+
+    def test_fixture_has_no_uppercase_fechaalta_grupo(self):
+        records = _load_sample_deputies()
+        for r in records:
+            assert "FECHAALTAENGRUPOPARLAMENTARIO" not in r, (
+                "Fixture must not contain FECHAALTAENGRUPOPARLAMENTARIO key"
+            )
+
+
+# ---------------------------------------------------------------------------
+# normalize_member_name — unchanged regression guard
 # ---------------------------------------------------------------------------
 
 
@@ -48,104 +102,120 @@ class TestNormalizeMemberName:
 
 
 # ---------------------------------------------------------------------------
-# resolve_download_url
-# ---------------------------------------------------------------------------
-
-
-class TestResolveDownloadUrl:
-    def test_discovers_url_from_index_html(self, mock_requests, monkeypatch):
-        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
-        index_html = (
-            "<html><body>"
-            '<a href="https://www.congreso.es/webpublica/opendata/diputados/'
-            'DiputadosActivos__20260101_120000.json">Diputados Activos</a>'
-            "</body></html>"
-        )
-        mock_requests.get.return_value = mock_requests.make_response(status_code=200, text=index_html)
-
-        url = resolve_download_url()
-
-        assert url == (
-            "https://www.congreso.es/webpublica/opendata/diputados/"
-            "DiputadosActivos__20260101_120000.json"
-        )
-        mock_requests.get.assert_any_call(CONGRESO_DEPUTIES_INDEX, timeout=30)
-
-    def test_resolves_relative_href_against_index(self, mock_requests, monkeypatch):
-        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
-        index_html = '<html><body><a href="DiputadosActivos__20260101_120000.json">link</a></body></html>'
-        mock_requests.get.return_value = mock_requests.make_response(status_code=200, text=index_html)
-
-        url = resolve_download_url()
-
-        assert url == (
-            "https://www.congreso.es/webpublica/opendata/diputados/"
-            "DiputadosActivos__20260101_120000.json"
-        )
-
-    def test_env_override_skips_discovery(self, mock_requests, monkeypatch):
-        monkeypatch.setenv("CONGRESO_DEPUTIES_URL", "https://example.test/override.json")
-
-        url = resolve_download_url()
-
-        assert url == "https://example.test/override.json"
-        mock_requests.get.assert_not_called()
-
-    def test_raises_when_no_link_found(self, mock_requests, monkeypatch):
-        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
-        mock_requests.get.return_value = mock_requests.make_response(
-            status_code=200, text="<html><body>no links here</body></html>"
-        )
-
-        with pytest.raises(ValueError):
-            resolve_download_url()
-
-
-# ---------------------------------------------------------------------------
-# fetch_active_deputies
+# TestFetchActiveDeputies — B-1 RED + B-2 RED → GREEN
 # ---------------------------------------------------------------------------
 
 
 class TestFetchActiveDeputies:
-    def test_successful_download_and_parse(self, mock_requests, monkeypatch):
-        monkeypatch.setenv("CONGRESO_DEPUTIES_URL", "https://example.test/deputies.json")
+    """Tests for fetch_active_deputies() POST-based ingestion."""
+
+    def test_portlet_post_default(self, mock_requests, monkeypatch):
+        """Default path: POST to portlet URL with correct form body and browser UA."""
+        from congress_videos.config.constants import (
+            CONGRESO_DEPUTIES_PORTLET_URL,
+            CONGRESO_BROWSER_USER_AGENT,
+        )
+
+        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
+        sample = _load_sample_deputies()
+        mock_requests.post.return_value = mock_requests.make_response(status_code=200, json_data=sample)
+
+        result = fetch_active_deputies()
+
+        mock_requests.post.assert_called_once()
+        call_args = mock_requests.post.call_args
+        call_url = call_args[0][0] if call_args[0] else call_args[1].get("url")
+        assert call_url == CONGRESO_DEPUTIES_PORTLET_URL
+
+        data = call_args[1].get("data") or (call_args[0][1] if len(call_args[0]) > 1 else None)
+        assert data is not None
+        assert data["_diputadomodule_fileType"] == "json"
+        assert data["_diputadomodule_fileIndex"] == 0
+        assert int(data["_diputadomodule_idLegislatura"]) == 15
+
+        headers = call_args[1].get("headers", {})
+        assert headers.get("User-Agent") == CONGRESO_BROWSER_USER_AGENT
+
+        assert result == sample
+
+    def test_env_override_uses_get_not_post(self, mock_requests, monkeypatch):
+        """Env-override path: GET to override URL; POST must NOT be called."""
+        monkeypatch.setenv("CONGRESO_DEPUTIES_URL", "https://example.test/override.json")
         sample = _load_sample_deputies()
         mock_requests.get.return_value = mock_requests.make_response(status_code=200, json_data=sample)
 
-        raw = fetch_active_deputies()
+        result = fetch_active_deputies()
 
-        assert raw == sample
-        assert len(raw) == 4
+        mock_requests.get.assert_called_once()
+        call_url = mock_requests.get.call_args[0][0]
+        assert call_url == "https://example.test/override.json"
+        mock_requests.post.assert_not_called()
+        assert result == sample
 
-    def test_http_error_propagates(self, mock_requests, monkeypatch):
-        monkeypatch.setenv("CONGRESO_DEPUTIES_URL", "https://example.test/deputies.json")
-        error_response = mock_requests.make_response(status_code=503)
-
-        import requests
-
-        error_response.raise_for_status.side_effect = requests.HTTPError("503 Server Error")
-        mock_requests.get.return_value = error_response
-
-        with pytest.raises(Exception):
-            fetch_active_deputies()
-
-    def test_malformed_json_raises(self, mock_requests, monkeypatch):
-        monkeypatch.setenv("CONGRESO_DEPUTIES_URL", "https://example.test/deputies.json")
-        bad_response = mock_requests.make_response(status_code=200)
-        bad_response.json.side_effect = ValueError("Expecting value")
-        mock_requests.get.return_value = bad_response
+    def test_empty_response_raises_value_error(self, mock_requests, monkeypatch):
+        """Empty JSON array from portlet raises ValueError."""
+        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
+        empty_response = mock_requests.make_response(status_code=200)
+        # Bypass the `json_data or {}` quirk: set return_value directly to empty list
+        empty_response.json.return_value = []
+        mock_requests.post.return_value = empty_response
 
         with pytest.raises(ValueError):
             fetch_active_deputies()
 
+    def test_malformed_json_raises_value_error(self, mock_requests, monkeypatch):
+        """Malformed JSON raises ValueError with portlet URL in message."""
+        from congress_videos.config.constants import CONGRESO_DEPUTIES_PORTLET_URL
+
+        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
+        bad_response = mock_requests.make_response(status_code=200)
+        bad_response.json.side_effect = ValueError("Expecting value")
+        mock_requests.post.return_value = bad_response
+
+        with pytest.raises(ValueError, match=CONGRESO_DEPUTIES_PORTLET_URL.split("?")[0]):
+            fetch_active_deputies()
+
+    def test_http_error_propagates(self, mock_requests, monkeypatch):
+        """503 response raises HTTPError (transient outage, not WAF)."""
+        import requests as req_lib
+
+        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
+        error_response = mock_requests.make_response(status_code=503)
+        error_response.raise_for_status.side_effect = req_lib.HTTPError("503 Server Error")
+        mock_requests.post.return_value = error_response
+
+        with pytest.raises(Exception):
+            fetch_active_deputies()
+
+    def test_403_raises_clear_waf_message(self, mock_requests, monkeypatch):
+        """HTTP 403 raises RuntimeError with WAF diagnostic (URL + body snippet)."""
+        from congress_videos.config.constants import CONGRESO_DEPUTIES_PORTLET_URL
+
+        monkeypatch.delenv("CONGRESO_DEPUTIES_URL", raising=False)
+        waf_response = mock_requests.make_response(
+            status_code=403, text="Forbidden WAF body — access denied by security policy"
+        )
+        mock_requests.post.return_value = waf_response
+
+        with pytest.raises(RuntimeError) as exc_info:
+            fetch_active_deputies()
+
+        message = str(exc_info.value)
+        assert "403" in message
+        assert "congreso.es" in message or CONGRESO_DEPUTIES_PORTLET_URL.split("?")[0] in message
+        assert "WAF" in message or "endpoint change" in message
+        # Confirm raise_for_status was never the trigger (RuntimeError not HTTPError)
+        assert exc_info.type is RuntimeError
+
 
 # ---------------------------------------------------------------------------
-# parse_deputies
+# TestParseDeputies — D-1 RED → GREEN (TitleCase keys)
 # ---------------------------------------------------------------------------
 
 
 class TestParseDeputies:
     def test_parses_all_named_fields(self):
+        """TitleCase fixture drives full field mapping including group_entry_date=None."""
         sample = _load_sample_deputies()
 
         records = parse_deputies(sample)
@@ -160,8 +230,20 @@ class TestParseDeputies:
         assert first["biography"].startswith("Licenciada en Derecho")
         assert first["full_membership_date"] == "2023-12-17"
         assert first["start_date"] == "2023-12-10"
-        assert first["group_entry_date"] == "2023-12-12"
+        assert first["group_entry_date"] is None  # field absent from opendataExport
         assert first["photo_url"] is None
+
+    def test_group_entry_date_always_none(self):
+        """group_entry_date is always None regardless of any key name in input."""
+        entry = {
+            "Nombre": "Test, Persona",
+            "FECHAALTAENGRUPOPARLAMENTARIO": "12/12/2023",  # old key, must be ignored
+            "SomeOtherGroupKey": "2024-01-01",
+        }
+
+        records = parse_deputies([entry])
+
+        assert records[0]["group_entry_date"] is None
 
     def test_empty_payload_raises_value_error(self):
         with pytest.raises(ValueError):
@@ -169,21 +251,17 @@ class TestParseDeputies:
 
     def test_unparseable_date_becomes_none(self):
         entry = {
-            "NOMBRE": "Test, Persona",
-            "FORMACIONELECTORAL": "Grupo",
-            "GRUPOPARLAMENTARIO": "Grupo",
-            "CIRCUNSCRIPCION": "Madrid",
-            "BIOGRAFIA": "Bio",
-            "FECHACONDICIONPLENA": "not-a-date",
-            "FECHAALTA": "",
+            "Nombre": "Test, Persona",
+            "FechaCondicionPlena": "not-a-date",
+            "FechaAlta": "",
         }
         records = parse_deputies([entry])
         assert records[0]["full_membership_date"] is None
         assert records[0]["start_date"] is None
 
     def test_skips_entry_missing_nombre(self):
-        good = {"NOMBRE": "Test, Persona"}
-        bad = {"FORMACIONELECTORAL": "Grupo sin nombre"}
+        good = {"Nombre": "Test, Persona"}
+        bad = {"Formacion": "Grupo sin nombre"}
 
         records = parse_deputies([bad, good])
 
@@ -191,7 +269,7 @@ class TestParseDeputies:
         assert records[0]["display_name"] == "Test, Persona"
 
     def test_deduplicates_repeated_normalized_name(self):
-        entry = {"NOMBRE": "Test, Persona"}
+        entry = {"Nombre": "Test, Persona"}
 
         records = parse_deputies([entry, dict(entry)])
 
@@ -199,4 +277,4 @@ class TestParseDeputies:
 
     def test_raises_when_all_entries_missing_nombre(self):
         with pytest.raises(ValueError):
-            parse_deputies([{"FORMACIONELECTORAL": "Grupo sin nombre"}])
+            parse_deputies([{"Formacion": "Grupo sin nombre"}])

--- a/tests/fixtures/sample_diputados_activos.json
+++ b/tests/fixtures/sample_diputados_activos.json
@@ -1,42 +1,38 @@
 [
   {
-    "NOMBRE": "Pérez García, María",
-    "FORMACIONELECTORAL": "Partido Socialista Obrero Español",
-    "GRUPOPARLAMENTARIO": "Grupo Parlamentario Socialista",
-    "CIRCUNSCRIPCION": "Madrid",
-    "BIOGRAFIA": "Licenciada en Derecho por la Universidad Complutense de Madrid.",
-    "FECHACONDICIONPLENA": "17/12/2023",
-    "FECHAALTA": "10/12/2023",
-    "FECHAALTAENGRUPOPARLAMENTARIO": "12/12/2023"
+    "Nombre": "Pérez García, María",
+    "Formacion": "Partido Socialista Obrero Español",
+    "GrupoParlamentario": "Grupo Parlamentario Socialista",
+    "Circunscripcion": "Madrid",
+    "Biografia": "Licenciada en Derecho por la Universidad Complutense de Madrid.",
+    "FechaCondicionPlena": "17/12/2023",
+    "FechaAlta": "10/12/2023"
   },
   {
-    "NOMBRE": "Ruiz-Gallardón Jiménez, Alberto",
-    "FORMACIONELECTORAL": "Partido Popular",
-    "GRUPOPARLAMENTARIO": "Grupo Parlamentario Popular en el Congreso",
-    "CIRCUNSCRIPCION": "Barcelona",
-    "BIOGRAFIA": "Diputado por Barcelona desde la XV legislatura.",
-    "FECHACONDICIONPLENA": "17/12/2023",
-    "FECHAALTA": "10/12/2023",
-    "FECHAALTAENGRUPOPARLAMENTARIO": "12/12/2023"
+    "Nombre": "Ruiz-Gallardón Jiménez, Alberto",
+    "Formacion": "Partido Popular",
+    "GrupoParlamentario": "Grupo Parlamentario Popular en el Congreso",
+    "Circunscripcion": "Barcelona",
+    "Biografia": "Diputado por Barcelona desde la XV legislatura.",
+    "FechaCondicionPlena": "17/12/2023",
+    "FechaAlta": "10/12/2023"
   },
   {
-    "NOMBRE": "Núñez Fernández, José",
-    "FORMACIONELECTORAL": "VOX",
-    "GRUPOPARLAMENTARIO": "Grupo Parlamentario VOX",
-    "CIRCUNSCRIPCION": "Valencia",
-    "BIOGRAFIA": "Diputado por Valencia.",
-    "FECHACONDICIONPLENA": "17/12/2023",
-    "FECHAALTA": "10/12/2023",
-    "FECHAALTAENGRUPOPARLAMENTARIO": "12/12/2023"
+    "Nombre": "Núñez Fernández, José",
+    "Formacion": "VOX",
+    "GrupoParlamentario": "Grupo Parlamentario VOX",
+    "Circunscripcion": "Valencia",
+    "Biografia": "Diputado por Valencia.",
+    "FechaCondicionPlena": "17/12/2023",
+    "FechaAlta": "10/12/2023"
   },
   {
-    "NOMBRE": "López Sánchez, Ana",
-    "FORMACIONELECTORAL": "Sumar",
-    "GRUPOPARLAMENTARIO": "Grupo Parlamentario Plurinacional Sumar",
-    "CIRCUNSCRIPCION": "Sevilla",
-    "BIOGRAFIA": "Diputada por Sevilla desde 2023.",
-    "FECHACONDICIONPLENA": "17/12/2023",
-    "FECHAALTA": "10/12/2023",
-    "FECHAALTAENGRUPOPARLAMENTARIO": "12/12/2023"
+    "Nombre": "López Sánchez, Ana",
+    "Formacion": "Sumar",
+    "GrupoParlamentario": "Grupo Parlamentario Plurinacional Sumar",
+    "Circunscripcion": "Sevilla",
+    "Biografia": "Diputada por Sevilla desde 2023.",
+    "FechaCondicionPlena": "17/12/2023",
+    "FechaAlta": "10/12/2023"
   }
 ]


### PR DESCRIPTION
## Problem

`congress_participants_sync` (task `fetch_and_parse`) was failing at runtime with `403 Forbidden` on `https://www.congreso.es/webpublica/opendata/diputados/`.

**Root cause (verified with live requests from a Spain IP):** congreso.es disabled Apache directory autoindex under `/webpublica/opendata/` — the directory listing now returns 403. The old code scraped that listing to discover the `DiputadosActivos__*.json` file, so URL discovery is impossible. Confirmed it is **not** the User-Agent and **not** IP/geo blocking (the domain and sibling paths respond 200 from the same IP). The open-data portal moved to a Liferay portlet under `/es/opendata/diputados`.

## Change

Repoint ingestion to the working `opendataExport` Liferay portlet (POST) and adapt the parser to the new schema.

- **Ingestion:** replace the dead directory-scrape (`resolve_download_url` + `fetch_active_deputies`) with a single POST to the `opendataExport` portlet, sending a browser `User-Agent`. The `CONGRESO_DEPUTIES_URL` env override is preserved for static-file local testing.
- **Parsing:** `parse_deputies` remapped from the old UPPERCASE keys to the new TitleCase schema (`Nombre`, `Formacion`, `GrupoParlamentario`, `Circunscripcion`, `FechaAlta`, `FechaCondicionPlena`, `Biografia`). `group_entry_date` is set to `None` — the source field (`FECHAALTAENGRUPOPARLAMENTARIO`) no longer exists in the new API.
- **Error signaling:** HTTP 403 now raises a typed `RuntimeError` with the URL and a response-body snippet, distinguishing a WAF/endpoint change from a transient outage. It is raised **before** `raise_for_status`, so 5xx outages still propagate as `HTTPError` under the existing retry policy.
- **DB safety:** `upsert_batch` now uses an `EXCLUDED`-first `COALESCE` for `group_entry_date`, so the now-always-`None` ingest value never blanks previously stored history.
- Removed dead imports (`urljoin`, `BeautifulSoup`, `_DOWNLOAD_LINK_PATTERN`); `beautifulsoup4` stays (still used by `youtube_channel.py`).

## Accepted tradeoffs (product decision)

Ingestion source is **opendataExport only**. That file carries biography + `FechaCondicionPlena` but **not** `codParlamentario`, so the deterministic congreso.es official-photo fallback is not available. Photos remain Commons/Wikidata-only, which measured at ~50% coverage of the 350 deputies. This was chosen deliberately to keep biography data. `group_entry_date` is no longer available from any source.

## Test plan

- `uv run pytest` → **1320 passed, 1 skipped, 84.33% coverage** (80% gate enforced in addopts).
- Docker e2e (`bash scripts/test-airflow-e2e.sh`) → **PASS**, `airflow dags list-import-errors` empty. This closes the import-time gap that previously let a broken DAG ship.
- New/rewritten tests cover: portlet POST body + browser UA, env-override GET branch, empty/malformed payload → `ValueError`, 403 → clear `RuntimeError` (incl. body snippet), 503 still propagates as `HTTPError`, TitleCase field mapping, `group_entry_date is None`, and the `EXCLUDED`-first COALESCE SQL shape.

## Known residual risks

- `opendataExport` is an undocumented Liferay portlet endpoint; its form fields / WAF rules could change silently. The 403 `RuntimeError` is the early-warning signal, but the e2e smoke test only checks DAG import — it does not exercise the live POST.
- ~50% Commons-only photo coverage (accepted above).
