### PR TITLE
fix(speakers): set search_path before unqualified table queries

### DIFF
--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from dataclasses import dataclass, field
 
 from congress_videos.config.ai_prompts import (
@@ -171,7 +172,10 @@ def normalize_chapter_speakers(
     if not dirty_names:
         return result
 
+    _schema = os.getenv("POSTGRES_SCHEMA", "public")
+
     with db_conn.cursor() as cursor:
+        cursor.execute(f"SET search_path TO {_schema}, public")
         for dirty in dirty_names:
             # Step 1: fuzzy lookup
             candidate = lookup_participant_fuzzy(dirty, threshold=config.FUZZY_THRESHOLD)


### PR DESCRIPTION
Post-merge hotfix for #33

## Summary

`normalize_chapter_speakers` now sets `SET search_path TO <schema>, public` at the start of the cursor block so unqualified table names resolve correctly against `development`/`production`.

**Root cause**: `PostgresConnection.get_connection()` doesn't set `search_path`, so it defaults to `public` and the migration tables under `development` schema weren't found.

## Test plan

- [x] 15 unit tests pass
- [x] Verified in dev container — no more `relation does not exist`