### PR TITLE
feat(thumbnail-dag): slug lookup, no-speaker tolerance & skill-aligned art-director prompts

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -135,6 +135,30 @@ IMPORTANTE: Si la frase supera {max_length} caracteres, acórtala eliminando pal
 
 Devuelve SOLO la frase, sin explicaciones."""
 
+# Art Direction — produces a JSON brief ({text, background, person, mood}) used by
+# build_pikzels_prompt to fill Template A/B/C from the congress-thumbnail skill.
+ART_DIRECTION_SYSTEM_PROMPT = (
+    "Eres un director de arte experto en miniaturas de YouTube de alto CTR para canales políticos españoles. "
+    "Tu tarea es crear un brief visual en JSON para una miniatura siguiendo estas reglas estrictas:\n\n"
+    "- text: frase de 3-6 palabras, TODO EN MAYÚSCULAS, máximo 40 caracteres. Provocadora, no descriptiva.\n"
+    "- background: fondo contextual al tema (protesta callejera, fábrica cerrada, hospital, etc.). "
+    "NUNCA hemiciclo, cámara parlamentaria ni sala de gobierno.\n"
+    "- person: persona relatable, edad/expresión/ropa concreta. Ocupa el 35-40%% del frame. "
+    "Expresión emocional (indignación, miedo, sorpresa). Que cualquier ciudadano español se vea reflejado.\n"
+    "- mood: tono emocional dominante (indignación, amenaza, curiosidad, identidad, pérdida).\n\n"
+    "PROHIBICIÓN ABSOLUTA: no incluyas nunca URLs ni la palabra 'http' en ningún campo. "
+    "Pikzels rechaza cualquier prompt que contenga 'http'.\n\n"
+    "Responde SOLO con JSON válido, sin markdown:\n"
+    '{"text": "...", "background": "...", "person": "...", "mood": "..."}'
+)
+
+ART_DIRECTION_USER_PROMPT_TEMPLATE = (
+    "Crea el brief visual JSON para la miniatura de YouTube de este debate parlamentario.\n\n"
+    "RESUMEN DEL DEBATE:\n{debate_summary}\n\n"
+    "Devuelve SOLO el JSON con los campos text, background, person y mood. Sin markdown."
+)
+
+
 # Thumbnail Title Generation (Pikzels + OpenAI pipeline)
 THUMBNAIL_TITLE_SYSTEM_PROMPT = (
     "Eres un redactor político experto en titulares de alto impacto para YouTube. "

--- a/congress_videos/config/thumbnail_config.py
+++ b/congress_videos/config/thumbnail_config.py
@@ -21,13 +21,13 @@ class ConfigError(Exception):
 def _get_thumbnail_config() -> dict:
     """Build and return the full per-domain thumbnail configuration dict.
 
-    Defined as a function to defer import of ``lookup_participant_fuzzy``
+    Defined as a function to defer import of ``lookup_participant_by_slug``
     until call time (avoids circular imports at module load).
 
     Returns:
         Mapping from domain key to per-domain config dict.
     """
-    from congress_videos.modules.participants_db import lookup_participant_fuzzy
+    from congress_videos.modules.participants_db import lookup_participant_by_slug
 
     return {
         "congreso": {
@@ -57,9 +57,9 @@ def _get_thumbnail_config() -> dict:
                     ),
                 },
             ],
-            # Callable that resolves a participant by normalized name.
-            # Signature: (name: str) -> dict | None
-            "participants_lookup": lookup_participant_fuzzy,
+            # Callable that resolves a participant by slug: exact, case-sensitive match.
+            # Signature: (slug: str) -> dict | None
+            "participants_lookup": lookup_participant_by_slug,
             # Optional absolute path to a fallback party logo image.
             # Set to None when no logo file is available.
             "party_logo_map": None,

--- a/congress_videos/config/thumbnail_config.py
+++ b/congress_videos/config/thumbnail_config.py
@@ -31,30 +31,17 @@ def _get_thumbnail_config() -> dict:
 
     return {
         "congreso": {
-            # Visual styles / personas for Pikzels thumbnail generation.
-            # Exactly 2 entries — one per generated option.
+            # Visual styles for Pikzels thumbnail generation.
+            # Each entry maps a label to a Pikzels Template layout (A, B, or C).
+            # Exactly 2 entries — one per generated option for A/B testing.
             "styles": [
                 {
                     "label": "option_a",
-                    "style": (
-                        "Dramatic political documentary style. High-contrast lighting. "
-                        "Spanish parliament chamber background. Bold typography overlay."
-                    ),
-                    "persona": (
-                        "Senior political journalist covering the Spanish Congress. "
-                        "Authoritative, serious, newsroom aesthetic."
-                    ),
+                    "layout": "A",
                 },
                 {
                     "label": "option_b",
-                    "style": (
-                        "Modern editorial news style. Clean, professional composition. "
-                        "Gradient overlay with official Spanish flag colours."
-                    ),
-                    "persona": (
-                        "Digital-native political correspondent. "
-                        "Dynamic, impactful, social-media-ready framing."
-                    ),
+                    "layout": "B",
                 },
             ],
             # Callable that resolves a participant by slug: exact, case-sensitive match.

--- a/congress_videos/generic_thumbnail_generator_dag.py
+++ b/congress_videos/generic_thumbnail_generator_dag.py
@@ -20,6 +20,17 @@ Usage::
 
 Note: ``slug`` is optional. When absent or empty, the photo-resolution task
 returns an empty result and the DAG proceeds without a support image.
+
+Pipeline overview::
+
+    validate_input
+      → resolve_participant_photo
+        → art_direction
+          → generate_thumbnail_option_a → download_option_a → score_option_a
+          → generate_thumbnail_option_b → download_option_b → score_option_b
+                                                              → choose_best_option
+                                                                → generate_title
+                                                                  → persist_results
 """
 
 from __future__ import annotations
@@ -35,11 +46,13 @@ from congress_videos.config.paths import get_thumbnail_dir
 from congress_videos.config.thumbnail_config import ConfigError, get_domain_config
 from congress_videos.modules import pikzels_client as _pkz
 from congress_videos.modules.thumbnail_generation import (
+    art_direct,
     choose_best_option,
     generate_title,
     persist_results,
     resolve_participant_photo,
 )
+from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
 
 # ---------------------------------------------------------------------------
 # Required conf keys for every DAG run.
@@ -102,29 +115,37 @@ def _task_resolve_photo(ti: TaskInstance, **context: object) -> dict:
     return resolve_participant_photo(conf.get("slug"), domain_cfg)
 
 
+def _task_art_direction(ti: TaskInstance, **context: object) -> dict:
+    """Generate an art-direction brief via OpenAI for both thumbnail options."""
+    conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
+    domain_cfg = get_domain_config(conf["domain"])
+    return art_direct(conf["debate_summary"], domain_cfg)
+
+
 def _task_generate_thumbnail(label: str, ti: TaskInstance, **context: object) -> dict:
-    """Generate one thumbnail option via Pikzels and return the raw response."""
+    """Generate one thumbnail option via Pikzels using the art-direction brief."""
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
     photo_data: dict = ti.xcom_pull(task_ids="resolve_participant_photo") or {}
+    art_brief: dict = ti.xcom_pull(task_ids="art_direction") or {}
     domain_cfg = get_domain_config(conf["domain"])
 
     styles = domain_cfg["styles"]
     style_cfg = next(s for s in styles if s["label"] == label)
+    layout = style_cfg["layout"]
 
     support_b64 = photo_data.get("support_image_b64", "")
     data_url = f"data:image/jpeg;base64,{support_b64}" if support_b64 else None
 
+    prompt = build_pikzels_prompt(art_brief, layout)
+
     result = _pkz.thumbnail_from_text(
-        conf["debate_summary"],
-        persona=style_cfg.get("persona"),
-        style=style_cfg.get("style"),
+        prompt,
         support_image_base64=data_url,
     )
-    # Attach label and style context for downstream tasks.
+    # Attach label, layout (as style), and prompt for downstream tasks.
     result["label"] = label
-    result["style"] = style_cfg.get("style", "")
-    result["persona"] = style_cfg.get("persona", "")
-    result["prompt"] = conf["debate_summary"]
+    result["style"] = layout
+    result["prompt"] = prompt
     return result
 
 
@@ -144,7 +165,6 @@ def _task_download_option(label: str, ti: TaskInstance, **context: object) -> di
         "local_path": str(local_path),
         "output_url": output_url,
         "style": gen_result.get("style", ""),
-        "persona": gen_result.get("persona", ""),
         "prompt": gen_result.get("prompt", ""),
     }
 
