### PR TITLE
feat(youtube-uploader): generate thumbnail+title via shared generic pipeline pre-upload

### DIFF
--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -288,6 +288,35 @@ class CongressionalVideoDB:
                 """, (thumbnail_text, thumbnail_path, video_topic_entry_id))
                 logger.info(f"Updated thumbnail info for video topic {video_topic_entry_id}")
 
+    def update_thumbnail_youtube_video_id(
+        self, chapter_id: int, youtube_video_id: str
+    ) -> None:
+        """Back-fill the youtube_video_id for a chapter's thumbnail row after upload.
+
+        Called after the YouTube upload completes to associate the real video ID
+        with the pre-generated thumbnail persisted in ``video_thumbnails``.
+
+        Args:
+            chapter_id: FK to ``video_chapters.chapter_id``.
+            youtube_video_id: The YouTube video ID returned by the upload task.
+        """
+        thumbnails_table = self.pg_conn.get_qualified_table("video_thumbnails")
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE {thumbnails_table}
+                    SET youtube_video_id = %s
+                    WHERE chapter_id = %s
+                    """,
+                    (youtube_video_id, chapter_id),
+                )
+        logger.info(
+            "update_thumbnail_youtube_video_id: chapter_id=%d -> youtube_video_id=%r",
+            chapter_id,
+            youtube_video_id,
+        )
+
     def get_interventions_by_main_topic(self, main_topic_entry_id: str) -> List[Dict]:
         """Get all interventions for a specific main topic"""
         with self.pg_conn.get_connection() as conn:

--- a/congress_videos/modules/thumbnail_generator.py
+++ b/congress_videos/modules/thumbnail_generator.py
@@ -8,6 +8,14 @@ Generates eye-catching YouTube thumbnails with:
 - Session number
 - Gold border
 - Professional styling with shadows and effects
+
+NOTE — Uploader dead code (2026-08):
+``generate_thumbnail_text_for_videos`` and ``generate_video_thumbnails`` are no
+longer called by ``congress_youtube_chapter_uploader``; that DAG now uses the
+shared Pikzels pipeline (``congress_videos.modules.thumbnail_generation``).
+These functions remain here because they are still imported by the standalone
+scripts ``generate_thumbnails_today.py`` and ``generate_thumbnails_last_two.py``.
+Removal is deferred to a follow-up change once those scripts are migrated.
 """
 
 import logging

--- a/congress_videos/modules/youtube/youtube_upload.py
+++ b/congress_videos/modules/youtube/youtube_upload.py
@@ -14,6 +14,7 @@ def prepare_chapter_upload_config(
     chapter_extraction_results,
     youtube_metadata_results,
     thumbnail_results=None,
+    thumbnail_result=None,
     is_testing=False
 ):
     """
@@ -53,7 +54,8 @@ def prepare_chapter_upload_config(
                     }
                 ]
             }
-        thumbnail_results: (optional) Results from thumbnail_generator.generate_video_thumbnails
+        thumbnail_results: (optional) Legacy batch results from
+            thumbnail_generator.generate_video_thumbnails.
             Expected structure:
             {
                 'results': [
@@ -63,6 +65,17 @@ def prepare_chapter_upload_config(
                         'output_path': str
                     }
                 ]
+            }
+        thumbnail_result: (optional) Single-chapter result from the generic
+            Pikzels pipeline (_generate_thumbnail). When provided and
+            ``success`` is True, ``output_path`` is used as the thumbnail
+            file and ``title`` overrides the upload metadata title.
+            Expected structure:
+            {
+                'chapter_id': int,
+                'success': bool,
+                'output_path': str | None,
+                'title': str | None,
             }
         is_testing: If True, uploads as private; if False, uploads as public
 
