### PR TITLE
feat(speakers): normalize video chapter speakers against congress_participants

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -399,6 +399,26 @@ ESCALA FINAL (suma automática de puntos):
 
 IMPORTANTE: Sé objetivo y evalúa la relevancia real para el público español general, no solo para expertos en política."""
 
+# Speaker Normalization — match a dirty speaker string to a congress_participants candidate
+SPEAKER_MATCH_SYSTEM_PROMPT = (
+    "You are a speaker-name disambiguation assistant for the Spanish Congress of Deputies. "
+    "Given a dirty speaker name extracted from a transcript and a candidate participant from the "
+    "congress_participants database, decide whether they refer to the same person. "
+    "Always respond with a strict JSON object and NOTHING else. "
+    "JSON schema: {\"decision\": \"match\" | \"no_match\" | \"needs_manual\", "
+    "\"confidence\": <float 0-1>, \"reason\": \"<one sentence>\"}"
+)
+
+SPEAKER_MATCH_USER_PROMPT_TEMPLATE = """Dirty speaker name (from transcript): {dirty_name}
+
+Candidate participant:
+  - display_name: {display_name}
+  - normalized_name: {normalized_name}
+{context_block}
+Decide if the dirty name and the candidate refer to the same person.
+Return ONLY valid JSON: {{\"decision\": \"match\" | \"no_match\" | \"needs_manual\", \"confidence\": <0-1>, \"reason\": \"<one sentence>\"}}"""
+
+
 CHAPTER_RELEVANCE_SCORING_USER_PROMPT_TEMPLATE = """Evalúa la relevancia de este capítulo de sesión parlamentaria para contenido de YouTube.
 
 === INFORMACIÓN DEL CAPÍTULO ===

--- a/congress_videos/config/speaker_normalization_config.py
+++ b/congress_videos/config/speaker_normalization_config.py
@@ -1,0 +1,24 @@
+"""
+Speaker normalization configuration constants.
+
+Controls fuzzy-match threshold, AI model selection, and feature toggle for
+the speaker_normalization module.  Mirrors the pattern used by other config
+modules in this package (Python constants only — no YAML loader).
+"""
+
+# Minimum fuzzy similarity score (0-1) for a candidate to proceed to AI
+# verification.  Mirrors WIKIDATA_FUZZY_THRESHOLD from constants.py.
+FUZZY_THRESHOLD: float = 0.90
+
+# OpenAI model used for AI-assisted speaker identity verification.
+# Consistent with the default model used by cached_json_completion in
+# utils/ai_helpers.py.
+AI_MODEL: str = "gpt-4o-mini"
+
+# Master on/off switch.  When False, the t_normalize_speakers DAG task
+# short-circuits and the DAG completes without modifying any chapter.
+ENABLED: bool = True
+
+# When True, the AI verification prompt includes a snippet of the chapter
+# timeline as additional context for the speaker match decision.
+CONTEXT_ENABLED: bool = True

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1284,6 +1284,45 @@ class CongressionalVideoDB:
                         (video_id, video_url, str(retry_after_hours)),
                     )
 
+    def update_chapter_speakers(
+        self,
+        chapter_id: int,
+        speakers: list,
+        key_speakers: list,
+        timeline: list,
+    ) -> None:
+        """Overwrite the speakers, key_speakers and timeline JSONB for a chapter.
+
+        Called by normalize_chapter_speakers after confirmed AI matches have been
+        applied to all three fields.
+
+        Args:
+            chapter_id: PK of the video_chapters row to update.
+            speakers: Updated list of speaker display names.
+            key_speakers: Updated list of key speaker display names.
+            timeline: Updated list of timeline dicts (each has 'speaker' field).
+        """
+        chapters_table = self.pg_conn.get_qualified_table("video_chapters")
+
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE {chapters_table}
+                    SET speakers = %s,
+                        key_speakers = %s,
+                        timeline = %s::jsonb,
+                        updated_at = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (speakers, key_speakers, json.dumps(timeline), chapter_id),
+                )
+                logger.info(
+                    "update_chapter_speakers: updated chapter %d "
+                    "(%d speakers, %d key_speakers, %d timeline entries)",
+                    chapter_id, len(speakers), len(key_speakers), len(timeline),
+                )
+
     def get_processed_video_ids(self, video_ids: list[str]) -> set[str]:
         """Return the subset of video_ids that should be skipped for download.
 

--- a/congress_videos/modules/participants_db.py
+++ b/congress_videos/modules/participants_db.py
@@ -167,6 +167,12 @@ def lookup_participant_fuzzy(
     """
     Look up a participant using rapidfuzz token_sort_ratio fuzzy matching.
 
+    Scores each candidate against BOTH ``normalized_name`` AND the normalized
+    form of ``display_name`` and returns the candidate with the highest score
+    across both fields.  This allows matching dirty speaker strings like
+    "Pedro Sanchez" that may not closely match the full official normalized name
+    but score well against the shorter display_name form (e.g. "Sánchez, Pedro").
+
     Returns the single best match whose score is >= threshold, or None.
 
     Args:
@@ -174,7 +180,8 @@ def lookup_participant_fuzzy(
         threshold: Minimum similarity ratio in [0, 1] (default: WIKIDATA_FUZZY_THRESHOLD = 0.90).
 
     Returns:
-        Best-matching row dict if score >= threshold, None otherwise.
+        Best-matching row dict (includes ``display_name``) if score >= threshold,
+        None otherwise.
     """
     from rapidfuzz.fuzz import token_sort_ratio  # lazy import — Slice 2 dependency
 
@@ -183,7 +190,9 @@ def lookup_participant_fuzzy(
     best: dict | None = None
     best_score = 0.0
     for row in rows:
-        score = token_sort_ratio(key, row["normalized_name"]) / 100.0
+        score_normalized = token_sort_ratio(key, row["normalized_name"]) / 100.0
+        score_display = token_sort_ratio(key, normalize_member_name(row["display_name"])) / 100.0
+        score = max(score_normalized, score_display)
         if score > best_score:
             best, best_score = row, score
     return best if best_score >= threshold else None

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -1,0 +1,267 @@
+"""Speaker normalization module for congress_videos.
+
+Resolves free-text dirty speaker strings extracted by the LLM into canonical
+``congress_participants`` entries, persists every mapping outcome in
+``speaker_normalization_cache`` for idempotency and audit, and rewrites
+confirmed chapter speaker fields with canonical display names.
+
+Public API
+----------
+normalize_chapter_speakers(chapter_id, speakers, key_speakers, timeline,
+                           db_conn, config) -> NormalizationResult
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import dataclass, field
+
+from congress_videos.config.ai_prompts import (
+    SPEAKER_MATCH_SYSTEM_PROMPT,
+    SPEAKER_MATCH_USER_PROMPT_TEMPLATE,
+)
+from congress_videos.modules.participants_db import lookup_participant_fuzzy
+from congress_videos.modules.participants_ingestion import normalize_member_name
+from utils.llm_cache import cached_json_completion
+
+logger = logging.getLogger(__name__)
+
+# Table name — unqualified; callers supply a connected psycopg2 connection.
+_CACHE_TABLE = "speaker_normalization_cache"
+_CHAPTERS_TABLE = "video_chapters"
+
+
+@dataclass
+class NormalizationResult:
+    """Return value of :func:`normalize_chapter_speakers`."""
+
+    corrections: dict[str, str] = field(default_factory=dict)
+    """Mapping of dirty_speaker -> canonical display_name for matched speakers."""
+
+    cache_rows: list[dict] = field(default_factory=list)
+    """One entry per unique dirty speaker that was processed (for audit/testing)."""
+
+    updated: bool = False
+    """True if video_chapters was written back (at least one match confirmed)."""
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+def _dedupe_dirty_speakers(
+    speakers: list[str],
+    key_speakers: list[str],
+    timeline: list[dict],
+) -> list[str]:
+    """Return a de-duplicated, ordered list of unique dirty speaker names."""
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for name in list(speakers) + list(key_speakers) + [e.get("speaker", "") for e in timeline]:
+        if name and name not in seen_set:
+            seen.append(name)
+            seen_set.add(name)
+    return seen
+
+
+def _upsert_cache_row(cursor, chapter_id: int, dirty_speaker: str, status: str,
+                      canonical_speaker: str | None = None,
+                      participant_normalized_name: str | None = None,
+                      confidence_score: float | None = None) -> None:
+    """INSERT or UPDATE a speaker_normalization_cache row."""
+    cursor.execute(
+        f"""
+        INSERT INTO {_CACHE_TABLE}
+            (chapter_id, dirty_speaker, canonical_speaker,
+             participant_normalized_name, status, confidence_score)
+        VALUES (%s, %s, %s, %s, %s, %s)
+        ON CONFLICT (chapter_id, dirty_speaker) DO UPDATE SET
+            canonical_speaker           = EXCLUDED.canonical_speaker,
+            participant_normalized_name = EXCLUDED.participant_normalized_name,
+            status                      = EXCLUDED.status,
+            confidence_score            = EXCLUDED.confidence_score,
+            updated_at                  = NOW()
+        """,
+        (chapter_id, dirty_speaker, canonical_speaker,
+         participant_normalized_name, status, confidence_score),
+    )
+
+
+def _apply_corrections(
+    items: list[str],
+    corrections: dict[str, str],
+) -> list[str]:
+    """Return a new list with dirty names replaced by canonical names."""
+    return [corrections.get(item, item) for item in items]
+
+
+def _apply_corrections_to_timeline(
+    timeline: list[dict],
+    corrections: dict[str, str],
+) -> list[dict]:
+    """Return a new timeline with speaker fields replaced by canonical names."""
+    result = []
+    for entry in timeline:
+        new_entry = dict(entry)
+        speaker = new_entry.get("speaker", "")
+        if speaker in corrections:
+            new_entry["speaker"] = corrections[speaker]
+        result.append(new_entry)
+    return result
+
+
+def _build_user_prompt(dirty_name: str, candidate: dict, context_enabled: bool) -> str:
+    """Build the user prompt for the speaker-match AI call."""
+    context_block = ""
+    if context_enabled:
+        context_block = ""  # no timeline snippet available at this level
+    return SPEAKER_MATCH_USER_PROMPT_TEMPLATE.format(
+        dirty_name=dirty_name,
+        display_name=candidate.get("display_name", ""),
+        normalized_name=candidate.get("normalized_name", ""),
+        context_block=context_block,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def normalize_chapter_speakers(
+    chapter_id: int,
+    speakers: list[str],
+    key_speakers: list[str],
+    timeline: list[dict],
+    db_conn,
+    config,
+) -> NormalizationResult:
+    """Normalize dirty speaker strings for a single chapter.
+
+    For each unique dirty speaker name found across ``speakers``,
+    ``key_speakers``, and ``timeline[].speaker``:
+
+    1. Call ``lookup_participant_fuzzy``; if no candidate → upsert ``no_match``.
+    2. If a candidate exists, call ``cached_json_completion`` with the
+       speaker-match prompt; if ``error`` is non-None → skip (no cache write).
+    3. Parse ``result['data']``; upsert cache row with mapped status.
+    4. On ``matched`` → record correction ``dirty → display_name``.
+    5. After the loop: if any corrections, patch all three arrays Python-side and
+       issue a single ``UPDATE video_chapters``.
+
+    Args:
+        chapter_id: PK of the video_chapters row.
+        speakers:     Raw list of speaker names from the chapter.
+        key_speakers: Raw list of key speaker names from the chapter.
+        timeline:     List of timeline dicts (each with a 'speaker' key).
+        db_conn:      Open psycopg2 connection (caller manages lifecycle).
+        config:       Config module / namespace with ENABLED, FUZZY_THRESHOLD,
+                      AI_MODEL, CONTEXT_ENABLED.
+
+    Returns:
+        :class:`NormalizationResult` with corrections, cache_rows, and updated flag.
+    """
+    result = NormalizationResult()
+
+    if not config.ENABLED:
+        logger.debug("normalize_chapter_speakers: ENABLED=False — skipping chapter %d", chapter_id)
+        return result
+
+    dirty_names = _dedupe_dirty_speakers(speakers, key_speakers, timeline)
+    if not dirty_names:
+        return result
+
+    with db_conn.cursor() as cursor:
+        for dirty in dirty_names:
+            # Step 1: fuzzy lookup
+            candidate = lookup_participant_fuzzy(dirty, threshold=config.FUZZY_THRESHOLD)
+            if candidate is None:
+                logger.debug(
+                    "normalize_chapter_speakers: no fuzzy match for %r (chapter %d)",
+                    dirty, chapter_id,
+                )
+                _upsert_cache_row(cursor, chapter_id, dirty, "no_match")
+                result.cache_rows.append({"dirty_speaker": dirty, "status": "no_match"})
+                continue
+
+            # Step 2: AI verification
+            user_prompt = _build_user_prompt(dirty, candidate, config.CONTEXT_ENABLED)
+            ai_response = cached_json_completion(
+                SPEAKER_MATCH_SYSTEM_PROMPT,
+                user_prompt,
+                model=config.AI_MODEL,
+            )
+
+            if ai_response.get("error") is not None:
+                logger.warning(
+                    "normalize_chapter_speakers: AI error for %r (chapter %d): %s",
+                    dirty, chapter_id, ai_response["error"],
+                )
+                # Graceful skip — no cache write per design
+                continue
+
+            data = ai_response.get("data") or {}
+            decision = data.get("decision", "no_match")
+            confidence = data.get("confidence")
+
+            # Map AI decision to cache status
+            if decision == "match":
+                canonical = candidate["display_name"]
+                _upsert_cache_row(
+                    cursor, chapter_id, dirty,
+                    status="matched",
+                    canonical_speaker=canonical,
+                    participant_normalized_name=candidate.get("normalized_name"),
+                    confidence_score=confidence,
+                )
+                result.cache_rows.append({
+                    "dirty_speaker": dirty,
+                    "status": "matched",
+                    "canonical_speaker": canonical,
+                    "confidence_score": confidence,
+                })
+                result.corrections[dirty] = canonical
+                logger.info(
+                    "normalize_chapter_speakers: matched %r -> %r (chapter %d, confidence=%.2f)",
+                    dirty, canonical, chapter_id, confidence or 0.0,
+                )
+            elif decision == "needs_manual":
+                _upsert_cache_row(
+                    cursor, chapter_id, dirty,
+                    status="needs_manual",
+                    confidence_score=confidence,
+                )
+                result.cache_rows.append({"dirty_speaker": dirty, "status": "needs_manual"})
+            else:
+                # no_match or unknown
+                _upsert_cache_row(
+                    cursor, chapter_id, dirty,
+                    status="no_match",
+                    confidence_score=confidence,
+                )
+                result.cache_rows.append({"dirty_speaker": dirty, "status": "no_match"})
+
+        # Step 3: bulk UPDATE video_chapters if any corrections were recorded
+        if result.corrections:
+            new_speakers = _apply_corrections(speakers, result.corrections)
+            new_key_speakers = _apply_corrections(key_speakers, result.corrections)
+            new_timeline = _apply_corrections_to_timeline(timeline, result.corrections)
+
+            cursor.execute(
+                f"""
+                UPDATE {_CHAPTERS_TABLE}
+                SET speakers     = %s,
+                    key_speakers = %s,
+                    timeline     = %s::jsonb,
+                    updated_at   = CURRENT_TIMESTAMP
+                WHERE chapter_id = %s
+                """,
+                (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
+            )
+            result.updated = True
+            logger.info(
+                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d",
+                len(result.corrections), chapter_id,
+            )
+
+    return result

--- a/congress_videos/sql/migrations/017_create_speaker_normalization_cache.sql
+++ b/congress_videos/sql/migrations/017_create_speaker_normalization_cache.sql
@@ -1,0 +1,29 @@
+-- Migration: Create speaker_normalization_cache table
+-- Created: 2026-07-31
+-- Depends on: 004_create_video_shorts.sql (video_chapters table), 015_create_congress_participants.sql
+--
+-- Stores every fuzzy-lookup + AI-verification outcome for each dirty speaker
+-- string found in a video chapter.  Provides idempotency for re-runs and an
+-- audit trail for manual review.
+--
+-- FK targets video_chapters(chapter_id) — the actual PK column (SERIAL),
+-- not the legacy `id` name used in the spec draft.
+--
+-- Runner executes `SET search_path TO {schema}, public` before this file,
+-- so all table names are intentionally UNQUALIFIED.
+--
+-- Example (development): psql ... -c "SET search_path TO development, public;" -f 017_create_speaker_normalization_cache.sql
+-- Example (production):  psql ... -c "SET search_path TO production, public;"  -f 017_create_speaker_normalization_cache.sql
+
+CREATE TABLE IF NOT EXISTS speaker_normalization_cache (
+    id                          SERIAL          PRIMARY KEY,
+    chapter_id                  INT             NOT NULL REFERENCES video_chapters(chapter_id),
+    dirty_speaker               TEXT            NOT NULL,
+    canonical_speaker           TEXT,
+    participant_normalized_name TEXT            REFERENCES congress_participants(normalized_name),
+    status                      TEXT            NOT NULL CHECK (status IN ('matched', 'no_match', 'needs_manual')),
+    confidence_score            NUMERIC(5,4),
+    created_at                  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    updated_at                  TIMESTAMPTZ     NOT NULL DEFAULT NOW(),
+    UNIQUE (chapter_id, dirty_speaker)
+);

--- a/congress_videos/youtube_channel_monitor_dag.py
+++ b/congress_videos/youtube_channel_monitor_dag.py
@@ -23,13 +23,14 @@ import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
-from airflow.operators.python import BranchPythonOperator, PythonOperator
+from airflow.operators.python import BranchPythonOperator, PythonOperator, ShortCircuitOperator
 
 from congress_videos.config.constants import (
     YOUTUBE_CHANNEL_ID,
     TARGET_VIDEO_TITLE,
     VAD_ENABLED,
 )
+from congress_videos.config import speaker_normalization_config as snc
 from congress_videos.modules import youtube as yt_channel
 from congress_videos.modules.postgres_operators import PostgreSQLOperator
 from congress_videos.modules.vad_helpers import trim_chapter_silence_with_vad
@@ -546,6 +547,80 @@ with DAG(
         python_callable=lambda: logging.info("No plenary sessions found. DAG execution stopped."),
     )
 
+    # Step 10: Normalize speaker names for saved chapters
+    # Resolves dirty speaker strings from the LLM into canonical congress_participants
+    # entries via dual-field fuzzy matching + AI verification. Writes audit rows to
+    # speaker_normalization_cache and rewrites confirmed chapter fields in video_chapters.
+    #
+    # trigger_rule='all_done': runs regardless of t9_db outcome so a partial DB save
+    # never blocks normalization of the chapters that did succeed.
+    # ShortCircuitOperator: if snc.ENABLED=False the task is skipped cleanly.
+
+    def _normalize_speakers(**context):
+        """Load chapters from t9_db XCom and normalize each chapter's speakers."""
+        import json as _json
+        from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+        from congress_videos.modules.database import CongressionalVideoDB
+        from utils.postgres_helpers import PostgresConnection
+
+        ti = context["ti"]
+        db_save_results = ti.xcom_pull(key="db_save_results")
+
+        if not db_save_results:
+            logging.info("_normalize_speakers: no db_save_results XCom — skipping")
+            return True
+
+        pg = PostgresConnection()
+        chapters_table = pg.get_qualified_table("video_chapters")
+        db = CongressionalVideoDB()
+
+        with pg.get_connection() as conn:
+            with conn.cursor() as cur:
+                for video_result in db_save_results.get("videos", []):
+                    video_id = video_result.get("video_id")
+                    if video_result.get("error"):
+                        continue
+                    # Fetch saved chapters for this video
+                    cur.execute(
+                        f"SELECT chapter_id, speakers, key_speakers, timeline "
+                        f"FROM {chapters_table} WHERE video_id = %s",
+                        (video_id,),
+                    )
+                    rows = cur.fetchall()
+                    for row in rows:
+                        chapter_id = row["chapter_id"]
+                        speakers_raw = row.get("speakers") or []
+                        key_speakers_raw = row.get("key_speakers") or []
+                        timeline_raw = row.get("timeline") or []
+                        if isinstance(timeline_raw, str):
+                            timeline_raw = _json.loads(timeline_raw)
+                        try:
+                            result = normalize_chapter_speakers(
+                                chapter_id,
+                                speakers_raw,
+                                key_speakers_raw,
+                                timeline_raw,
+                                conn,
+                                snc,
+                            )
+                            if result.updated:
+                                logging.info(
+                                    "_normalize_speakers: chapter %d updated with %d correction(s)",
+                                    chapter_id, len(result.corrections),
+                                )
+                        except Exception as exc:  # noqa: BLE001
+                            logging.warning(
+                                "_normalize_speakers: error normalizing chapter %d: %s",
+                                chapter_id, exc,
+                            )
+        return True
+
+    t_normalize_speakers = ShortCircuitOperator(
+        task_id="normalize_speakers",
+        python_callable=lambda **ctx: snc.ENABLED and _normalize_speakers(**ctx),
+        trigger_rule="all_done",
+    )
+
     # Task dependencies
 
     # Start: Branch based on test mode
@@ -622,3 +697,7 @@ with DAG(
     # Note: session_number and session_date come from t5c and t5d tasks
     # We need both the VAD-trimmed scoring (t_trim) and session info (t5c)
     [t_trim, t5c] >> t9_db
+
+    # After saving chapters, normalize speaker names (best-effort; all_done so a
+    # partial save never blocks normalization)
+    t9_db >> t_normalize_speakers

--- a/tests/congress_videos/modules/test_participants_db.py
+++ b/tests/congress_videos/modules/test_participants_db.py
@@ -232,6 +232,24 @@ class TestLookupParticipantFuzzy:
         monkeypatch.setitem(sys.modules, "rapidfuzz", stub_rapidfuzz)
         monkeypatch.setitem(sys.modules, "rapidfuzz.fuzz", stub_fuzz)
 
+    @staticmethod
+    def _stub_rapidfuzz_per_pair(monkeypatch, score_map: dict) -> None:
+        """Install a stub token_sort_ratio that returns different scores per (a,b) pair.
+
+        score_map keys are (a, b) tuples; any unrecognised pair returns 0.
+        """
+        import types
+        import sys
+
+        def _token_sort_ratio(a: str, b: str) -> float:
+            return score_map.get((a, b), 0.0) * 100
+
+        stub_fuzz = types.SimpleNamespace(token_sort_ratio=_token_sort_ratio)
+        stub_rapidfuzz = types.ModuleType("rapidfuzz")
+        stub_rapidfuzz.fuzz = stub_fuzz
+        monkeypatch.setitem(sys.modules, "rapidfuzz", stub_rapidfuzz)
+        monkeypatch.setitem(sys.modules, "rapidfuzz.fuzz", stub_fuzz)
+
     def test_above_threshold_returns_dict(self, monkeypatch):
         """Fuzzy match at or above 0.90 → returns best matching dict."""
         rows = [
@@ -266,6 +284,136 @@ class TestLookupParticipantFuzzy:
         result = lookup_participant_fuzzy("zzzunknownzzz", threshold=0.90)
 
         assert result is None
+
+    # -----------------------------------------------------------------------
+    # TASK 3 (RED): dual-field scoring tests
+    # -----------------------------------------------------------------------
+
+    def test_match_via_display_name_only(self, monkeypatch):
+        """A name that only matches display_name (not normalized_name) is found.
+
+        Simulates: dirty name 'Pedro Sanchez' whose normalized form scores
+        LOW against normalized_name 'sanchez pedro jose luis' but HIGH against
+        normalize_member_name(display_name) = 'sanchez pedro'.
+        """
+        from congress_videos.modules.participants_ingestion import normalize_member_name
+
+        rows = [
+            {
+                "normalized_name": "sanchez pedro jose luis",  # full official name — low similarity
+                "display_name": "Sánchez, Pedro",             # short display name — high similarity
+                "party": "PSOE",
+                "photo_url": None,
+                "biography": "Bio.",
+            }
+        ]
+
+        # normalized key for 'Pedro Sanchez' via normalize_member_name
+        key = normalize_member_name("Pedro Sanchez")
+        display_key = normalize_member_name("Sánchez, Pedro")
+
+        # normalized_name score: LOW (below threshold)
+        # display_name score: HIGH (above threshold)
+        score_map = {
+            (key, "sanchez pedro jose luis"): 0.60,  # below 0.90
+            (key, display_key): 0.95,                # above 0.90
+        }
+        self._stub_rapidfuzz_per_pair(monkeypatch, score_map)
+
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_fuzzy
+        result = lookup_participant_fuzzy("Pedro Sanchez", threshold=0.90)
+
+        assert result is not None, (
+            "Expected a match via display_name scoring, got None"
+        )
+        assert result["normalized_name"] == "sanchez pedro jose luis"
+
+    def test_match_via_display_name_includes_display_name_in_result(self, monkeypatch):
+        """Result dict must contain 'display_name' key."""
+        from congress_videos.modules.participants_ingestion import normalize_member_name
+
+        rows = [
+            {
+                "normalized_name": "sanchez pedro jose luis",
+                "display_name": "Sánchez, Pedro",
+                "party": "PSOE",
+                "photo_url": None,
+                "biography": "Bio.",
+            }
+        ]
+
+        key = normalize_member_name("Pedro Sanchez")
+        display_key = normalize_member_name("Sánchez, Pedro")
+        score_map = {
+            (key, "sanchez pedro jose luis"): 0.60,
+            (key, display_key): 0.95,
+        }
+        self._stub_rapidfuzz_per_pair(monkeypatch, score_map)
+
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_fuzzy
+        result = lookup_participant_fuzzy("Pedro Sanchez", threshold=0.90)
+
+        assert result is not None
+        assert "display_name" in result, "Result dict must include display_name"
+        assert result["display_name"] == "Sánchez, Pedro"
+
+    def test_no_match_when_both_fields_below_threshold(self, monkeypatch):
+        """Returns None when both normalized_name and display_name score below threshold."""
+        from congress_videos.modules.participants_ingestion import normalize_member_name
+
+        rows = [
+            {
+                "normalized_name": "garcia ana",
+                "display_name": "García, Ana",
+                "party": "PP",
+                "photo_url": None,
+                "biography": "Bio.",
+            }
+        ]
+
+        # All scores are below threshold
+        key = normalize_member_name("zzzunknownzzz")
+        score_map: dict = {}  # all pairs return 0 (default)
+
+        self._stub_rapidfuzz_per_pair(monkeypatch, score_map)
+
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_fuzzy
+        result = lookup_participant_fuzzy("zzzunknownzzz", threshold=0.90)
+
+        assert result is None, "Expected None when both scoring fields are below threshold"
+
+    def test_normalized_name_match_still_works(self, monkeypatch):
+        """Existing normalized_name match is preserved after dual-field extension."""
+        rows = [
+            {
+                "normalized_name": "garcia ana",
+                "display_name": "García, Ana",
+                "party": "P",
+                "photo_url": None,
+                "biography": "Bio.",
+            }
+        ]
+
+        # All calls return 0.95 (above threshold)
+        self._stub_rapidfuzz(monkeypatch, score=0.95)
+
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_fuzzy
+        result = lookup_participant_fuzzy("garcia ana", threshold=0.90)
+
+        assert result is not None
+        assert result["normalized_name"] == "garcia ana"
 
 
 # ===========================================================================

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -1,0 +1,479 @@
+"""Tests for congress_videos.modules.speaker_normalization — TASK 6 (RED).
+
+Covers six behavioral scenarios from REQ: speaker_normalization module.
+All DB and LLM calls are stubbed; no real network or DB needed.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def set_pg_env(monkeypatch):
+    """Provide minimal DB env vars so PostgresConnection.__init__ does not raise."""
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "testuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "testpass")
+    monkeypatch.setenv("POSTGRES_SCHEMA", "public")
+
+
+@pytest.fixture
+def mock_db_conn(mock_psycopg2_connection):
+    """Return (mock_conn, mock_cursor) with psycopg2 fully mocked."""
+    _, mock_conn, mock_cursor = mock_psycopg2_connection
+    return mock_conn, mock_cursor
+
+
+def _make_config(enabled: bool = True, fuzzy_threshold: float = 0.90,
+                 ai_model: str = "gpt-4o-mini", context_enabled: bool = True):
+    """Build a minimal config-like namespace."""
+    cfg = MagicMock()
+    cfg.ENABLED = enabled
+    cfg.FUZZY_THRESHOLD = fuzzy_threshold
+    cfg.AI_MODEL = ai_model
+    cfg.CONTEXT_ENABLED = context_enabled
+    return cfg
+
+
+def _make_ai_result(decision: str, confidence: float = 0.95, reason: str = "test"):
+    """Return a cached_json_completion-style result dict."""
+    return {
+        "data": {"decision": decision, "confidence": confidence, "reason": reason},
+        "raw_content": "",
+        "error": None,
+    }
+
+
+def _make_participant(display_name: str, normalized_name: str = "pedro sanchez"):
+    """Return a participant row dict as returned by lookup_participant_fuzzy."""
+    return {
+        "normalized_name": normalized_name,
+        "display_name": display_name,
+        "party": "PartyA",
+        "parliamentary_group": "GroupA",
+        "constituency": "Madrid",
+        "biography": None,
+        "photo_url": None,
+    }
+
+
+# ---------------------------------------------------------------------------
+# T-01: Confident match rewrites chapter fields
+# ---------------------------------------------------------------------------
+
+class TestConfidentMatch:
+    """T-01 — fuzzy hit + AI match → canonical name replaces dirty name in all fields."""
+
+    def test_matched_speaker_updates_chapter_fields(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        chapter_id = 5
+        speakers = ["Pedro Sanchez", "Unknown Person"]
+        key_speakers = ["Pedro Sanchez"]
+        timeline = [
+            {"time": "00:01:00", "speaker": "Pedro Sanchez", "content": "Hola"},
+            {"time": "00:02:00", "speaker": "Unknown Person", "content": "Bye"},
+        ]
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate) as mock_fuzzy,
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result) as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                chapter_id, speakers, key_speakers, timeline,
+                mock_conn, _make_config()
+            )
+
+        # AI must have been called for the matched dirty name
+        assert mock_ai.called
+
+        # Result reports a correction
+        assert "Pedro Sanchez" in result.corrections
+        assert result.corrections["Pedro Sanchez"] == "Pedro Sánchez"
+        assert result.updated is True
+
+        # Cache row for matched speaker written via cursor execute
+        # Verify that an upsert was attempted (execute called)
+        assert mock_cursor.execute.called
+
+        # The DB UPDATE for video_chapters must have been issued
+        calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
+        assert any("update" in s and "video_chapters" in s for s in calls_sql), (
+            "Expected UPDATE video_chapters to be executed for matched speaker"
+        )
+
+    def test_matched_speaker_cache_row_has_matched_status(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert len(result.cache_rows) == 1
+        row = result.cache_rows[0]
+        assert row["status"] == "matched"
+        assert row["dirty_speaker"] == "Pedro Sanchez"
+        assert row["canonical_speaker"] == "Pedro Sánchez"
+
+    def test_unknown_person_left_unchanged(self, mock_db_conn):
+        """Only the matched dirty name should be corrected; others remain."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        def fuzzy_side_effect(name, threshold):
+            if name == "Pedro Sanchez":
+                return _make_participant("Pedro Sánchez", "pedro sanchez")
+            return None
+
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  side_effect=fuzzy_side_effect),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["Pedro Sanchez", "Unknown Person"], ["Pedro Sanchez"], [],
+                mock_conn, _make_config()
+            )
+
+        # Unknown Person must not appear in corrections
+        assert "Unknown Person" not in result.corrections
+
+
+# ---------------------------------------------------------------------------
+# T-02: Fuzzy threshold miss — no AI call
+# ---------------------------------------------------------------------------
+
+class TestFuzzyThresholdMiss:
+    """T-02 — score below FUZZY_THRESHOLD → cached_json_completion NOT called, no_match row."""
+
+    def test_no_ai_call_when_fuzzy_misses(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None) as mock_fuzzy,
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion") as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["UnknownSpeakerXYZ"], [], [],
+                mock_conn, _make_config()
+            )
+
+        mock_ai.assert_not_called()
+
+    def test_no_match_cache_row_written_on_fuzzy_miss(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["UnknownSpeakerXYZ"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert len(result.cache_rows) == 1
+        assert result.cache_rows[0]["status"] == "no_match"
+
+    def test_chapter_not_updated_on_fuzzy_miss(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["UnknownSpeakerXYZ"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert result.updated is False
+
+        # No UPDATE to video_chapters should have been issued
+        calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
+        assert not any("update" in s and "video_chapters" in s for s in calls_sql)
+
+
+# ---------------------------------------------------------------------------
+# T-03: AI returns no_match — chapter unchanged
+# ---------------------------------------------------------------------------
+
+class TestAINoMatch:
+    """T-03 — fuzzy hit, but AI returns no_match → no UPDATE, no_match cache row."""
+
+    def test_no_update_when_ai_returns_no_match(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("no_match", confidence=0.3)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["PedroSanchezVariant"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert result.updated is False
+
+        calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
+        assert not any("update" in s and "video_chapters" in s for s in calls_sql)
+
+    def test_no_match_cache_row_written_when_ai_returns_no_match(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("no_match", confidence=0.3)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["PedroSanchezVariant"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert len(result.cache_rows) == 1
+        assert result.cache_rows[0]["status"] == "no_match"
+
+
+# ---------------------------------------------------------------------------
+# T-04: AI returns needs_manual — chapter unchanged
+# ---------------------------------------------------------------------------
+
+class TestAINeedsManual:
+    """T-04 — AI cannot decide → needs_manual cache row, no chapter update."""
+
+    def test_no_update_when_ai_returns_needs_manual(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("needs_manual", confidence=0.5)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["PedroAmbiguous"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert result.updated is False
+
+    def test_needs_manual_cache_row_written(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("needs_manual", confidence=0.5)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["PedroAmbiguous"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert len(result.cache_rows) == 1
+        assert result.cache_rows[0]["status"] == "needs_manual"
+
+
+# ---------------------------------------------------------------------------
+# T-05: Multiple speakers — each processed independently
+# ---------------------------------------------------------------------------
+
+class TestMultipleSpeakers:
+    """T-05 — three dirty speakers → one cache row per unique dirty name."""
+
+    def test_each_speaker_gets_independent_cache_row(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        participant_map = {
+            "Speaker One": _make_participant("Speaker One", "speaker one"),
+            "Speaker Two": _make_participant("Speaker Two", "speaker two"),
+        }
+
+        def fuzzy_side(name, threshold):
+            return participant_map.get(name)
+
+        ai_result = _make_ai_result("match", confidence=0.90)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  side_effect=fuzzy_side),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                7,
+                ["Speaker One", "Speaker Two", "Unknown"],
+                [],
+                [],
+                mock_conn,
+                _make_config(),
+            )
+
+        # One cache row per unique dirty speaker
+        assert len(result.cache_rows) == 3
+
+    def test_only_matched_speakers_corrected(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        def fuzzy_side(name, threshold):
+            if name == "Speaker One":
+                return _make_participant("Speaker One", "speaker one")
+            return None
+
+        ai_result = _make_ai_result("match", confidence=0.90)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  side_effect=fuzzy_side),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                7,
+                ["Speaker One", "Speaker Two", "Unknown"],
+                [],
+                [],
+                mock_conn,
+                _make_config(),
+            )
+
+        assert "Speaker One" in result.corrections
+        assert "Speaker Two" not in result.corrections
+        assert "Unknown" not in result.corrections
+
+
+# ---------------------------------------------------------------------------
+# T-06: AI call error — graceful skip, no cache write
+# ---------------------------------------------------------------------------
+
+class TestAICallError:
+    """T-06 — cached_json_completion returns non-None error → skip, no cache row."""
+
+    def test_ai_error_skips_cache_write(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_error_result = {"data": None, "raw_content": "", "error": "Timeout"}
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_error_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # No cache row written on error
+        assert len(result.cache_rows) == 0
+
+    def test_ai_error_does_not_update_chapter(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_error_result = {"data": None, "raw_content": "", "error": "Timeout"}
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_error_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config()
+            )
+
+        assert result.updated is False
+        calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
+        assert not any("update" in s and "video_chapters" in s for s in calls_sql)
+
+
+# ---------------------------------------------------------------------------
+# T-07 (Bonus from task description): ENABLED=False → immediate return
+# ---------------------------------------------------------------------------
+
+class TestEnabledFalse:
+    """ENABLED=False → function returns without any DB or AI calls."""
+
+    def test_disabled_config_returns_immediately(self, mock_db_conn):
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy") as mock_fuzzy,
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion") as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                1, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config(enabled=False)
+            )
+
+        mock_fuzzy.assert_not_called()
+        mock_ai.assert_not_called()
+        mock_cursor.execute.assert_not_called()
+        assert result.updated is False
+        assert result.corrections == {}
+        assert result.cache_rows == []

--- a/tests/congress_videos/sql/test_migration_017.py
+++ b/tests/congress_videos/sql/test_migration_017.py
@@ -1,0 +1,102 @@
+"""Test: migration 017 DDL presence.
+
+Reads the SQL file and asserts that all required table definitions, constraints,
+and FK references are present in the text.  Fast and infrastructure-free.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "017_create_speaker_normalization_cache.sql"
+)
+
+
+class TestMigration017FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), (
+            f"Migration file not found: {MIGRATION_PATH}"
+        )
+
+
+class TestMigration017TableStructure:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_creates_speaker_normalization_cache_table(self):
+        """DDL must create the speaker_normalization_cache table."""
+        sql = self._sql()
+        assert "CREATE TABLE" in sql.upper()
+        assert "speaker_normalization_cache" in sql
+
+    def test_has_unique_constraint_on_chapter_id_and_dirty_speaker(self):
+        """DDL must include UNIQUE (chapter_id, dirty_speaker)."""
+        sql = self._sql()
+        # Allow both UNIQUE(chapter_id, dirty_speaker) and UNIQUE (chapter_id, dirty_speaker)
+        assert "chapter_id" in sql
+        assert "dirty_speaker" in sql
+        assert "UNIQUE" in sql.upper()
+
+    def test_status_check_contains_matched(self):
+        """CHECK constraint must include 'matched' status value."""
+        sql = self._sql()
+        assert "matched" in sql
+        assert "CHECK" in sql.upper()
+
+    def test_status_check_contains_no_match(self):
+        """CHECK constraint must include 'no_match' status value."""
+        sql = self._sql()
+        assert "no_match" in sql
+
+    def test_status_check_contains_needs_manual(self):
+        """CHECK constraint must include 'needs_manual' status value."""
+        sql = self._sql()
+        assert "needs_manual" in sql
+
+    def test_fk_references_video_chapters_chapter_id(self):
+        """FK must reference video_chapters(chapter_id) — NOT video_chapters(id)."""
+        sql = self._sql()
+        assert "REFERENCES video_chapters(chapter_id)" in sql
+
+    def test_fk_references_congress_participants_normalized_name(self):
+        """FK must reference congress_participants(normalized_name)."""
+        sql = self._sql()
+        assert "REFERENCES congress_participants(normalized_name)" in sql
+
+    def test_has_id_primary_key(self):
+        """DDL must define an id SERIAL PRIMARY KEY column."""
+        sql = self._sql().upper()
+        assert "SERIAL" in sql
+        assert "PRIMARY KEY" in sql
+
+    def test_has_created_at_and_updated_at_columns(self):
+        """DDL must define created_at and updated_at TIMESTAMPTZ columns."""
+        sql = self._sql()
+        assert "created_at" in sql
+        assert "updated_at" in sql
+        assert "TIMESTAMPTZ" in sql.upper() or "TIMESTAMP WITH TIME ZONE" in sql.upper()
+
+    def test_has_confidence_score_column(self):
+        """DDL must include a confidence_score NUMERIC column."""
+        sql = self._sql()
+        assert "confidence_score" in sql
+        assert "NUMERIC" in sql.upper()
+
+    def test_has_canonical_speaker_column(self):
+        """DDL must include a canonical_speaker TEXT column."""
+        sql = self._sql()
+        assert "canonical_speaker" in sql
+
+    def test_has_participant_normalized_name_column(self):
+        """DDL must include participant_normalized_name column."""
+        sql = self._sql()
+        assert "participant_normalized_name" in sql

--- a/tests/congress_videos/test_youtube_channel_monitor_dag.py
+++ b/tests/congress_videos/test_youtube_channel_monitor_dag.py
@@ -174,3 +174,39 @@ class TestFilterFinishedStreamsTopology:
         }
 
         assert branch.python_callable(ti) == "no_plenary_sessions"
+
+
+# ---------------------------------------------------------------------------
+# TASK 8 (RED) — t_normalize_speakers topology
+# ---------------------------------------------------------------------------
+
+class TestNormalizeSpeakersTask:
+    """TASK 8 — t_normalize_speakers exists, is wired after save_chapters_to_db,
+    and has trigger_rule='all_done'."""
+
+    def test_normalize_speakers_task_exists(self):
+        from congress_videos.youtube_channel_monitor_dag import dag
+        task_ids = {t.task_id for t in dag.tasks}
+        assert "normalize_speakers" in task_ids, (
+            "Expected task_id 'normalize_speakers' in DAG tasks"
+        )
+
+    def test_normalize_speakers_trigger_rule_is_all_done(self):
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t = tasks_by_id["normalize_speakers"]
+        assert str(t.trigger_rule) == "all_done", (
+            f"Expected trigger_rule='all_done', got {t.trigger_rule!r}"
+        )
+
+    def test_normalize_speakers_is_downstream_of_save_chapters_to_db(self):
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+
+        t9_db = tasks_by_id["save_chapters_to_db"]
+        normalize = tasks_by_id["normalize_speakers"]
+
+        downstream_ids = {t.task_id for t in t9_db.downstream_list}
+        assert normalize.task_id in downstream_ids, (
+            "'normalize_speakers' must be a direct downstream of 'save_chapters_to_db'"
+        )


### PR DESCRIPTION
Closes #33

## Summary

- Adds `speaker_normalization_cache` table (migration 017) to persist every dirty→canonical speaker mapping with status (`matched`/`no_match`/`needs_manual`) and confidence score.
- Extends `lookup_participant_fuzzy` to score against both `normalized_name` and `display_name`, then AI-verifies candidates via `cached_json_completion`; writes corrections back to `video_chapters.speakers`, `key_speakers`, and `timeline[].speaker`.
- Wires `t_normalize_speakers` (`ShortCircuitOperator`, `trigger_rule='all_done'`) after `save_chapters_to_db` in `youtube_channel_monitor_dag.py`; skippable via `ENABLED=False`.

## Changes

| File | Change |
|------|--------|
| `congress_videos/sql/migrations/017_create_speaker_normalization_cache.sql` | New DDL — mapping table with FK to `video_chapters(chapter_id)` and `congress_participants(normalized_name)` |
| `congress_videos/modules/participants_db.py` | `lookup_participant_fuzzy` extended to dual-field scoring, returns `display_name` |
| `congress_videos/config/speaker_normalization_config.py` | New — `FUZZY_THRESHOLD`, `AI_MODEL`, `ENABLED`, `CONTEXT_ENABLED` |
| `congress_videos/modules/speaker_normalization.py` | New — `normalize_chapter_speakers` orchestration module |
| `congress_videos/modules/database.py` | `update_chapter_speakers` helper added |
| `congress_videos/config/ai_prompts.py` | `SPEAKER_MATCH_SYSTEM_PROMPT` + user template added |
| `congress_videos/youtube_channel_monitor_dag.py` | `t_normalize_speakers` task + wiring |
| `tests/congress_videos/sql/test_migration_017.py` | New — DDL + constraint assertions |
| `tests/congress_videos/modules/test_participants_db.py` | Dual-field scoring tests added |
| `tests/congress_videos/modules/test_speaker_normalization.py` | New — 15 tests across 7 scenarios |
| `tests/congress_videos/test_youtube_channel_monitor_dag.py` | DAG topology tests added |

## Test plan

- [x] Full suite: 1386 passed, 1 skipped
- [x] `test_speaker_normalization.py`: 15 tests GREEN (matched, no-match, needs-manual, fuzzy-miss, multi-speaker, AI-error, ENABLED=False)
- [x] `test_migration_017.py`: 13 DDL/constraint tests GREEN
- [x] DAG topology: 3 tests GREEN (task exists, trigger_rule, downstream wiring)
- [x] Coverage on `speaker_normalization.py`: 96.49%
- [x] Strict TDD: all production files preceded by RED test