### PR TITLE
fix(speakers): use token_set_ratio for partial name subset matching

### DIFF
--- a/congress_videos/modules/participants_db.py
+++ b/congress_videos/modules/participants_db.py
@@ -183,15 +183,18 @@ def lookup_participant_fuzzy(
         Best-matching row dict (includes ``display_name``) if score >= threshold,
         None otherwise.
     """
-    from rapidfuzz.fuzz import token_sort_ratio  # lazy import — Slice 2 dependency
+    from rapidfuzz.fuzz import token_sort_ratio, token_set_ratio  # lazy import — Slice 2 dependency
 
     key = normalize_member_name(name)
     rows = _get_participants_for_lookup()
     best: dict | None = None
     best_score = 0.0
     for row in rows:
-        score_normalized = token_sort_ratio(key, row["normalized_name"]) / 100.0
-        score_display = token_sort_ratio(key, normalize_member_name(row["display_name"])) / 100.0
+        norm = row["normalized_name"]
+        disp = normalize_member_name(row["display_name"])
+        # token_sort_ratio for full-name matches; token_set_ratio for partial/subset matches
+        score_normalized = max(token_sort_ratio(key, norm), token_set_ratio(key, norm)) / 100.0
+        score_display = max(token_sort_ratio(key, disp), token_set_ratio(key, disp)) / 100.0
         score = max(score_normalized, score_display)
         if score > best_score:
             best, best_score = row, score

--- a/tests/congress_videos/modules/test_participants_db.py
+++ b/tests/congress_videos/modules/test_participants_db.py
@@ -226,7 +226,10 @@ class TestLookupParticipantFuzzy:
         import types
         import sys
 
-        stub_fuzz = types.SimpleNamespace(token_sort_ratio=lambda a, b: score * 100)
+        stub_fuzz = types.SimpleNamespace(
+            token_sort_ratio=lambda a, b: score * 100,
+            token_set_ratio=lambda a, b: score * 100,
+        )
         stub_rapidfuzz = types.ModuleType("rapidfuzz")
         stub_rapidfuzz.fuzz = stub_fuzz
         monkeypatch.setitem(sys.modules, "rapidfuzz", stub_rapidfuzz)
@@ -234,17 +237,17 @@ class TestLookupParticipantFuzzy:
 
     @staticmethod
     def _stub_rapidfuzz_per_pair(monkeypatch, score_map: dict) -> None:
-        """Install a stub token_sort_ratio that returns different scores per (a,b) pair.
+        """Install a stub that returns different scores per (a,b) pair.
 
         score_map keys are (a, b) tuples; any unrecognised pair returns 0.
         """
         import types
         import sys
 
-        def _token_sort_ratio(a: str, b: str) -> float:
+        def _ratio(a: str, b: str) -> float:
             return score_map.get((a, b), 0.0) * 100
 
-        stub_fuzz = types.SimpleNamespace(token_sort_ratio=_token_sort_ratio)
+        stub_fuzz = types.SimpleNamespace(token_sort_ratio=_ratio, token_set_ratio=_ratio)
         stub_rapidfuzz = types.ModuleType("rapidfuzz")
         stub_rapidfuzz.fuzz = stub_fuzz
         monkeypatch.setitem(sys.modules, "rapidfuzz", stub_rapidfuzz)


### PR DESCRIPTION
Post-merge fix for #33 — adds `token_set_ratio` alongside `token_sort_ratio` so partial names like 'Santana Perera' correctly match 'Santana Perera, Noemí' (the ratio scorer penalises short queries against long candidates). Also updates test stubs to expose both functions.