@@ -238,6 +258,11 @@ with DAG(
         python_callable=_task_resolve_photo,
     )
 
+    t_art_direction = PythonOperator(
+        task_id="art_direction",
+        python_callable=_task_art_direction,
+    )
+
     t_gen_a = PythonOperator(
         task_id="generate_thumbnail_option_a",
         python_callable=lambda ti, **ctx: _task_generate_thumbnail("option_a", ti=ti, **ctx),
@@ -290,12 +315,13 @@ with DAG(
     # Task dependency graph:
     #   validate_input
     #     → resolve_participant_photo
-    #       → generate_thumbnail_option_a → download_option_a → score_option_a
-    #       → generate_thumbnail_option_b → download_option_b → score_option_b
-    #                                                           → choose_best_option
-    #                                                             → generate_title
-    #                                                               → persist_results
-    t_validate >> t_resolve_photo
-    t_resolve_photo >> t_gen_a >> t_dl_a >> t_score_a
-    t_resolve_photo >> t_gen_b >> t_dl_b >> t_score_b
+    #       → art_direction
+    #         → generate_thumbnail_option_a → download_option_a → score_option_a
+    #         → generate_thumbnail_option_b → download_option_b → score_option_b
+    #                                                             → choose_best_option
+    #                                                               → generate_title
+    #                                                                 → persist_results
+    t_validate >> t_resolve_photo >> t_art_direction
+    t_art_direction >> t_gen_a >> t_dl_a >> t_score_a
+    t_art_direction >> t_gen_b >> t_dl_b >> t_score_b
     [t_score_a, t_score_b] >> t_choose >> t_title >> t_persist

--- a/congress_videos/generic_thumbnail_generator_dag.py
+++ b/congress_videos/generic_thumbnail_generator_dag.py
@@ -15,8 +15,11 @@ Usage::
         "debate_summary": "El debate ...",
         "session": "Pleno 2026-06-10",
         "domain": "<domain_key>",
-        "normalized_name": "<normalized_speaker_name>"
+        "slug": "<participant_slug>"
     }'
+
+Note: ``slug`` is optional. When absent or empty, the photo-resolution task
+returns an empty result and the DAG proceeds without a support image.
 """
 
 from __future__ import annotations
@@ -48,7 +51,6 @@ _REQUIRED_CONF_KEYS = (
     "debate_summary",
     "session",
     "domain",
-    "normalized_name",
 )
 
 # ---------------------------------------------------------------------------
@@ -97,7 +99,7 @@ def _task_resolve_photo(ti: TaskInstance, **context: object) -> dict:
     """Resolve participant photo to base64 support image."""
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
     domain_cfg = get_domain_config(conf["domain"])
-    return resolve_participant_photo(conf["normalized_name"], domain_cfg)
+    return resolve_participant_photo(conf.get("slug"), domain_cfg)
 
 
 def _task_generate_thumbnail(label: str, ti: TaskInstance, **context: object) -> dict:

--- a/congress_videos/modules/participants_db.py
+++ b/congress_videos/modules/participants_db.py
@@ -163,6 +163,12 @@ def lookup_participant(name: str) -> dict | None:
     return next((r for r in rows if r["normalized_name"] == key), None)
 
 
+def lookup_participant_by_slug(slug: str) -> dict | None:
+    """Look up a participant by slug: exact, case-sensitive match on the UNIQUE slug column."""
+    rows = _get_participants_for_lookup()
+    return next((r for r in rows if r["slug"] == slug), None)
+
+
 def lookup_participant_fuzzy(
     name: str, threshold: float = WIKIDATA_FUZZY_THRESHOLD
 ) -> dict | None:

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -28,6 +28,7 @@ from congress_videos.config.ai_prompts import (
     THUMBNAIL_TITLE_SYSTEM_PROMPT,
     THUMBNAIL_TITLE_USER_PROMPT_TEMPLATE,
 )
+from congress_videos.config.constants import CONGRESO_BROWSER_USER_AGENT
 from utils.ai_helpers import generate_json_completion
 from utils.postgres_helpers import PostgresConnection
 
@@ -195,7 +196,11 @@ def resolve_participant_photo(slug: str | None, cfg: dict) -> dict:
 
     if photo_url:
         try:
-            response = requests.get(photo_url, timeout=30)
+            response = requests.get(
+                photo_url,
+                timeout=30,
+                headers={"User-Agent": CONGRESO_BROWSER_USER_AGENT},
+            )
             if response.status_code == 200:
                 image_bytes = response.content
                 return {

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -23,6 +23,8 @@ from typing import Optional
 import requests
 
 from congress_videos.config.ai_prompts import (
+    ART_DIRECTION_SYSTEM_PROMPT,
+    ART_DIRECTION_USER_PROMPT_TEMPLATE,
     THUMBNAIL_TITLE_SYSTEM_PROMPT,
     THUMBNAIL_TITLE_USER_PROMPT_TEMPLATE,
 )
@@ -52,10 +54,103 @@ TITLE_MAX_CHARS = 90
 # Sentinel returned when no photo source is available (tolerant mode — no raise).
 EMPTY_RESULT: dict = {"support_image_b64": "", "source": "none"}
 
+# Fallback art-direction brief used when both OpenAI attempts fail.
+# Background must never reference hemiciclo or parliamentary chamber.
+_DEFAULT_ART_BRIEF: dict = {
+    "background": (
+        "una calle española con gente caminando, luz de tarde, tono documental"
+    ),
+    "person": (
+        "un ciudadano español de mediana edad, expresión seria y preocupada, ropa casual"
+    ),
+    "text": "LO QUE NO TE CUENTAN",
+    "mood": "tensión y curiosidad",
+    "logo": "",
+}
+
+_ART_BRIEF_REQUIRED_KEYS = ("text", "background", "person", "mood")
+
 
 # ---------------------------------------------------------------------------
 # Public interface
 # ---------------------------------------------------------------------------
+
+
+def art_direct(debate_summary: str, domain_cfg: dict) -> dict:
+    """Generate an art-direction brief for a Pikzels thumbnail via OpenAI.
+
+    Calls ``generate_json_completion`` with the ART_DIRECTION prompts and
+    validates that the result contains all required keys (text, background,
+    person, mood).  Re-prompts once on validation failure.  Falls back to
+    ``_DEFAULT_ART_BRIEF`` if both attempts fail or raise.
+
+    Any ``"http"`` substring found in returned string values is stripped to
+    prevent Pikzels from rejecting the downstream prompt.
+
+    Args:
+        debate_summary: Free-text summary of the debate used as context.
+        domain_cfg: Per-domain config dict (currently unused beyond signature
+                    consistency with generate_title; reserved for future use).
+
+    Returns:
+        Dict with keys ``text``, ``background``, ``person``, ``mood``, and
+        ``logo`` (defaults to ``""``).  Never raises.
+    """
+
+    def _call_api(extra_instruction: str = "") -> Optional[dict]:
+        user_prompt = ART_DIRECTION_USER_PROMPT_TEMPLATE.format(
+            debate_summary=debate_summary
+        )
+        if extra_instruction:
+            user_prompt += f"\n\nINSTRUCCIÓN ADICIONAL: {extra_instruction}"
+        try:
+            result = generate_json_completion(
+                system_prompt=ART_DIRECTION_SYSTEM_PROMPT,
+                user_prompt=user_prompt,
+                model="gpt-4o-mini",
+                max_tokens=400,
+            )
+        except Exception as exc:
+            logger.warning("art_direct: generate_json_completion raised: %s", exc)
+            return None
+
+        if result.get("error"):
+            logger.warning("art_direct: API error: %s", result["error"])
+            return None
+
+        data = result.get("data") or {}
+        # Validate all required keys are present.
+        if not all(k in data for k in _ART_BRIEF_REQUIRED_KEYS):
+            return None
+        return data
+
+    # First attempt.
+    brief = _call_api()
+
+    if brief is None:
+        # Re-prompt once with a clarifying instruction.
+        brief = _call_api(
+            extra_instruction=(
+                "Asegúrate de devolver un JSON con EXACTAMENTE los campos: "
+                "text, background, person, mood."
+            )
+        )
+
+    if brief is None:
+        logger.warning(
+            "art_direct: both OpenAI attempts failed — using _DEFAULT_ART_BRIEF"
+        )
+        brief = dict(_DEFAULT_ART_BRIEF)
+
+    # Ensure logo key present.
+    brief.setdefault("logo", "")
+
+    # Strip any accidental "http" from string values.
+    cleaned = {
+        k: (v.replace("http", "") if isinstance(v, str) else v)
+        for k, v in brief.items()
+    }
+    return cleaned
 
 
 def resolve_participant_photo(slug: str | None, cfg: dict) -> dict:

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -49,39 +49,52 @@ _EMOJI_RE = re.compile(
 
 TITLE_MAX_CHARS = 90
 
+# Sentinel returned when no photo source is available (tolerant mode — no raise).
+EMPTY_RESULT: dict = {"support_image_b64": "", "source": "none"}
+
 
 # ---------------------------------------------------------------------------
 # Public interface
 # ---------------------------------------------------------------------------
 
 
-def resolve_participant_photo(name: str, cfg: dict) -> dict:
+def resolve_participant_photo(slug: str | None, cfg: dict) -> dict:
     """Resolve the support image for a participant using DB lookup then HTTP download.
 
     Resolution order:
-    1. Look up participant via ``cfg["participants_lookup"]``.
+    0. If ``slug`` is absent, empty, or whitespace, return EMPTY_RESULT (WARNING logged).
+    1. Look up participant via ``cfg["participants_lookup"]`` by slug.
+       If not found, return EMPTY_RESULT (WARNING logged).
     2. If ``photo_url`` is non-null, perform HTTP GET and return raw bytes.
-       If the GET returns non-200, treat as undownloadable and fall through.
+       If the GET returns non-200 or raises, return EMPTY_RESULT (WARNING logged).
     3. If photo unavailable and ``cfg["party_logo_map"]`` is set, read logo file.
-    4. If neither source is available, raise ``ValueError``.
+    4. If neither source is available, return EMPTY_RESULT (WARNING logged).
 
     Args:
-        name: Normalized participant name to look up.
+        slug: Participant slug to look up (exact, case-sensitive).
         cfg: Per-domain config dict from ``THUMBNAIL_CONFIG``.
 
     Returns:
-        Dict with keys ``support_image_b64`` (base64-encoded image bytes as str)
-        and ``source`` (``"photo"`` or ``"party_logo"``).
-
-    Raises:
-        LookupError: If the participant is not found in the database.
-        ValueError: If the participant has no photo URL and no party logo is configured.
+        Dict with keys ``support_image_b64`` (base64-encoded image bytes as str,
+        empty string when no source found) and ``source``
+        (``"photo"``, ``"party_logo"``, or ``"none"``).
     """
+    # Guard: absent / blank slug — skip lookup entirely.
+    if not slug or not str(slug).strip():
+        logger.warning(
+            "resolve_participant_photo: slug is absent or blank — returning empty result"
+        )
+        return EMPTY_RESULT
+
     lookup_fn = cfg["participants_lookup"]
-    participant = lookup_fn(name)
+    participant = lookup_fn(slug)
 
     if participant is None:
-        raise LookupError(f"Participant not found: {name!r}")
+        logger.warning(
+            "resolve_participant_photo: participant not found for slug %r — returning empty result",
+            slug,
+        )
+        return EMPTY_RESULT
 
     photo_url = participant.get("photo_url")
 
@@ -116,10 +129,12 @@ def resolve_participant_photo(name: str, cfg: dict) -> dict:
             "source": "party_logo",
         }
 
-    raise ValueError(
-        f"no photo source available for participant {name!r}: "
-        "photo_url is absent/undownloadable and no party_logo_map configured"
+    logger.warning(
+        "resolve_participant_photo: no photo source available for slug %r "
+        "(photo_url absent/undownloadable, no party_logo_map) — returning empty result",
+        slug,
     )
+    return EMPTY_RESULT
 
 
 def choose_best_option(options: list[dict]) -> dict:

--- a/congress_videos/modules/thumbnail_prompt.py
+++ b/congress_videos/modules/thumbnail_prompt.py
@@ -1,0 +1,128 @@
+"""Pure prompt builder for Pikzels thumbnail generation.
+
+Converts an art-direction brief dict into a Pikzels text prompt using one of
+the three layout templates from the congress-thumbnail skill (Template A/B/C).
+
+No I/O, no external calls — pure function, safe to unit-test in isolation.
+"""
+
+from __future__ import annotations
+
+# ---------------------------------------------------------------------------
+# Layout templates verbatim from congress-thumbnail skill (Template A/B/C).
+# Placeholders use {field} syntax; <...> → {field} substitution applied.
+# ---------------------------------------------------------------------------
+
+_TEMPLATE_A = """\
+A thick gold (#C9A84C) border frames the entire image edge.
+
+BACKGROUND: {background}.
+
+SUBJECT (RIGHT HALF): {person}. Face fills 35-40%. Looks at camera or left toward text.
+
+TEXT (LEFT HALF, 42% from top): Bold ALL-CAPS white (#FFFFFF) '{text}'.
+Font: bold compressed sans-serif (Impact / Bebas Neue).
+3-4px black (#000000) outline + drop shadow (4px down, 6px blur, 80% opacity).
+
+{logo_line}NO logos, icons, watermarks, play buttons, channel symbols, or brand marks.
+NO data charts, infographic overlays, or economic graphs.
+NO government chambers or parliamentary hemiciclo.
+
+Overall mood: {mood}.
+16:9 YouTube thumbnail."""
+
+_TEMPLATE_B = """\
+A thick gold (#C9A84C) border frames the entire image edge.
+
+BACKGROUND: {background}.
+
+SUBJECT (LEFT HALF): {person}. Face fills 35-40%. Looks toward right (toward text).
+
+TEXT (RIGHT HALF, 42% from top): Bold ALL-CAPS white (#FFFFFF) '{text}'.
+Font: bold compressed sans-serif (Impact / Bebas Neue).
+3-4px black (#000000) outline + drop shadow (4px down, 6px blur, 80% opacity).
+
+{logo_line}NO logos, icons, watermarks, play buttons, channel symbols, or brand marks.
+NO data charts, infographic overlays, or economic graphs.
+NO government chambers or parliamentary hemiciclo.
+
+Overall mood: {mood}.
+16:9 YouTube thumbnail."""
+
+_TEMPLATE_C = """\
+A thick gold (#C9A84C) border frames the entire image edge.
+
+BACKGROUND: {background}.
+
+SUBJECT (UPPER HALF, centered): {person}. Face fills 30-35%. Looks directly at camera.
+
+TEXT (LOWER THIRD, centered horizontally): One or two GIANT words in bold ALL-CAPS white (#FFFFFF): '{text}'. \
+The text dominates the bottom third of the image, filling most of its width. \
+Font: bold compressed sans-serif (Impact / Bebas Neue). \
+3-4px black (#000000) outline + drop shadow (4px down, 6px blur, 80% opacity).
+
+{logo_line}NO logos, icons, watermarks, play buttons, channel symbols, or brand marks.
+NO data charts, infographic overlays, or economic graphs.
+NO government chambers or parliamentary hemiciclo.
+
+Overall mood: {mood}.
+16:9 YouTube thumbnail."""
+
+# Logo line per layout (inserted only when brief["logo"] is non-empty).
+_LOGO_LINE_A = "TOP-LEFT corner, small {logo} logo.\n\n"
+_LOGO_LINE_B = "TOP-RIGHT corner, small {logo} logo.\n\n"
+_LOGO_LINE_C = "BOTTOM-RIGHT corner, small {logo} logo.\n\n"
+
+_TEMPLATES = {"A": _TEMPLATE_A, "B": _TEMPLATE_B, "C": _TEMPLATE_C}
+_LOGO_LINES = {"A": _LOGO_LINE_A, "B": _LOGO_LINE_B, "C": _LOGO_LINE_C}
+
+_REQUIRED_KEYS = ("text", "background", "person", "mood")
+
+
+def build_pikzels_prompt(art_brief: dict, layout: str) -> str:
+    """Build a Pikzels text prompt from an art-direction brief and a layout choice.
+
+    Args:
+        art_brief: Dict with keys ``text``, ``background``, ``person``, ``mood``.
+                   Optional key ``logo`` adds a corner logo line when non-empty.
+                   The dict is never mutated.
+        layout:    One of ``"A"``, ``"B"``, or ``"C"`` (case-sensitive).
+
+    Returns:
+        Formatted prompt string safe to pass to ``PikzelsClient.thumbnail_from_text``.
+        Guaranteed to contain no ``"http"`` substring.
+
+    Raises:
+        ValueError: When ``layout`` is not in ``{"A", "B", "C"}``.
+        KeyError:   When any of the required keys is missing from ``art_brief``.
+    """
+    if layout not in _TEMPLATES:
+        raise ValueError(
+            f"Unknown layout {layout!r}. Valid values are: 'A', 'B', 'C'."
+        )
+
+    # Access required keys — raises KeyError naturally if missing.
+    for key in _REQUIRED_KEYS:
+        _ = art_brief[key]
+
+    # Build values without mutating input.
+    text_upper = art_brief["text"].upper()
+    background = art_brief["background"]
+    person = art_brief["person"]
+    mood = art_brief["mood"]
+
+    logo = art_brief.get("logo", "")
+    logo_line = _LOGO_LINES[layout].format(logo=logo) if logo else ""
+
+    rendered = _TEMPLATES[layout].format(
+        text=text_upper,
+        background=background,
+        person=person,
+        mood=mood,
+        logo_line=logo_line,
+    )
+
+    # Defensive: strip any accidental "http" that may have leaked from brief values.
+    rendered = rendered.replace("http", "")
+
+    return rendered

--- a/tests/congress_videos/modules/test_generic_thumbnail_dag.py
+++ b/tests/congress_videos/modules/test_generic_thumbnail_dag.py
@@ -28,6 +28,33 @@ import pytest
 
 
 # ---------------------------------------------------------------------------
+# ThumbnailConfigWiring tests (GROUP 2 — REQ-A2)
+# ---------------------------------------------------------------------------
+
+
+class TestThumbnailConfigWiring:
+    """Verify congreso config wires lookup_participant_by_slug, not fuzzy."""
+
+    def test_congreso_participants_lookup_is_lookup_participant_by_slug(self) -> None:
+        """congreso config 'participants_lookup' must be lookup_participant_by_slug."""
+        from congress_videos.config.thumbnail_config import get_domain_config
+        from congress_videos.modules.participants_db import lookup_participant_by_slug
+
+        cfg = get_domain_config("congreso")
+        assert cfg["participants_lookup"] is lookup_participant_by_slug or \
+               cfg["participants_lookup"].__name__ == "lookup_participant_by_slug"
+
+    def test_lookup_participant_fuzzy_string_absent_from_thumbnail_config_source(self) -> None:
+        """'lookup_participant_fuzzy' must NOT appear in thumbnail_config.py source."""
+        import congress_videos.config.thumbnail_config as _tcfg
+        import inspect
+        source = inspect.getsource(_tcfg)
+        assert "lookup_participant_fuzzy" not in source, (
+            "thumbnail_config.py must not reference lookup_participant_fuzzy"
+        )
+
+
+# ---------------------------------------------------------------------------
 # T-01  DAG imports cleanly
 # ---------------------------------------------------------------------------
 
@@ -188,13 +215,21 @@ class TestNoCongresoBranding:
 # ---------------------------------------------------------------------------
 
 
+_REQUIRED_KEYS = [
+    "youtube_video_id",
+    "chapter_id",
+    "debate_summary",
+    "session",
+    "domain",
+]
+
 VALID_CONF = {
     "youtube_video_id": "abc123",
     "chapter_id": 7,
     "debate_summary": "El debate sobre pensiones fue intenso.",
     "session": "Pleno 2026-06-10",
     "domain": "congreso",
-    "normalized_name": "garcia_lopez_maria",
+    "slug": "garcia-lopez-maria",
 }
 
 
@@ -208,23 +243,42 @@ class TestValidateInput:
         self.mod = importlib.import_module("congress_videos.generic_thumbnail_generator_dag")
 
     def test_valid_conf_does_not_raise(self) -> None:
-        """All 6 required keys present → no exception."""
+        """5 required keys present → no exception."""
         # Call the underlying function directly (not via Airflow trigger).
         self.mod.validate_input(VALID_CONF)
 
-    @pytest.mark.parametrize("missing_key", list(VALID_CONF.keys()))
+    @pytest.mark.parametrize("missing_key", _REQUIRED_KEYS)
     def test_missing_key_raises_value_error(self, missing_key: str) -> None:
         """Omitting any required key must raise ValueError."""
         conf = {k: v for k, v in VALID_CONF.items() if k != missing_key}
         with pytest.raises(ValueError, match=missing_key):
             self.mod.validate_input(conf)
 
-    @pytest.mark.parametrize("empty_key", list(VALID_CONF.keys()))
+    @pytest.mark.parametrize("empty_key", _REQUIRED_KEYS)
     def test_empty_string_raises_value_error(self, empty_key: str) -> None:
         """Empty string for any required key must raise ValueError."""
         conf = {**VALID_CONF, empty_key: ""}
         with pytest.raises(ValueError, match=empty_key):
             self.mod.validate_input(conf)
+
+    def test_conf_without_slug_is_accepted(self) -> None:
+        """slug is optional — conf without it must not raise."""
+        conf = {k: v for k, v in VALID_CONF.items() if k != "slug"}
+        self.mod.validate_input(conf)  # must not raise
+
+    def test_conf_with_slug_is_accepted(self) -> None:
+        """conf that includes slug= is accepted normally."""
+        conf = {**VALID_CONF, "slug": "garcia-lopez-maria"}
+        self.mod.validate_input(conf)  # must not raise
+
+    def test_conf_with_empty_slug_is_accepted(self) -> None:
+        """conf with slug='' is accepted (slug is optional, tolerant lookup handles it)."""
+        conf = {**VALID_CONF, "slug": ""}
+        self.mod.validate_input(conf)  # must not raise
+
+    def test_no_normalized_name_key_in_required_keys(self) -> None:
+        """'normalized_name' must NOT appear in _REQUIRED_CONF_KEYS."""
+        assert "normalized_name" not in self.mod._REQUIRED_CONF_KEYS
 
 
 # ---------------------------------------------------------------------------
@@ -275,7 +329,7 @@ _FAKE_CONF = {
     "debate_summary": "El Congreso debate el presupuesto general.",
     "session": "Pleno 2026-07-31",
     "domain": "congreso",
-    "normalized_name": "garcia_lopez_maria",
+    "slug": "garcia-lopez-maria",
 }
 
 _FAKE_STYLES = [

--- a/tests/congress_videos/modules/test_generic_thumbnail_dag.py
+++ b/tests/congress_videos/modules/test_generic_thumbnail_dag.py
@@ -100,6 +100,7 @@ class TestDagSchedule:
 EXPECTED_TASK_IDS = {
     "validate_input",
     "resolve_participant_photo",
+    "art_direction",
     "generate_thumbnail_option_a",
     "download_option_a",
     "score_option_a",
@@ -153,11 +154,14 @@ class TestDagDependencies:
     def test_resolve_participant_photo_upstream_is_validate_input(self) -> None:
         assert self._upstream_ids("resolve_participant_photo") == {"validate_input"}
 
-    def test_generate_thumbnail_option_a_upstream_is_resolve_participant_photo(self) -> None:
-        assert self._upstream_ids("generate_thumbnail_option_a") == {"resolve_participant_photo"}
+    def test_art_direction_upstream_is_resolve_participant_photo(self) -> None:
+        assert self._upstream_ids("art_direction") == {"resolve_participant_photo"}
 
-    def test_generate_thumbnail_option_b_upstream_is_resolve_participant_photo(self) -> None:
-        assert self._upstream_ids("generate_thumbnail_option_b") == {"resolve_participant_photo"}
+    def test_generate_thumbnail_option_a_upstream_is_art_direction(self) -> None:
+        assert self._upstream_ids("generate_thumbnail_option_a") == {"art_direction"}
+
+    def test_generate_thumbnail_option_b_upstream_is_art_direction(self) -> None:
+        assert self._upstream_ids("generate_thumbnail_option_b") == {"art_direction"}
 
     def test_download_option_a_upstream_is_generate_thumbnail_option_a(self) -> None:
         assert self._upstream_ids("download_option_a") == {"generate_thumbnail_option_a"}
@@ -335,13 +339,11 @@ _FAKE_CONF = {
 _FAKE_STYLES = [
     {
         "label": "option_a",
-        "style": "Dramatic political documentary style.",
-        "persona": "Senior political journalist.",
+        "layout": "A",
     },
     {
         "label": "option_b",
-        "style": "Modern editorial news style.",
-        "persona": "Digital-native correspondent.",
+        "layout": "B",
     },
 ]
 
@@ -349,6 +351,15 @@ _FAKE_DOMAIN_CFG = {
     "styles": _FAKE_STYLES,
     "participants_lookup": lambda name: None,
     "party_logo_map": None,
+}
+
+# Art-direction brief returned by the art_direction task xcom.
+_FAKE_ART_BRIEF = {
+    "text": "LO QUE NO TE CUENTAN",
+    "background": "una calle española con gente, luz de tarde",
+    "person": "ciudadano de mediana edad, expresión preocupada, ropa casual",
+    "mood": "tensión y curiosidad",
+    "logo": "",
 }
 
 
@@ -370,8 +381,9 @@ def _make_fake_ti(xcom_map: dict) -> MagicMock:
 
 class TestTaskGenerateThumbnail:
     """T-08: _task_generate_thumbnail must call _pkz.thumbnail_from_text with
-    support_image_base64= (data URI), never support_image=, and return a dict
-    with label, style, persona, and prompt attached.
+    support_image_base64= (data URI), pull from art_direction xcom, return a dict
+    with label, style (layout letter A/B/C), prompt (rendered Pikzels template
+    containing #C9A84C), and NO persona key.
     """
 
     def test_calls_thumbnail_from_text_with_support_image_base64(self, mocker) -> None:
@@ -385,6 +397,7 @@ class TestTaskGenerateThumbnail:
             {
                 "validate_input": _FAKE_CONF,
                 "resolve_participant_photo": fake_photo_data,
+                "art_direction": _FAKE_ART_BRIEF,
             }
         )
 
@@ -413,14 +426,15 @@ class TestTaskGenerateThumbnail:
         )
         assert photo_b64 in data_url
 
-    def test_returns_dict_with_label_style_persona_prompt(self, mocker) -> None:
-        """Return dict must carry label, style, persona, and prompt."""
+    def test_returns_dict_with_label_and_style_as_layout_letter(self, mocker) -> None:
+        """Return dict must carry label and style (layout letter A/B/C), no 'persona' key."""
         import congress_videos.generic_thumbnail_generator_dag as dag_mod
 
         ti = _make_fake_ti(
             {
                 "validate_input": _FAKE_CONF,
                 "resolve_participant_photo": {"support_image_b64": "b64data", "source": "photo"},
+                "art_direction": _FAKE_ART_BRIEF,
             }
         )
 
@@ -435,9 +449,18 @@ class TestTaskGenerateThumbnail:
         result = dag_mod._task_generate_thumbnail("option_a", ti=ti)
 
         assert result["label"] == "option_a"
-        assert result["style"] == _FAKE_STYLES[0]["style"]
-        assert result["persona"] == _FAKE_STYLES[0]["persona"]
-        assert result["prompt"] == _FAKE_CONF["debate_summary"]
+        # style must be the layout letter, not the old style prose
+        assert result["style"] in {"A", "B", "C"}, (
+            f"style must be a layout letter (A/B/C), got: {result['style']!r}"
+        )
+        # prompt must be a rendered Pikzels template containing the gold border spec
+        assert "#C9A84C" in result["prompt"], (
+            "prompt must be the rendered Pikzels template containing '#C9A84C'"
+        )
+        # No persona key expected
+        assert "persona" not in result, (
+            "result must not contain 'persona' key — removed in this change"
+        )
 
     def test_no_photo_sends_none_support_image(self, mocker) -> None:
         """When support_image_b64 is empty, support_image_base64 is None."""
@@ -447,6 +470,7 @@ class TestTaskGenerateThumbnail:
             {
                 "validate_input": _FAKE_CONF,
                 "resolve_participant_photo": {"support_image_b64": "", "source": "party_logo"},
+                "art_direction": _FAKE_ART_BRIEF,
             }
         )
 
@@ -482,9 +506,8 @@ class TestTaskDownloadOption:
         gen_result = {
             "output": "https://pikzels.com/generated.png",
             "label": "option_a",
-            "style": _FAKE_STYLES[0]["style"],
-            "persona": _FAKE_STYLES[0]["persona"],
-            "prompt": _FAKE_CONF["debate_summary"],
+            "style": "A",
+            "prompt": "A thick gold (#C9A84C) border...",
         }
 
         ti = _make_fake_ti(
@@ -517,9 +540,8 @@ class TestTaskDownloadOption:
 
         gen_result = {
             "output": "https://pikzels.com/generated.png",
-            "style": _FAKE_STYLES[0]["style"],
-            "persona": _FAKE_STYLES[0]["persona"],
-            "prompt": _FAKE_CONF["debate_summary"],
+            "style": "A",
+            "prompt": "A thick gold (#C9A84C) border...",
         }
 
         ti = _make_fake_ti(
@@ -567,9 +589,8 @@ class TestTaskScoreOption:
             "label": "option_a",
             "local_path": str(fake_image),
             "output_url": "https://pikzels.com/generated.png",
-            "style": _FAKE_STYLES[0]["style"],
-            "persona": _FAKE_STYLES[0]["persona"],
-            "prompt": _FAKE_CONF["debate_summary"],
+            "style": "A",
+            "prompt": "A thick gold (#C9A84C) border...",
         }
 
         ti = _make_fake_ti({"download_option_a": download_info})
@@ -598,9 +619,8 @@ class TestTaskScoreOption:
             "label": "option_b",
             "local_path": str(fake_image),
             "output_url": "https://pikzels.com/b.png",
-            "style": _FAKE_STYLES[1]["style"],
-            "persona": _FAKE_STYLES[1]["persona"],
-            "prompt": _FAKE_CONF["debate_summary"],
+            "style": "B",
+            "prompt": "A thick gold (#C9A84C) border...",
         }
 
         ti = _make_fake_ti({"download_option_b": download_info})

--- a/tests/congress_videos/modules/test_participants_db.py
+++ b/tests/congress_videos/modules/test_participants_db.py
@@ -482,6 +482,92 @@ class TestUpdatePhotoUrl:
 
 
 # ===========================================================================
+# T-04 RED: lookup_participant_by_slug
+# ===========================================================================
+
+
+class TestLookupParticipantBySlug:
+    """Tests for lookup_participant_by_slug — exact, case-sensitive slug match."""
+
+    def test_slug_hit_returns_row_dict(self, monkeypatch):
+        """Exact slug match → returns the row dict."""
+        rows = [
+            {"normalized_name": "garcia ana", "slug": "garcia-ana", "display_name": "García, Ana",
+             "photo_url": "https://example.com/garcia.jpg"},
+        ]
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_by_slug
+        result = lookup_participant_by_slug("garcia-ana")
+
+        assert result is not None
+        assert result["slug"] == "garcia-ana"
+
+    def test_slug_miss_returns_none(self, monkeypatch):
+        """Unknown slug → None."""
+        rows = [
+            {"normalized_name": "garcia ana", "slug": "garcia-ana", "display_name": "García, Ana",
+             "photo_url": None},
+        ]
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_by_slug
+        result = lookup_participant_by_slug("unknown-slug-xyz")
+
+        assert result is None
+
+    def test_exact_case_sensitive_mismatch_returns_none(self, monkeypatch):
+        """Case mismatch: row has 'Garcia-Ana', calling 'garcia-ana' → None."""
+        rows = [
+            {"normalized_name": "garcia ana", "slug": "Garcia-Ana", "display_name": "García, Ana",
+             "photo_url": None},
+        ]
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_by_slug
+        result = lookup_participant_by_slug("garcia-ana")
+
+        assert result is None
+
+    def test_exact_case_sensitive_match_works(self, monkeypatch):
+        """Exact case match: row and call both use 'Garcia-Ana' → returns row."""
+        rows = [
+            {"normalized_name": "garcia ana", "slug": "Garcia-Ana", "display_name": "García, Ana",
+             "photo_url": None},
+        ]
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        from congress_videos.modules.participants_db import lookup_participant_by_slug
+        result = lookup_participant_by_slug("Garcia-Ana")
+
+        assert result is not None
+        assert result["slug"] == "Garcia-Ana"
+
+    def test_never_calls_normalize_member_name(self, monkeypatch):
+        """normalize_member_name must never be invoked by lookup_participant_by_slug."""
+        rows = [
+            {"normalized_name": "garcia ana", "slug": "garcia-ana", "display_name": "García, Ana",
+             "photo_url": None},
+        ]
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+
+        def _raise(*args, **kwargs):
+            raise AssertionError("normalize_member_name must not be called by lookup_participant_by_slug")
+
+        monkeypatch.setattr(_mod, "normalize_member_name", _raise)
+
+        from congress_videos.modules.participants_db import lookup_participant_by_slug
+        # Must not call normalize_member_name — no AssertionError should propagate
+        result = lookup_participant_by_slug("garcia-ana")
+        assert result is not None
+
+
+# ===========================================================================
 # T-07 RED: migration file tests
 # ===========================================================================
 

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -88,7 +88,13 @@ class TestResolveParticipantPhoto:
         with patch("requests.get", return_value=mock_resp) as mock_get:
             result = resolve_participant_photo("garcia_maria", cfg)
 
-        mock_get.assert_called_once_with("https://example.com/garcia.jpg", timeout=30)
+        from congress_videos.config.constants import CONGRESO_BROWSER_USER_AGENT
+
+        mock_get.assert_called_once_with(
+            "https://example.com/garcia.jpg",
+            timeout=30,
+            headers={"User-Agent": CONGRESO_BROWSER_USER_AGENT},
+        )
         assert result["source"] == "photo"
         assert result["support_image_b64"] == base64.b64encode(fake_bytes).decode()
 

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -111,23 +111,167 @@ class TestResolveParticipantPhoto:
         assert result["support_image_b64"] == base64.b64encode(logo_bytes).decode()
 
     def test_photo_url_none_no_logo_raises_value_error(self):
-        """When photo_url is NULL and no party logo, ValueError raised."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        """When photo_url is NULL and no party logo, EMPTY_RESULT returned + WARNING logged."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
 
         participant = {"normalized_name": "garcia_maria", "photo_url": None}
         cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
 
-        with pytest.raises(ValueError, match="no photo source"):
-            resolve_participant_photo("garcia_maria", cfg)
+        import logging as _logging
+        with pytest.warns(None):
+            pass  # just to clear any pending warnings
+        import io
+        import logging
+
+        # Use caplog-style: capture via root logger
+        with patch("congress_videos.modules.thumbnail_generation.logger") as mock_log:
+            result = resolve_participant_photo("garcia_maria", cfg)
+
+        assert result == EMPTY_RESULT
+        mock_log.warning.assert_called()
 
     def test_participant_not_found_raises_lookup_error(self):
-        """When lookup returns None, LookupError is raised."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        """When lookup returns None (unknown slug), EMPTY_RESULT returned + WARNING logged."""
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
 
         cfg = _make_cfg(lookup_return=None)
 
-        with pytest.raises(LookupError):
-            resolve_participant_photo("unknown_person", cfg)
+        with patch("congress_videos.modules.thumbnail_generation.logger") as mock_log:
+            result = resolve_participant_photo("unknown_person", cfg)
+
+        assert result == EMPTY_RESULT
+        mock_log.warning.assert_called()
+
+
+# ---------------------------------------------------------------------------
+# TestSlugResolution: tolerant resolve_participant_photo (GROUP 3 — REQ-B)
+# ---------------------------------------------------------------------------
+
+
+class TestSlugResolution:
+    """resolve_participant_photo(slug, cfg) — slug-aware tolerant contracts."""
+
+    def test_slug_hit_returns_photo_source_and_non_empty_b64(self, monkeypatch):
+        """Valid slug resolving to a participant with photo_url → source='photo' + non-empty b64."""
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+
+        participant = {"slug": "garcia-lopez-maria", "photo_url": "https://example.com/img.jpg"}
+        cfg = _make_cfg(lookup_return=participant)
+
+        fake_bytes = b"\x89PNG" + b"\x00" * 20
+        mock_resp = MagicMock()
+        mock_resp.status_code = 200
+        mock_resp.content = fake_bytes
+
+        with patch("requests.get", return_value=mock_resp):
+            result = resolve_participant_photo("garcia-lopez-maria", cfg)
+
+        import base64
+        assert result["source"] == "photo"
+        assert result["support_image_b64"] == base64.b64encode(fake_bytes).decode()
+
+    def test_absent_slug_none_returns_empty_result_no_lookup(self, caplog):
+        """slug=None → EMPTY_RESULT returned + WARNING logged, lookup never called."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        cfg = _make_cfg(lookup_raises=True)  # lookup raises if called
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo(None, cfg)
+
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_empty_string_slug_returns_empty_result_no_lookup(self, caplog):
+        """slug='' → EMPTY_RESULT + WARNING, lookup never called."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        cfg = _make_cfg(lookup_raises=True)
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo("", cfg)
+
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_whitespace_slug_returns_empty_result_no_lookup(self, caplog):
+        """slug='   ' → EMPTY_RESULT + WARNING, lookup never called."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        cfg = _make_cfg(lookup_raises=True)
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo("   ", cfg)
+
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_unknown_slug_lookup_returns_none_gives_empty_result_with_warning(self, caplog):
+        """Unknown slug (lookup returns None) → EMPTY_RESULT + WARNING, no raise."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        cfg = _make_cfg(lookup_return=None)
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo("nonexistent-slug-xyz", cfg)
+
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_photo_url_none_party_logo_map_none_returns_empty_result_no_http(self, caplog):
+        """photo_url=None + party_logo_map=None → EMPTY_RESULT + WARNING, no HTTP call."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        participant = {"slug": "garcia-ana", "photo_url": None}
+        cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
+
+        with patch("requests.get") as mock_get, \
+             caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo("garcia-ana", cfg)
+
+        mock_get.assert_not_called()
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_http_404_returns_empty_result_with_warning(self, caplog):
+        """HTTP 404 for photo_url (no logo fallback) → EMPTY_RESULT + WARNING."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        participant = {"slug": "garcia-ana", "photo_url": "https://example.com/broken.jpg"}
+        cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
+
+        mock_resp = MagicMock()
+        mock_resp.status_code = 404
+
+        with patch("requests.get", return_value=mock_resp), \
+             caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo("garcia-ana", cfg)
+
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+    def test_request_exception_returns_empty_result_with_warning(self, caplog):
+        """requests.RequestException → EMPTY_RESULT + WARNING."""
+        import logging
+        import requests as req
+        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+
+        participant = {"slug": "garcia-ana", "photo_url": "https://example.com/broken.jpg"}
+        cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
+
+        with patch("requests.get", side_effect=req.RequestException("timeout")), \
+             caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            result = resolve_participant_photo("garcia-ana", cfg)
+
+        assert result == EMPTY_RESULT
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -322,11 +322,15 @@ class TestChooseBestOption:
 class TestGenerateTitle:
     """generate_title(summary, best, cfg) contracts."""
 
-    def _best_opt(self, label="option_a", style="dramatic style", persona="persona A", prompt="prompt text"):
+    def _best_opt(
+        self,
+        label="option_a",
+        style="A",
+        prompt="A thick gold (#C9A84C) border frames the entire image edge.\n\nBACKGROUND: calle española.",
+    ):
         return {
             "label": label,
             "style": style,
-            "persona": persona,
             "prompt": prompt,
             "output_url": "u",
             "local_path": "/a.png",
@@ -598,8 +602,12 @@ class TestTriangulateEdgeCases:
         )
         cfg = _make_cfg()
         best = {
-            "label": "option_a", "style": "s", "persona": "p", "prompt": "pr",
-            "output_url": "u", "local_path": "/a.png", "main_score": 80.0,
+            "label": "option_a",
+            "style": "A",
+            "prompt": "A thick gold (#C9A84C) border frames the entire image edge.",
+            "output_url": "u",
+            "local_path": "/a.png",
+            "main_score": 80.0,
         }
         with caplog.at_level(logging.WARNING):
             result = generate_title("summary", best, cfg)
@@ -619,3 +627,188 @@ class TestTriangulateEdgeCases:
         assert best["local_path"] == "/b.png"
         assert best["style"] == "s2"
         assert best["is_chosen"] is True
+
+
+# ---------------------------------------------------------------------------
+# T-06: art_direct
+# ---------------------------------------------------------------------------
+
+
+class TestArtDirect:
+    """art_direct(debate_summary, domain_cfg) contracts."""
+
+    def _make_cfg(self) -> dict:
+        return {
+            "styles": [
+                {"label": "option_a", "layout": "A"},
+                {"label": "option_b", "layout": "B"},
+            ],
+            "participants_lookup": lambda slug: None,
+            "party_logo_map": None,
+        }
+
+    def _valid_brief_response(self) -> dict:
+        return {
+            "data": {
+                "text": "LO QUE NO TE CUENTAN",
+                "background": "una calle española con manifestantes, luz de atardecer",
+                "person": "un ciudadano de mediana edad con expresión seria, ropa casual",
+                "mood": "indignación y urgencia",
+            },
+            "error": None,
+        }
+
+    def test_happy_path_returns_required_keys(self, mocker) -> None:
+        """art_direct returns dict with text, background, person, mood on success."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            return_value=self._valid_brief_response(),
+        )
+        cfg = self._make_cfg()
+        result = art_direct("Debate sobre pensiones", cfg)
+
+        assert "text" in result
+        assert "background" in result
+        assert "person" in result
+        assert "mood" in result
+
+    def test_malformed_response_reprompts_once_then_default(self, mocker) -> None:
+        """Malformed response (missing keys) → reprompt once → _DEFAULT_ART_BRIEF on second failure."""
+        from congress_videos.modules.thumbnail_generation import art_direct, _DEFAULT_ART_BRIEF
+
+        call_count = {"n": 0}
+
+        def _side(system_prompt, user_prompt, **kw):
+            call_count["n"] += 1
+            # Both calls return malformed data (no required keys)
+            return {"data": {"wrong_key": "value"}, "error": None}
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_side,
+        )
+        cfg = self._make_cfg()
+        result = art_direct("summary", cfg)
+
+        assert call_count["n"] == 2
+        assert result["background"] == _DEFAULT_ART_BRIEF["background"]
+
+    def test_exception_does_not_raise_and_returns_all_keys(self, mocker) -> None:
+        """When generate_json_completion raises, art_direct must not raise."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=RuntimeError("network error"),
+        )
+        cfg = self._make_cfg()
+        result = art_direct("summary", cfg)
+
+        assert "text" in result
+        assert "background" in result
+        assert "person" in result
+        assert "mood" in result
+
+    def test_none_response_does_not_raise(self, mocker) -> None:
+        """When generate_json_completion returns None-data, art_direct must not raise."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            return_value={"data": None, "error": "api error"},
+        )
+        cfg = self._make_cfg()
+        result = art_direct("summary", cfg)
+
+        assert "text" in result
+        assert "background" in result
+        assert "person" in result
+        assert "mood" in result
+
+    def test_http_stripped_from_values(self, mocker) -> None:
+        """Any 'http' substring in returned values must be stripped from the result."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            return_value={
+                "data": {
+                    "text": "CRISIS REAL",
+                    "background": "http://example.com una calle",
+                    "person": "ciudadano serio",
+                    "mood": "indignación",
+                },
+                "error": None,
+            },
+        )
+        cfg = self._make_cfg()
+        result = art_direct("summary", cfg)
+
+        for value in result.values():
+            if isinstance(value, str):
+                assert "http" not in value, f"Found 'http' in result value: {value!r}"
+
+    def test_default_background_has_no_hemiciclo(self) -> None:
+        """The _DEFAULT_ART_BRIEF background must not contain 'hemiciclo'."""
+        from congress_videos.modules.thumbnail_generation import _DEFAULT_ART_BRIEF
+
+        assert "hemiciclo" not in _DEFAULT_ART_BRIEF["background"].lower()
+
+    def test_system_prompt_contains_http_prohibition(self, mocker) -> None:
+        """The system prompt passed to generate_json_completion must mention 'http' as a prohibition."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        captured = {}
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured["system_prompt"] = system_prompt
+            return self._valid_brief_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        cfg = self._make_cfg()
+        art_direct("summary", cfg)
+
+        assert "http" in captured.get("system_prompt", ""), (
+            "System prompt must reference 'http' as a prohibition"
+        )
+
+    def test_uses_art_direction_system_prompt(self, mocker) -> None:
+        """art_direct must use ART_DIRECTION_SYSTEM_PROMPT as the system prompt."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+        from congress_videos.config.ai_prompts import ART_DIRECTION_SYSTEM_PROMPT
+
+        captured = {}
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured["system_prompt"] = system_prompt
+            return self._valid_brief_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        cfg = self._make_cfg()
+        art_direct("summary", cfg)
+
+        assert captured["system_prompt"] == ART_DIRECTION_SYSTEM_PROMPT
+
+    def test_warning_logged_on_fallback(self, mocker, caplog) -> None:
+        """A WARNING is logged when falling back to _DEFAULT_ART_BRIEF."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            return_value={"data": None, "error": "error"},
+        )
+        cfg = self._make_cfg()
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            art_direct("summary", cfg)
+
+        assert any(r.levelno >= logging.WARNING for r in caplog.records)

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -48,16 +48,8 @@ def _make_cfg(
             return None
 
     styles = [
-        {
-            "label": "option_a",
-            "style": "dramatic style A",
-            "persona": "persona A",
-        },
-        {
-            "label": "option_b",
-            "style": "editorial style B",
-            "persona": "persona B",
-        },
+        {"label": "option_a", "layout": "A"},
+        {"label": "option_b", "layout": "B"},
     ]
     return {
         "styles": styles,
@@ -116,28 +108,20 @@ class TestResolveParticipantPhoto:
         assert result["source"] == "party_logo"
         assert result["support_image_b64"] == base64.b64encode(logo_bytes).decode()
 
-    def test_photo_url_none_no_logo_raises_value_error(self):
+    def test_photo_url_none_no_logo_returns_empty_result(self):
         """When photo_url is NULL and no party logo, EMPTY_RESULT returned + WARNING logged."""
-        import logging
         from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
 
         participant = {"normalized_name": "garcia_maria", "photo_url": None}
         cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
 
-        import logging as _logging
-        with pytest.warns(None):
-            pass  # just to clear any pending warnings
-        import io
-        import logging
-
-        # Use caplog-style: capture via root logger
         with patch("congress_videos.modules.thumbnail_generation.logger") as mock_log:
             result = resolve_participant_photo("garcia_maria", cfg)
 
         assert result == EMPTY_RESULT
         mock_log.warning.assert_called()
 
-    def test_participant_not_found_raises_lookup_error(self):
+    def test_participant_not_found_returns_empty_result(self):
         """When lookup returns None (unknown slug), EMPTY_RESULT returned + WARNING logged."""
         from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
 

--- a/tests/congress_videos/modules/test_thumbnail_prompt.py
+++ b/tests/congress_videos/modules/test_thumbnail_prompt.py
@@ -1,0 +1,299 @@
+"""Tests for congress_videos.modules.thumbnail_prompt (TDD — RED first).
+
+Test groups:
+    T-01  build_pikzels_prompt layout A/B/C golden rules
+    T-02  logo line behaviour
+    T-03  error cases (unknown layout, missing keys)
+    T-04  http prohibition (no 'http' in output even when input contains it)
+    T-05  input immutability
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+_BRIEF = {
+    "text": "Lo que no te cuentan",
+    "background": "una calle española con manifestantes",
+    "person": "un ciudadano de mediana edad con expresión indignada",
+    "mood": "indignación y urgencia",
+}
+
+
+# ---------------------------------------------------------------------------
+# T-01: Golden rules for layouts A / B / C
+# ---------------------------------------------------------------------------
+
+
+class TestBuildPikzelsPrompt:
+    """build_pikzels_prompt must produce correct prompts for layouts A, B, C."""
+
+    def test_layout_a_contains_gold_color(self) -> None:
+        """Layout A output must contain the gold colour hex #C9A84C."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        result = build_pikzels_prompt(_BRIEF, "A")
+        assert "#C9A84C" in result
+
+    def test_layout_b_contains_gold_color(self) -> None:
+        """Layout B output must contain the gold colour hex #C9A84C."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        result = build_pikzels_prompt(_BRIEF, "B")
+        assert "#C9A84C" in result
+
+    def test_layout_c_contains_gold_color(self) -> None:
+        """Layout C output must contain the gold colour hex #C9A84C."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        result = build_pikzels_prompt(_BRIEF, "C")
+        assert "#C9A84C" in result
+
+    def test_text_is_uppercased(self) -> None:
+        """The text value must appear uppercased in the output."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {**_BRIEF, "text": "lo que no te cuentan"}
+        result = build_pikzels_prompt(brief, "A")
+        assert "LO QUE NO TE CUENTAN" in result
+
+    def test_prohibitions_present_no_logos(self) -> None:
+        """All layouts must include 'NO logos' prohibition."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        for layout in ("A", "B", "C"):
+            result = build_pikzels_prompt(_BRIEF, layout)
+            assert "NO logos" in result, f"Layout {layout} missing 'NO logos'"
+
+    def test_prohibitions_present_no_data_charts(self) -> None:
+        """All layouts must include 'NO data charts' prohibition."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        for layout in ("A", "B", "C"):
+            result = build_pikzels_prompt(_BRIEF, layout)
+            assert "NO data charts" in result, f"Layout {layout} missing 'NO data charts'"
+
+    def test_prohibitions_present_no_government_chambers(self) -> None:
+        """All layouts must include 'NO government chambers or parliamentary hemiciclo'."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        for layout in ("A", "B", "C"):
+            result = build_pikzels_prompt(_BRIEF, layout)
+            assert "NO government chambers or parliamentary hemiciclo" in result, (
+                f"Layout {layout} missing government-chambers prohibition"
+            )
+
+    def test_16_9_youtube_thumbnail_present(self) -> None:
+        """Output must contain '16:9 YouTube thumbnail'."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        for layout in ("A", "B", "C"):
+            result = build_pikzels_prompt(_BRIEF, layout)
+            assert "16:9 YouTube thumbnail" in result, (
+                f"Layout {layout} missing '16:9 YouTube thumbnail'"
+            )
+
+    def test_no_http_in_output_even_when_brief_contains_http(self) -> None:
+        """If any brief value contains 'http', the output must NOT contain 'http'."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief_with_http = {
+            "text": "LO QUE OCULTAN",
+            "background": "http://example.com fondo de calle",
+            "person": "un ciudadano serio",
+            "mood": "tensión http://evil.com",
+        }
+        result = build_pikzels_prompt(brief_with_http, "A")
+        assert "http" not in result, (
+            "Output must not contain 'http' even when input brief values contain URLs"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-02: Logo line behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestLogoLine:
+    """Logo line present when logo set; absent when empty/missing."""
+
+    def test_logo_line_present_when_logo_set_layout_a(self) -> None:
+        """When logo='RTVE', layout A output contains 'TOP-LEFT corner'."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {**_BRIEF, "logo": "RTVE"}
+        result = build_pikzels_prompt(brief, "A")
+        assert "TOP-LEFT corner" in result
+        assert "RTVE" in result
+
+    def test_logo_line_present_when_logo_set_layout_b(self) -> None:
+        """When logo='COPE', layout B output contains 'TOP-RIGHT corner'."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {**_BRIEF, "logo": "COPE"}
+        result = build_pikzels_prompt(brief, "B")
+        assert "TOP-RIGHT corner" in result
+        assert "COPE" in result
+
+    def test_logo_line_present_when_logo_set_layout_c(self) -> None:
+        """When logo='TVE', layout C output contains 'BOTTOM-RIGHT corner'."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {**_BRIEF, "logo": "TVE"}
+        result = build_pikzels_prompt(brief, "C")
+        assert "BOTTOM-RIGHT corner" in result
+        assert "TVE" in result
+
+    def test_logo_line_absent_when_logo_empty(self) -> None:
+        """When logo='', the logo corner line must not appear."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {**_BRIEF, "logo": ""}
+        result = build_pikzels_prompt(brief, "A")
+        assert "TOP-LEFT corner" not in result
+
+    def test_logo_line_absent_when_logo_key_missing(self) -> None:
+        """When 'logo' key is absent, the logo corner line must not appear."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {k: v for k, v in _BRIEF.items() if k != "logo"}
+        result = build_pikzels_prompt(brief, "B")
+        assert "TOP-RIGHT corner" not in result
+
+
+# ---------------------------------------------------------------------------
+# T-03: Error cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrorCases:
+    """Unknown layout raises ValueError; missing required key raises KeyError."""
+
+    def test_unknown_layout_raises_value_error(self) -> None:
+        """Layout value not in {A, B, C} must raise ValueError."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        with pytest.raises(ValueError, match="layout"):
+            build_pikzels_prompt(_BRIEF, "D")
+
+    def test_lowercase_layout_raises_value_error(self) -> None:
+        """Layout check is case-sensitive — 'a' must raise ValueError."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        with pytest.raises(ValueError):
+            build_pikzels_prompt(_BRIEF, "a")
+
+    def test_missing_text_key_raises_key_error(self) -> None:
+        """Missing 'text' in brief raises KeyError."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {k: v for k, v in _BRIEF.items() if k != "text"}
+        with pytest.raises(KeyError):
+            build_pikzels_prompt(brief, "A")
+
+    def test_missing_background_key_raises_key_error(self) -> None:
+        """Missing 'background' in brief raises KeyError."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {k: v for k, v in _BRIEF.items() if k != "background"}
+        with pytest.raises(KeyError):
+            build_pikzels_prompt(brief, "A")
+
+    def test_missing_person_key_raises_key_error(self) -> None:
+        """Missing 'person' in brief raises KeyError."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {k: v for k, v in _BRIEF.items() if k != "person"}
+        with pytest.raises(KeyError):
+            build_pikzels_prompt(brief, "A")
+
+    def test_missing_mood_key_raises_key_error(self) -> None:
+        """Missing 'mood' in brief raises KeyError."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {k: v for k, v in _BRIEF.items() if k != "mood"}
+        with pytest.raises(KeyError):
+            build_pikzels_prompt(brief, "A")
+
+
+# ---------------------------------------------------------------------------
+# T-04: http prohibition
+# ---------------------------------------------------------------------------
+
+
+class TestHttpProhibition:
+    """No 'http' in output regardless of input values."""
+
+    def test_background_with_url_stripped_from_output(self) -> None:
+        """URL in background value must not survive into the Pikzels prompt."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {
+            "text": "CRISIS POLÍTICA",
+            "background": "https://example.com/img una calle",
+            "person": "ciudadano serio",
+            "mood": "indignación",
+        }
+        result = build_pikzels_prompt(brief, "B")
+        assert "http" not in result
+
+    def test_person_with_url_stripped_from_output(self) -> None:
+        """URL in person value must not survive into the Pikzels prompt."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {
+            "text": "CRISIS POLÍTICA",
+            "background": "calle española",
+            "person": "http://avatar.com persona seria",
+            "mood": "urgencia",
+        }
+        result = build_pikzels_prompt(brief, "C")
+        assert "http" not in result
+
+
+# ---------------------------------------------------------------------------
+# T-05: Input immutability
+# ---------------------------------------------------------------------------
+
+
+class TestInputImmutability:
+    """build_pikzels_prompt must not mutate the input dict."""
+
+    def test_input_dict_not_mutated(self) -> None:
+        """Calling build_pikzels_prompt must not alter the original brief dict."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        brief = {
+            "text": "original text",
+            "background": "original background",
+            "person": "original person",
+            "mood": "original mood",
+        }
+        original_copy = dict(brief)
+        build_pikzels_prompt(brief, "A")
+
+        assert brief == original_copy, (
+            "build_pikzels_prompt must not mutate the input brief dict"
+        )
+
+    def test_text_uppercasing_does_not_mutate_input(self) -> None:
+        """Text uppercasing must produce a new string, not mutate brief['text']."""
+        from congress_videos.modules.thumbnail_prompt import build_pikzels_prompt
+
+        original_text = "lowercase text"
+        brief = {
+            "text": original_text,
+            "background": "fondo",
+            "person": "persona",
+            "mood": "mood",
+        }
+        build_pikzels_prompt(brief, "B")
+
+        assert brief["text"] == original_text, (
+            "brief['text'] must remain unchanged after build_pikzels_prompt call"
+        )


### PR DESCRIPTION
## Resumen

Mejora la generación de thumbnails del DAG `generic_thumbnail_generator` (Pikzels) en tres bloques:

### 1. Slug lookup + tolerancia a "sin speaker" (`b01fe56`)
- Nuevo `lookup_participant_by_slug(slug)` — match exacto y único (reemplaza el fuzzy `normalized_name`).
- Conf key `normalized_name` → `slug`, ahora **opcional**.
- `resolve_participant_photo` es **tolerante**: nunca lanza; devuelve `{"support_image_b64": "", "source": "none"}` + WARNING cuando el slug falta, no existe, o la foto no se puede bajar.

### 2. Alineación con la skill `congress-thumbnail` (`9b5ab55`)
- Nuevo módulo puro `thumbnail_prompt.py` → `build_pikzels_prompt(art_brief, layout)` con los templates A/B/C de la skill (marco dorado `#C9A84C`, texto ALL-CAPS, fondo contextual, **nunca hemiciclo**, persona 35-40%).
- Nuevo `art_direct()` (LLM art-director vía OpenAI) que produce el brief `{text, background, person, mood}`, con fallback seguro `_DEFAULT_ART_BRIEF` (nunca lanza).
- Prompts `ART_DIRECTION_*` en `ai_prompts.py` (prohíben URLs/"http").
- Nueva tarea de DAG `art_direction`; `_task_generate_thumbnail` arma el prompt con el builder y deja de pasar `persona`/`style` a Pikzels. Config de estilos pasa a ser layout-keyed.

### 3. Fix: descarga de fotos de congreso.es (`ce0bbcf`)
- `resolve_participant_photo` ahora manda `CONGRESO_BROWSER_USER_AGENT` al bajar la foto. Sin él, congreso.es devuelve **HTTP 403** y **todas** las fotos de speaker caían silenciosamente al fallback sin imagen.

Más limpieza de tests (`9642160`): nombres y fixtures actualizados a la conducta real.

## Test plan
- `uv run pytest` → **1549 passed, 1 skipped, cobertura 85.19%**.
- Docker e2e smoke: `airflow dags list-import-errors` vacío (PASS).
- Prueba en vivo contra la DB real (NAS): thumbnails generados con speaker (Ione Belarra, foto real de la DB) y sin speaker (texto solo). Las fotos oficiales de congreso.es (124×165 px) son suficientes como referencia para Pikzels.

## Follow-up (no bloquea este PR)
`congress_participants` (con `photo_url`/`slug`) existe solo en el schema `development`, pero el pipeline prod usa `POSTGRES_SCHEMA=production`. En prod, la resolución de foto por slug fallaría (tabla inexistente). Conviene un issue para confirmar si el enriquecimiento debe poblar también `production`.