@@ -84,13 +97,22 @@ def prepare_chapter_upload_config(
             if chapter_id:
                 metadata_lookup[chapter_id] = metadata
 
-    # Create thumbnail lookup by chapter_id
+    # Create thumbnail lookup by chapter_id (legacy batch path)
     thumbnail_lookup = {}
     if thumbnail_results and thumbnail_results.get('results'):
         for thumbnail in thumbnail_results['results']:
             chapter_id = thumbnail.get('chapter_id')
             if chapter_id and thumbnail.get('success'):
                 thumbnail_lookup[chapter_id] = thumbnail.get('output_path')
+
+    # Parse single-chapter Pikzels thumbnail result
+    pikzels_chapter_id = None
+    pikzels_thumbnail_path = None
+    pikzels_title = None
+    if thumbnail_result and thumbnail_result.get('success'):
+        pikzels_chapter_id = thumbnail_result.get('chapter_id')
+        pikzels_thumbnail_path = thumbnail_result.get('output_path')
+        pikzels_title = thumbnail_result.get('title')
 
     # Build videos list for generic uploader
     videos = []
@@ -121,6 +143,12 @@ def prepare_chapter_upload_config(
             if isinstance(description_data, dict)
             else str(description_data)
         )
+
+        # Apply Pikzels thumbnail result override when it matches this chapter
+        if chapter_id == pikzels_chapter_id and pikzels_thumbnail_path:
+            thumbnail_file = pikzels_thumbnail_path
+        if chapter_id == pikzels_chapter_id and pikzels_title:
+            title = pikzels_title
 
         logging.info(
             f"Chapter {chapter_id} (video {video_id}): "

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -20,6 +20,7 @@ as standalone YouTube videos.
 
 import logging
 import os
+import pathlib
 from datetime import datetime, timedelta
 
 from airflow import DAG
@@ -27,6 +28,19 @@ from airflow.operators.python import PythonOperator, ShortCircuitOperator
 from airflow.api.common.trigger_dag import trigger_dag as trigger_dag_api
 
 from congress_videos.modules.postgres_operators import PostgreSQLOperator
+from congress_videos.config.thumbnail_config import get_domain_config
+from congress_videos.modules.thumbnail_generation import (
+    resolve_participant_photo,
+    generate_title,
+    persist_results,
+)
+from congress_videos.modules.pikzels_client import (
+    thumbnail_from_text,
+    score_thumbnail,
+    download as pkz_download,
+    to_base64_data_url,
+)
+from congress_videos.config.paths import get_thumbnail_dir
 from utils.airflow_helpers import ensure_project_data_directory, xcom_task
 from utils.env_loader import load_env_if_local
 
@@ -56,6 +70,279 @@ def should_upload(**context):
     hour = context['logical_date'].hour
     threshold = THRESHOLD_BY_HOUR.get(hour, 0)
     return queue_size > threshold
+
+
+# ---------------------------------------------------------------------------
+# Thumbnail pipeline helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_speaker_name(chapter: dict) -> str | None:
+    """Extract the first speaker name from key_speakers or speakers.
+
+    Args:
+        chapter: Chapter dict from the uploadable_chapters view.
+
+    Returns:
+        Speaker name string, or None when no speakers are present.
+
+    Raises:
+        LookupError: Re-raised from downstream participant lookup callers.
+        ValueError: Re-raised from downstream participant lookup callers.
+    """
+    key_speakers = chapter.get("key_speakers") or []
+    speakers = chapter.get("speakers") or []
+
+    # Prefer key_speakers; fall back to speakers
+    if key_speakers:
+        first = key_speakers[0]
+        # key_speakers entries may be dicts {"name": "..."} or plain strings
+        return first["name"] if isinstance(first, dict) else first
+    if speakers:
+        first = speakers[0]
+        return first["name"] if isinstance(first, dict) else first
+    return None
+
+
+def _prepare_thumbnail_config(chapter: dict, db) -> dict:
+    """Build the thumbnail-generation config dict for a single chapter.
+
+    Resolves the normalized speaker name and assembles the six fields
+    expected by the generic thumbnail pipeline.
+
+    Args:
+        chapter: Chapter row from the uploadable_chapters view.
+        db: CongressionalVideoDB instance (unused for name resolution
+            but kept in signature for future participant-lookup extension).
+
+    Returns:
+        Dict with keys: chapter_id, debate_summary, domain, session,
+        normalized_name (may be None on fallback).
+    """
+    chapter_id = chapter.get("chapter_id")
+    title = chapter.get("chapter_title", "")
+    description = chapter.get("description", "")
+    session_number = chapter.get("session_number")
+    session_date = chapter.get("session_date")
+
+    # debate_summary: title + description (D6)
+    debate_summary = (
+        f"{title}\n{description}" if description else title
+    )
+
+    # session label (D6)
+    if session_number is not None:
+        session = f"Sesión {session_number}"
+    else:
+        session = str(session_date) if session_date else None
+
+    # Resolve normalized_name; fall back gracefully on any error
+    try:
+        normalized_name = _resolve_speaker_name(chapter)
+    except (LookupError, ValueError) as exc:
+        logging.warning(
+            "_prepare_thumbnail_config: speaker resolution failed for "
+            "chapter_id=%s: %s — setting normalized_name=None",
+            chapter_id,
+            exc,
+        )
+        normalized_name = None
+
+    return {
+        "chapter_id": chapter_id,
+        "debate_summary": debate_summary,
+        "domain": "congreso",
+        "session": session,
+        "normalized_name": normalized_name,
+    }
+
+
+def _generate_thumbnail(thumbnail_config: dict, chapter_id: int) -> dict:
+    """Run the full Pikzels + OpenAI thumbnail pipeline for a single chapter.
+
+    Sequentially generates options A and B, downloads them, scores each,
+    chooses the best, generates an AI title, and persists both rows to
+    ``video_thumbnails`` with ``youtube_video_id=NULL`` (back-filled post-upload).
+
+    Returns ``{success: False, output_path: None, title: None}`` on any error
+    or when ``normalized_name`` is ``None`` — the DAG run continues unaffected.
+
+    Args:
+        thumbnail_config: Dict from ``_prepare_thumbnail_config``.
+        chapter_id: Chapter DB identifier.
+
+    Returns:
+        Dict with keys: chapter_id, success, output_path, title.
+    """
+    _FAILURE = {"chapter_id": chapter_id, "success": False, "output_path": None, "title": None}
+
+    normalized_name = thumbnail_config.get("normalized_name")
+    if normalized_name is None:
+        logging.info(
+            "_generate_thumbnail: normalized_name is None for chapter_id=%s — skipping",
+            chapter_id,
+        )
+        return _FAILURE
+
+    domain = thumbnail_config.get("domain", "congreso")
+    debate_summary = thumbnail_config.get("debate_summary", "")
+
+    try:
+        domain_cfg = get_domain_config(domain)
+        styles = domain_cfg["styles"]
+
+        # Resolve participant photo (base64)
+        photo_data = resolve_participant_photo(normalized_name, domain_cfg)
+        support_b64 = photo_data.get("support_image_b64", "")
+        support_data_url = (
+            f"data:image/jpeg;base64,{support_b64}" if support_b64 else None
+        )
+
+        # Prepare thumbnail output directory (use chapter_id as stable pre-upload key)
+        thumb_dir = get_thumbnail_dir(str(chapter_id))
+        pathlib.Path(str(thumb_dir)).mkdir(parents=True, exist_ok=True)
+
+        options = []
+        for style_cfg in styles:
+            label = style_cfg["label"]
+            try:
+                gen_result = thumbnail_from_text(
+                    debate_summary,
+                    persona=style_cfg.get("persona"),
+                    style=style_cfg.get("style"),
+                    support_image_base64=support_data_url,
+                )
+                gen_result["label"] = label
+                gen_result["style"] = style_cfg.get("style", "")
+                gen_result["persona"] = style_cfg.get("persona", "")
+                gen_result["prompt"] = debate_summary
+
+                output_url = gen_result.get("output") or gen_result.get("output_url", "")
+                local_path = pathlib.Path(str(thumb_dir)) / f"{label}.png"
+
+                try:
+                    pkz_download(output_url, str(local_path))
+                except Exception as dl_exc:
+                    logging.warning(
+                        "_generate_thumbnail: download failed for %s/%s: %s — skipping option",
+                        chapter_id, label, dl_exc,
+                    )
+                    continue
+
+                image_bytes = local_path.read_bytes()
+                image_b64 = to_base64_data_url(image_bytes, "image/png")
+                score_result = score_thumbnail(image_base64=image_b64)
+                main_score = score_result.get("main_score", 0.0)
+
+                options.append({
+                    "label": label,
+                    "local_path": str(local_path),
+                    "output_url": output_url,
+                    "style": gen_result.get("style", ""),
+                    "persona": gen_result.get("persona", ""),
+                    "prompt": debate_summary,
+                    "main_score": main_score,
+                })
+            except Exception as opt_exc:
+                logging.warning(
+                    "_generate_thumbnail: option %s failed for chapter_id=%s: %s",
+                    label, chapter_id, opt_exc,
+                )
+                raise  # Re-raise so outer try catches and returns failure
+
+        if not options:
+            logging.warning(
+                "_generate_thumbnail: no valid options for chapter_id=%s", chapter_id
+            )
+            return _FAILURE
+
+        # Choose best option (highest score)
+        best = max(options, key=lambda o: o.get("main_score", 0.0))
+        best_label = best["label"]
+
+        # Generate AI title
+        title = generate_title(debate_summary, best, domain_cfg)
+
+        # Persist both rows with youtube_video_id=NULL (back-filled after upload)
+        persist_results(
+            chapter_id=chapter_id,
+            youtube_video_id="",
+            title=title,
+            options=options,
+            best_label=best_label,
+        )
+
+        logging.info(
+            "_generate_thumbnail: chapter_id=%s → best=%s score=%.3f title=%r",
+            chapter_id, best_label, best.get("main_score", 0.0), title,
+        )
+
+        return {
+            "chapter_id": chapter_id,
+            "success": True,
+            "output_path": best["local_path"],
+            "title": title,
+        }
+
+    except Exception as exc:
+        logging.warning(
+            "_generate_thumbnail: pipeline failed for chapter_id=%s: %s — "
+            "returning failure result; upload will proceed without thumbnail",
+            chapter_id, exc,
+        )
+        return _FAILURE
+
+
+def _backfill_thumbnail_video_id(ti, db=None) -> None:
+    """Back-fill the real YouTube video ID in video_thumbnails after upload.
+
+    Reads thumbnail_result and upload_results XComs. Calls
+    ``db.update_thumbnail_youtube_video_id`` only when the thumbnail
+    generation succeeded (``success is True``).
+
+    Args:
+        ti: Airflow TaskInstance.
+        db: CongressionalVideoDB instance (injected for testability; created
+            internally when None).
+    """
+    thumbnail_result = ti.xcom_pull(key="thumbnail_result") or {}
+    if not thumbnail_result.get("success"):
+        logging.info(
+            "_backfill_thumbnail_video_id: thumbnail_result.success is False — "
+            "skipping back-fill"
+        )
+        return
+
+    upload_results = ti.xcom_pull(key="upload_results") or {}
+    upload_details = upload_results.get("upload_details", [])
+
+    chapter_id = thumbnail_result.get("chapter_id")
+
+    # Find the matching upload detail for this chapter
+    youtube_video_id = None
+    for detail in upload_details:
+        if detail.get("chapter_id") == chapter_id:
+            youtube_video_id = detail.get("youtube_video_id")
+            break
+
+    if youtube_video_id is None:
+        logging.warning(
+            "_backfill_thumbnail_video_id: no youtube_video_id found for "
+            "chapter_id=%s in upload_details",
+            chapter_id,
+        )
+        return
+
+    if db is None:
+        from congress_videos.modules.database import CongressionalVideoDB
+        db = CongressionalVideoDB()
+
+    db.update_thumbnail_youtube_video_id(
+        chapter_id=chapter_id, youtube_video_id=youtube_video_id
+    )
+    logging.info(
+        "_backfill_thumbnail_video_id: chapter_id=%s → %r",
+        chapter_id, youtube_video_id,
+    )
 
 
 default_args = {
@@ -126,29 +413,22 @@ with DAG(
             'youtube_metadata_results'
         )
 
-    def _generate_thumbnail_text(ti):
-        from congress_videos.modules import thumbnail_generator as thumb_gen
-        return xcom_task(
-            ti,
-            lambda: thumb_gen.generate_thumbnail_text_for_videos(
-                ti.xcom_pull(key='uploadable_chapters'),
-                ti.xcom_pull(key='youtube_metadata_results')
-            ),
-            'thumbnail_text_results'
-        )
+    def _run_prepare_thumbnail_config(ti):
+        """Resolve speaker name and build thumbnail config struct for the chapter."""
+        from congress_videos.modules.database import CongressionalVideoDB
+        chapters = ti.xcom_pull(key='uploadable_chapters') or []
+        # Uploader processes exactly 1 chapter per run
+        chapter = chapters[0] if chapters else {}
+        db = CongressionalVideoDB()
+        result = _prepare_thumbnail_config(chapter, db)
+        ti.xcom_push(key='thumbnail_config', value=result)
 
-    def _generate_thumbnails(ti):
-        from congress_videos.modules import thumbnail_generator as thumb_gen
-        return xcom_task(
-            ti,
-            lambda: thumb_gen.generate_video_thumbnails(
-                ti.xcom_pull(key='uploadable_chapters'),
-                ti.xcom_pull(key='thumbnail_text_results'),
-                None,
-                ti.xcom_pull(key='data_directory_path')
-            ),
-            'thumbnail_results'
-        )
+    def _run_generate_thumbnail(ti):
+        """Execute the full Pikzels + OpenAI thumbnail pipeline for the chapter."""
+        thumb_cfg = ti.xcom_pull(key='thumbnail_config') or {}
+        chapter_id = thumb_cfg.get('chapter_id')
+        result = _generate_thumbnail(thumb_cfg, chapter_id=chapter_id)
+        ti.xcom_push(key='thumbnail_result', value=result)
 
     def _extract_chapter_videos(ti):
         from congress_videos.modules import video_splitter
@@ -168,11 +448,15 @@ with DAG(
             lambda: prepare_chapter_upload_config(
                 ti.xcom_pull(key='chapter_extraction_results'),
                 ti.xcom_pull(key='youtube_metadata_results'),
-                ti.xcom_pull(key='thumbnail_results'),
+                thumbnail_result=ti.xcom_pull(key='thumbnail_result'),
                 is_testing=context["params"].get("isTesting", False)
             ),
             'upload_config'
         )
+
+    def _run_backfill_thumbnail_video_id(ti):
+        """Back-fill youtube_video_id in video_thumbnails after upload completes."""
+        _backfill_thumbnail_video_id(ti)
 
     # Step 2: Generate YouTube metadata for chapters
     t2 = PythonOperator(
@@ -180,16 +464,16 @@ with DAG(
         python_callable=_generate_youtube_metadata,
     )
 
-    # Step 3: Generate thumbnail text using AI (3-6 words, max 40 chars)
-    t3 = PythonOperator(
-        task_id='generate_thumbnail_text',
-        python_callable=_generate_thumbnail_text,
+    # Step 3 (new): Prepare thumbnail config — resolve speaker, build config struct
+    t3_prepare = PythonOperator(
+        task_id='prepare_thumbnail_config',
+        python_callable=_run_prepare_thumbnail_config,
     )
 
-    # Step 4: Generate thumbnails and save to video_id/chapter_id/ folder
-    t4 = PythonOperator(
-        task_id='generate_thumbnails',
-        python_callable=_generate_thumbnails,
+    # Step 4 (new): Generate thumbnail via Pikzels + score + title + persist
+    t4_generate = PythonOperator(
+        task_id='generate_thumbnail',
+        python_callable=_run_generate_thumbnail,
     )
 
     # Step 5: Extract chapter videos from source YouTube videos using ffmpeg
@@ -307,11 +591,18 @@ with DAG(
         output_xcom_key='chapter_upload_updates'
     )
 
+    # Step 8b: Back-fill youtube_video_id in video_thumbnails
+    t8_backfill = PythonOperator(
+        task_id='backfill_thumbnail_video_id',
+        python_callable=_run_backfill_thumbnail_video_id,
+    )
+
     # Step 9: Alert when chapter upload failures were recorded (after DB write)
     t9 = PythonOperator(
         task_id='check_upload_failures',
         python_callable=_check_upload_failures,
     )
 
-    # Task dependencies
-    t0 >> t1_quota >> t1_skip >> t1_db >> t2 >> t3 >> t4 >> t5 >> t6 >> t7 >> t8_db >> t9
+    # Task dependencies (13 tasks total)
+    # t0 > t1_quota > t1_skip > t1_db > t2 > t3_prepare > t4_generate > t5 > t6 > t7 > t8_db > t8_backfill > t9
+    t0 >> t1_quota >> t1_skip >> t1_db >> t2 >> t3_prepare >> t4_generate >> t5 >> t6 >> t7 >> t8_db >> t8_backfill >> t9

--- a/tests/congress_videos/modules/test_database.py
+++ b/tests/congress_videos/modules/test_database.py
@@ -938,3 +938,44 @@ class TestGetProcessedVideoIds:
         assert "is_processed = TRUE" in sql
         assert "ANY(%s)" in sql
         assert params == (video_ids,)
+
+
+# --------------------------------------------------------------------------- #
+# update_thumbnail_youtube_video_id
+# --------------------------------------------------------------------------- #
+
+class TestUpdateThumbnailYoutubeVideoId:
+
+    def test_executes_update_with_correct_params(self, db):
+        """UPDATE video_thumbnails SET youtube_video_id uses correct param order."""
+        instance, mock_cursor = db
+
+        instance.update_thumbnail_youtube_video_id(
+            chapter_id=42, youtube_video_id="abc123"
+        )
+
+        mock_cursor.execute.assert_called_once()
+        sql, params = mock_cursor.execute.call_args[0]
+        assert "UPDATE" in sql
+        assert "video_thumbnails" in sql
+        assert "youtube_video_id" in sql
+        assert params == ("abc123", 42)
+
+    def test_returns_none(self, db):
+        """Method has no return value (returns None)."""
+        instance, mock_cursor = db
+
+        result = instance.update_thumbnail_youtube_video_id(
+            chapter_id=7, youtube_video_id="xyz789"
+        )
+
+        assert result is None
+
+    def test_accepts_empty_string_video_id(self, db):
+        """Empty-string youtube_video_id is forwarded as a param without error."""
+        instance, mock_cursor = db
+
+        instance.update_thumbnail_youtube_video_id(chapter_id=1, youtube_video_id="")
+
+        _, params = mock_cursor.execute.call_args[0]
+        assert params == ("", 1)

--- a/tests/congress_videos/modules/youtube/test_youtube_upload.py
+++ b/tests/congress_videos/modules/youtube/test_youtube_upload.py
@@ -176,3 +176,57 @@ class TestPrepareChapterUploadConfig:
         for field in ["chapter_id", "video_id", "video_file", "title", "description",
                       "category_id", "privacy_status", "tags", "made_for_kids"]:
             assert field in video, f"Missing field: {field}"
+
+
+# ---------------------------------------------------------------------------
+# TestPrepareChapterUploadConfigThumbnailResult
+# Tests for the thumbnail_result integration (output_path + title override)
+# ---------------------------------------------------------------------------
+
+class TestPrepareChapterUploadConfigThumbnailResult:
+
+    def test_success_thumbnail_result_sets_thumbnail_file_and_title(self):
+        """When thumbnail_result={success:True}, thumbnail_file and title are overridden."""
+        chapter_id = 42
+        extraction = _make_extraction_results([_make_chapter(chapter_id)])
+        metadata = _make_metadata_results([
+            _make_topic_metadata(chapter_id, "Original Title", "A description")
+        ])
+        thumbnail_result = {
+            "chapter_id": chapter_id,
+            "success": True,
+            "output_path": "/tmp/ch42/best.png",
+            "title": "AI title",
+        }
+
+        result = prepare_chapter_upload_config(
+            extraction, metadata, thumbnail_result=thumbnail_result
+        )
+
+        assert result is not None
+        video = result["videos"][0]
+        assert video["thumbnail_file"] == "/tmp/ch42/best.png"
+        assert video["title"] == "AI title"
+
+    def test_failure_thumbnail_result_leaves_title_and_thumbnail_unchanged(self):
+        """When thumbnail_result={success:False}, original title used, no thumbnail_file."""
+        chapter_id = 7
+        extraction = _make_extraction_results([_make_chapter(chapter_id)])
+        metadata = _make_metadata_results([
+            _make_topic_metadata(chapter_id, "Original Title", "A description")
+        ])
+        thumbnail_result = {
+            "chapter_id": chapter_id,
+            "success": False,
+            "output_path": None,
+            "title": None,
+        }
+
+        result = prepare_chapter_upload_config(
+            extraction, metadata, thumbnail_result=thumbnail_result
+        )
+
+        assert result is not None
+        video = result["videos"][0]
+        assert "thumbnail_file" not in video or video.get("thumbnail_file") is None
+        assert video["title"] == "Original Title"

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from unittest.mock import MagicMock
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -37,26 +37,79 @@ class TestYoutubeUploadDagLoads:
         assert dag is not None
         assert dag.dag_id == "congress_youtube_chapter_uploader"
 
-    def test_dag_has_twelve_tasks(self):
+    def test_dag_has_thirteen_tasks(self):
+        """DAG must have 13 tasks after replacing t3/t4 with 3 new tasks (net +1)."""
         from congress_videos.youtube_upload_dag import dag
-        assert len(dag.tasks) == 12
+        assert len(dag.tasks) == 13
 
     def test_expected_task_ids_present(self):
+        """New task IDs present; legacy Pillow task IDs absent."""
         from congress_videos.youtube_upload_dag import dag
         task_ids = {t.task_id for t in dag.tasks}
+        # Core tasks that must still exist
         assert "trigger_youtube_upload" in task_ids
         assert "mark_chapters_uploaded" in task_ids
         assert "check_upload_failures" in task_ids
+        # New Pikzels-based tasks
+        assert "prepare_thumbnail_config" in task_ids
+        assert "generate_thumbnail" in task_ids
+        assert "backfill_thumbnail_video_id" in task_ids
+        # Legacy Pillow tasks must be gone
+        assert "generate_thumbnail_text" not in task_ids
+        assert "generate_thumbnails" not in task_ids
 
-    def test_chain_t7_t8_t9(self):
+    def test_chain_t7_t8_backfill_t9(self):
+        """New chain: trigger -> mark_uploaded -> backfill -> check_failures."""
         from congress_videos.youtube_upload_dag import dag
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         t7 = tasks_by_id["trigger_youtube_upload"]
         t8 = tasks_by_id["mark_chapters_uploaded"]
+        t8_backfill = tasks_by_id["backfill_thumbnail_video_id"]
         t9 = tasks_by_id["check_upload_failures"]
 
         assert t8.task_id in {t.task_id for t in t7.downstream_list}
-        assert t9.task_id in {t.task_id for t in t8.downstream_list}
+        assert t8_backfill.task_id in {t.task_id for t in t8.downstream_list}
+        assert t9.task_id in {t.task_id for t in t8_backfill.downstream_list}
+
+    def test_prepare_precedes_generate(self):
+        """prepare_thumbnail_config must be upstream of generate_thumbnail."""
+        from congress_videos.youtube_upload_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        prepare = tasks_by_id["prepare_thumbnail_config"]
+        generate = tasks_by_id["generate_thumbnail"]
+
+        upstream_ids = {t.task_id for t in generate.upstream_list}
+        assert prepare.task_id in upstream_ids
+
+    def test_generate_precedes_extract(self):
+        """generate_thumbnail must be a direct upstream of extract_chapter_videos."""
+        from congress_videos.youtube_upload_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        generate = tasks_by_id["generate_thumbnail"]
+        extract = tasks_by_id["extract_chapter_videos"]
+
+        upstream_ids = {t.task_id for t in extract.upstream_list}
+        assert generate.task_id in upstream_ids
+
+    def test_extract_precedes_upload_config(self):
+        """extract_chapter_videos must be a direct upstream of prepare_upload_config."""
+        from congress_videos.youtube_upload_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        extract = tasks_by_id["extract_chapter_videos"]
+        upload_config = tasks_by_id["prepare_upload_config"]
+
+        upstream_ids = {t.task_id for t in upload_config.upstream_list}
+        assert extract.task_id in upstream_ids
+
+    def test_backfill_after_mark_uploaded(self):
+        """backfill_thumbnail_video_id must be downstream of mark_chapters_uploaded."""
+        from congress_videos.youtube_upload_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        mark = tasks_by_id["mark_chapters_uploaded"]
+        backfill = tasks_by_id["backfill_thumbnail_video_id"]
+
+        downstream_ids = {t.task_id for t in mark.downstream_list}
+        assert backfill.task_id in downstream_ids
 
 
 # ---------------------------------------------------------------------------
@@ -281,3 +334,246 @@ class TestDryRun:
         trigger_upload_with_config(ti, params={"dry_run": False}, run_id="test_real")
 
         trigger_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Helper: build a minimal chapter dict for thumbnail config tests
+# ---------------------------------------------------------------------------
+
+def _make_chapter(
+    chapter_id: int = 42,
+    title: str = "Debate sobre presupuestos",
+    description: str = "Una discusión importante",
+    session_number: int | None = 80,
+    session_date: str | None = "2025-06-10",
+    key_speakers: list | None = None,
+    speakers: list | None = None,
+) -> dict:
+    return {
+        "chapter_id": chapter_id,
+        "chapter_title": title,
+        "description": description,
+        "session_number": session_number,
+        "session_date": session_date,
+        "key_speakers": key_speakers if key_speakers is not None else [{"name": "Ana García"}],
+        "speakers": speakers if speakers is not None else ["Ana García"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# _prepare_thumbnail_config
+# ---------------------------------------------------------------------------
+
+class TestPrepareThumbnailConfig:
+
+    def test_resolved_speaker_returns_full_config(self):
+        """Happy path: chapter with key_speakers produces full config dict."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(
+            chapter_id=42,
+            title="Debate sobre presupuestos",
+            description="Una discusión importante",
+            session_number=80,
+            key_speakers=[{"name": "Ana García"}],
+        )
+        mock_db = MagicMock()
+
+        result = _prepare_thumbnail_config(chapter, mock_db)
+
+        assert result["normalized_name"] == "Ana García"
+        assert result["domain"] == "congreso"
+        assert result["debate_summary"] != ""
+        assert result["session"] is not None
+        assert result["chapter_id"] == 42
+
+    def test_lookup_error_sets_normalized_name_to_none(self):
+        """LookupError from speaker lookup yields normalized_name=None without raise."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(
+            key_speakers=[{"name": "Unknown Speaker"}],
+        )
+        # db is not called here; error path is simulated via absent lookup
+        # The function catches LookupError from the name resolution path.
+        # We patch the internal lookup call.
+        with patch(
+            "congress_videos.youtube_upload_dag._resolve_speaker_name",
+            side_effect=LookupError("not found"),
+        ):
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["normalized_name"] is None
+        assert result["domain"] == "congreso"
+
+    def test_empty_speakers_sets_normalized_name_to_none(self):
+        """Chapter with empty key_speakers and speakers produces normalized_name=None."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(key_speakers=[], speakers=[])
+
+        result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["normalized_name"] is None
+
+
+# ---------------------------------------------------------------------------
+# _generate_thumbnail
+# ---------------------------------------------------------------------------
+
+class TestGenerateThumbnail:
+
+    def _make_thumbnail_config(self, normalized_name="Ana García", chapter_id=42):
+        return {
+            "chapter_id": chapter_id,
+            "normalized_name": normalized_name,
+            "domain": "congreso",
+            "debate_summary": "Un debate importante sobre el presupuesto",
+            "session": "Sesión 80",
+        }
+
+    def test_happy_path_returns_success_with_path_and_title(self, mocker):
+        """Happy path: pikzels + thumbnail_generation mocked → success result."""
+        from congress_videos.youtube_upload_dag import _generate_thumbnail
+
+        thumb_cfg = self._make_thumbnail_config()
+
+        mock_domain_cfg = {"styles": [
+            {"label": "option_a", "style": "s1", "persona": "p1"},
+            {"label": "option_b", "style": "s2", "persona": "p2"},
+        ], "participants_lookup": MagicMock(return_value={"photo_url": None}), "party_logo_map": None}
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.get_domain_config",
+            return_value=mock_domain_cfg,
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.resolve_participant_photo",
+            return_value={"support_image_b64": "base64data", "source": "photo"},
+        )
+        mock_gen = mocker.patch(
+            "congress_videos.youtube_upload_dag.thumbnail_from_text",
+            side_effect=[
+                {"output": "http://pikzels.com/a.png", "label": "option_a", "style": "s1",
+                 "persona": "p1", "prompt": "prompt"},
+                {"output": "http://pikzels.com/b.png", "label": "option_b", "style": "s2",
+                 "persona": "p2", "prompt": "prompt"},
+            ],
+        )
+        mock_download = mocker.patch(
+            "congress_videos.youtube_upload_dag.pkz_download",
+            return_value=None,
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.to_base64_data_url",
+            return_value="data:image/png;base64,abc",
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.score_thumbnail",
+            side_effect=[
+                {"main_score": 0.8},
+                {"main_score": 0.6},
+            ],
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.generate_title",
+            return_value="AI Generated Title",
+        )
+        mocker.patch("congress_videos.youtube_upload_dag.persist_results", return_value=None)
+        mocker.patch("pathlib.Path.read_bytes", return_value=b"imgbytes")
+        mocker.patch("pathlib.Path.mkdir", return_value=None)
+
+        result = _generate_thumbnail(thumb_cfg, chapter_id=42)
+
+        assert result["success"] is True
+        assert result["output_path"] is not None
+        assert result["title"] == "AI Generated Title"
+
+    def test_normalized_name_none_returns_failure_without_api_calls(self, mocker):
+        """When normalized_name is None, skip Pikzels/OpenAI and return failure struct."""
+        from congress_videos.youtube_upload_dag import _generate_thumbnail
+
+        thumb_cfg = self._make_thumbnail_config(normalized_name=None)
+
+        mock_pikzels = mocker.patch(
+            "congress_videos.youtube_upload_dag.thumbnail_from_text",
+        )
+        mock_resolve = mocker.patch(
+            "congress_videos.youtube_upload_dag.resolve_participant_photo",
+        )
+
+        result = _generate_thumbnail(thumb_cfg, chapter_id=42)
+
+        assert result["success"] is False
+        assert result["output_path"] is None
+        assert result["title"] is None
+        mock_pikzels.assert_not_called()
+        mock_resolve.assert_not_called()
+
+    def test_pikzels_error_returns_failure_without_raising(self, mocker):
+        """Non-retryable Pikzels error → failure struct, no exception propagates."""
+        from congress_videos.youtube_upload_dag import _generate_thumbnail
+
+        thumb_cfg = self._make_thumbnail_config(normalized_name="Ana García")
+
+        mock_domain_cfg = {"styles": [
+            {"label": "option_a", "style": "s1", "persona": "p1"},
+            {"label": "option_b", "style": "s2", "persona": "p2"},
+        ], "participants_lookup": MagicMock(), "party_logo_map": None}
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.get_domain_config",
+            return_value=mock_domain_cfg,
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.resolve_participant_photo",
+            return_value={"support_image_b64": "b64", "source": "photo"},
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.thumbnail_from_text",
+            side_effect=ValueError("Pikzels API error"),
+        )
+        mocker.patch("pathlib.Path.mkdir", return_value=None)
+
+        result = _generate_thumbnail(thumb_cfg, chapter_id=42)
+
+        assert result["success"] is False
+        assert result["output_path"] is None
+        assert result["title"] is None
+
+
+# ---------------------------------------------------------------------------
+# _backfill_thumbnail_video_id
+# ---------------------------------------------------------------------------
+
+class TestBackfillThumbnailVideoId:
+
+    def test_calls_update_when_thumbnail_success_true(self):
+        """When thumbnail_result.success=True, update_thumbnail_youtube_video_id is called."""
+        from congress_videos.youtube_upload_dag import _backfill_thumbnail_video_id
+
+        ti = _make_ti({
+            "thumbnail_result": {"success": True, "chapter_id": 42, "output_path": "/tmp/x.png", "title": "T"},
+            "upload_results": {"upload_details": [{"chapter_id": 42, "youtube_video_id": "abc123"}]},
+        })
+        mock_db = MagicMock()
+
+        _backfill_thumbnail_video_id(ti, mock_db)
+
+        mock_db.update_thumbnail_youtube_video_id.assert_called_once_with(
+            chapter_id=42, youtube_video_id="abc123"
+        )
+
+    def test_skips_update_when_thumbnail_success_false(self):
+        """When thumbnail_result.success=False, update is NOT called."""
+        from congress_videos.youtube_upload_dag import _backfill_thumbnail_video_id
+
+        ti = _make_ti({
+            "thumbnail_result": {"success": False, "chapter_id": 42, "output_path": None, "title": None},
+            "upload_results": {"upload_details": [{"chapter_id": 42, "youtube_video_id": "abc123"}]},
+        })
+        mock_db = MagicMock()
+
+        _backfill_thumbnail_video_id(ti, mock_db)
+
+        mock_db.update_thumbnail_youtube_video_id.assert_not_called()


### PR DESCRIPTION
## Summary

Makes `congress_youtube_chapter_uploader` generate the thumbnail **and** title **before** upload by reusing the shared thumbnail modules that `generic_thumbnail_generator` already uses (Pikzels + scoring + OpenAI title + `video_thumbnails` persistence), replacing the legacy Pillow pipeline (tasks `generate_thumbnail_text` / `generate_thumbnails`).

Approach B of the SDD exploration: the uploader does **not** trigger the generic DAG (its required `youtube_video_id` doesn't exist pre-upload); it calls the same shared module functions inline, mirroring the existing "prepare config → task" upload shape.

## Changes

- **New tasks** in `youtube_upload_dag.py`: `prepare_thumbnail_config` → `generate_thumbnail` → … → `backfill_thumbnail_video_id` (12 → 13 tasks).
  - `prepare_thumbnail_config`: builds the 6 conf-equivalents (`youtube_video_id=""`, `chapter_id`, `debate_summary` from title+description, `session`, `domain="congreso"`, `normalized_name` from `key_speakers[0]` → `speakers[0]`).
  - `generate_thumbnail`: sequential A/B generate/download/score/choose + title + persist. Graceful fallback (`LookupError`/`ValueError` or no speaker → `success:False`, upload proceeds).
  - `backfill_thumbnail_video_id`: fills the real uploaded id into `video_thumbnails` post-upload (skips when thumbnail was skipped).
- **New DB fn** `update_thumbnail_youtube_video_id` in `database.py` (column is nullable per migration 019).
- **Wiring**: generated title override + chosen thumbnail local path injected into `prepare_chapter_upload_config`.
- Legacy Pillow functions in `thumbnail_generator.py` flagged as dead code (still used by root scripts, **not deleted**).

## Non-goals

No changes to the generic DAG, the upload mechanism, or the `video_thumbnails` schema.

## Test plan

- [x] `uv run pytest` → **1535 passed, 1 skipped, 85.08% coverage** (gate 80%). 23 new tests, Strict TDD.
- [x] All 13 spec scenarios mapped to passing tests (SDD verify: PASS, 0 CRITICAL).
- [ ] Docker E2E smoke (`bash scripts/test-airflow-e2e.sh`) — Docker unavailable in dev env; **run before merge**. Note: rc=5 is pre-existing on base `1f8bb7d`, not introduced here.

## Notes

- Spec text uses `local_path`; implementation uses `output_path` consistently — spec follow-up, no behavior impact.