### PR TITLE
fix(congress_participants): searchDiputados portlet body + apellidosNombre join

### DIFF
--- a/congress_videos/modules/participants_enrichment.py
+++ b/congress_videos/modules/participants_enrichment.py
@@ -40,10 +40,28 @@ _SEARCH_DIPUTADOS_ENV_VAR = "CONGRESO_SEARCH_DIPUTADOS_URL_OVERRIDE"
 _REQUEST_TIMEOUT = 30
 
 # Candidate key lists for defensive extraction from searchDiputados portlet.
-# The live response schema is unconfirmed from this environment; order matters —
-# first non-empty key value wins.
+# Verified live (2026-07-30, Spain egress): the portlet returns {"data": [...]}
+# with keys apellidosNombre ("Apellidos, Nombre" full name) and codParlamentario
+# (int). apellidosNombre MUST come before nombre — nombre is the given name only,
+# which would break the normalized-name join. Order matters — first non-empty wins.
 _COD_CANDIDATE_KEYS = ["codParlamentario", "codigo", "cod", "id"]
-_NAME_CANDIDATE_KEYS = ["nombre", "nombreCompleto", "apellidosNombre", "nombreCircunscripcion"]
+_NAME_CANDIDATE_KEYS = ["apellidosNombre", "nombreCompleto", "nombre"]
+
+# Liferay searchDiputados dataRequest body. Verified live: a bare
+# {"idLegislatura": 15} body makes the portlet return {"data": []}. The full
+# _diputadomodule_* form fields are required (same portlet as opendataExport,
+# minus the file-export fileIndex/fileType fields).
+_SEARCH_PORTLET_FORM_FIELDS: dict[str, object] = {
+    "_diputadomodule_idLegislatura": LEGISLATURE_ID,
+    "_diputadomodule_filtroProvincias": "[]",
+    "_diputadomodule_genero": "",
+    "_diputadomodule_grupo": "",
+    "_diputadomodule_tipo": "",
+    "_diputadomodule_nombre": "",
+    "_diputadomodule_apellidos": "",
+    "_diputadomodule_formacion": "",
+    "_diputadomodule_nombreCircunscripcion": "",
+}
 
 
 def fetch_congreso_cod_parlamentario() -> dict[str, str]:
@@ -76,7 +94,7 @@ def fetch_congreso_cod_parlamentario() -> dict[str, str]:
     else:
         response = requests.post(
             CONGRESO_SEARCH_DIPUTADOS_URL,
-            data={"idLegislatura": LEGISLATURE_ID},
+            data=dict(_SEARCH_PORTLET_FORM_FIELDS),
             headers={"User-Agent": CONGRESO_BROWSER_USER_AGENT},
             timeout=_REQUEST_TIMEOUT,
         )

--- a/tests/congress_videos/modules/test_participants_enrichment.py
+++ b/tests/congress_videos/modules/test_participants_enrichment.py
@@ -17,7 +17,7 @@ def _load_wikidata_fixture() -> dict:
     return json.loads((FIXTURES_DIR / "sample_wikidata_sparql.json").read_text(encoding="utf-8"))
 
 
-def _load_search_diputados_fixture() -> list:
+def _load_search_diputados_fixture() -> dict:
     return json.loads((FIXTURES_DIR / "sample_search_diputados.json").read_text(encoding="utf-8"))
 
 
@@ -332,7 +332,7 @@ class TestFetchCongresCodParlamentario:
         from congress_videos.modules.participants_enrichment import fetch_congreso_cod_parlamentario
 
         fixture_data = _load_search_diputados_fixture()
-        # Wrap in {"data": [...]} envelope to test both shapes
+        # Live shape: {"data": [...]} envelope with TitleCase "Apellidos, Nombre" in apellidosNombre.
         mock_requests.post.return_value = mock_requests.make_response(
             status_code=200,
             json_data=fixture_data,
@@ -341,10 +341,12 @@ class TestFetchCongresCodParlamentario:
         result = fetch_congreso_cod_parlamentario()
 
         assert isinstance(result, dict)
-        # Entry 1: codParlamentario="ABC123", nombre="García López, María"
-        # normalize_member_name("García López, María") → "maria garcia lopez"
-        assert "maria garcia lopez" in result
-        assert result["maria garcia lopez"] == "ABC123"
+        # Entry: codParlamentario=160, apellidosNombre="Abades Martínez, Cristina"
+        # normalize_member_name("Abades Martínez, Cristina") → "cristina abades martinez"
+        assert result["cristina abades martinez"] == "160"
+        assert result["santiago abascal conde"] == "317"
+        # Entry missing cod and entry missing name are both skipped.
+        assert len(result) == 2
 
     def test_defensive_alternate_cod_key(self, mock_requests):
         """Entry using 'codigo' instead of 'codParlamentario' → cod still resolved."""
@@ -449,6 +451,49 @@ class TestFetchCongresCodParlamentario:
 
         assert mock_requests.get.called
         assert mock_requests.post.call_count == 0
+
+    def test_post_body_includes_portlet_form_fields(self, mock_requests):
+        """POST body must carry the Liferay _diputadomodule_* form fields.
+
+        A bare {"idLegislatura": 15} body makes the searchDiputados portlet
+        return {"data": []} (verified live), so the full portlet dataRequest
+        is required.
+        """
+        from congress_videos.modules.participants_enrichment import fetch_congreso_cod_parlamentario
+
+        mock_requests.post.return_value = mock_requests.make_response(
+            status_code=200, json_data={"data": []}
+        )
+
+        fetch_congreso_cod_parlamentario()
+
+        _, call_kwargs = mock_requests.post.call_args
+        body = call_kwargs.get("data", {})
+        assert "_diputadomodule_idLegislatura" in body
+        assert "_diputadomodule_filtroProvincias" in body
+
+    def test_prefers_apellidos_nombre_over_given_name(self, mock_requests):
+        """When both 'nombre' (given only) and 'apellidosNombre' (full) exist,
+        the full name must win — otherwise the normalized-name join fails."""
+        from congress_videos.modules.participants_enrichment import fetch_congreso_cod_parlamentario
+
+        entries = {
+            "data": [
+                {
+                    "codParlamentario": 500,
+                    "nombre": "Cristina",
+                    "apellidosNombre": "Abades Martínez, Cristina",
+                }
+            ]
+        }
+        mock_requests.post.return_value = mock_requests.make_response(
+            status_code=200, json_data=entries
+        )
+
+        result = fetch_congreso_cod_parlamentario()
+
+        assert result["cristina abades martinez"] == "500"
+        assert "cristina" not in result  # must NOT key by the given name alone
 
 
 # ===========================================================================

--- a/tests/fixtures/sample_search_diputados.json
+++ b/tests/fixtures/sample_search_diputados.json
@@ -1,24 +1,29 @@
-[
-  {
-    "codParlamentario": "ABC123",
-    "nombre": "García López, María",
-    "partido": "PartidoA",
-    "circunscripcion": "Madrid"
-  },
-  {
-    "codigo": "DEF456",
-    "apellidosNombre": "López Sánchez, Ana",
-    "partido": "PartidoB",
-    "circunscripcion": "Barcelona"
-  },
-  {
-    "nombre": "Sin Código, Deputy",
-    "partido": "PartidoC",
-    "circunscripcion": "Valencia"
-  },
-  {
-    "codParlamentario": "GHI789",
-    "partido": "PartidoD",
-    "circunscripcion": "Sevilla"
-  }
-]
+{
+  "data": [
+    {
+      "codParlamentario": 160,
+      "apellidosNombre": "Abades Martínez, Cristina",
+      "nombre": "Cristina",
+      "apellidos": "Abades Martínez",
+      "formacion": "PSOE",
+      "nombreCircunscripcion": "Madrid"
+    },
+    {
+      "codParlamentario": 317,
+      "apellidosNombre": "Abascal Conde, Santiago",
+      "nombre": "Santiago",
+      "apellidos": "Abascal Conde",
+      "formacion": "VOX",
+      "nombreCircunscripcion": "Madrid"
+    },
+    {
+      "apellidosNombre": "Sin Código, Diputado",
+      "nombre": "Diputado",
+      "formacion": "MixtoTest"
+    },
+    {
+      "codParlamentario": 69,
+      "formacion": "SinNombreTest"
+    }
+  ]
+}


### PR DESCRIPTION
## Why

The congreso.es photo fallback merged in #31 resolved **0 deputies in production** (`fetch_congreso_cod_parlamentario: resolved 0 deputies`, `filled=0 skipped_no_cod=324 source_count=0`). Two bugs:

1. The `searchDiputados` POST body was a bare `{"idLegislatura": 15}`. Verified live, that makes the Liferay portlet return `{"data": []}`. The full `_diputadomodule_*` form fields are required (same portlet as `opendataExport`, minus the file-export fields).
2. The name-join used `nombre` (given name only, e.g. "Cristina") before `apellidosNombre` (full "Apellidos, Nombre"), so even with data the normalized-name join would miss.

## What

- Send the full `_diputadomodule_*` dataRequest body.
- `apellidosNombre` now takes priority over `nombre` for the join key.
- Fixture rewritten to the verified live schema (`{"data": [...]}` envelope, `apellidosNombre` + integer `codParlamentario`).

## Test plan

- [x] `uv run pytest` — 1347 passed, 84.58% coverage.
- [x] **Verified live against congreso.es (Spain egress):** the fixed `fetch_congreso_cod_parlamentario()` resolves **350/350** deputies; previously-skipped production names (Núñez Feijóo → 346, Sánchez Pérez-Castejón → 189, Abascal Conde → 317) now resolve. Sample photo URLs (`{cod}_15.jpg`) return `200 image/jpeg`.
- [ ] After merge, re-run `congress_participants_sync` in Airflow and confirm `photo_url` coverage jumps toward ~350/350.

🤖 Generated with [Claude Code](https://claude.com/claude-code)