### PR TITLE
refactor(thumbnail): resolve participant identity by stable slug

### DIFF
--- a/congress_videos/config/thumbnail_config.py
+++ b/congress_videos/config/thumbnail_config.py
@@ -21,13 +21,13 @@ class ConfigError(Exception):
 def _get_thumbnail_config() -> dict:
     """Build and return the full per-domain thumbnail configuration dict.
 
-    Defined as a function to defer import of ``lookup_participant_fuzzy``
+    Defined as a function to defer import of ``lookup_participant_by_slug``
     until call time (avoids circular imports at module load).
 
     Returns:
         Mapping from domain key to per-domain config dict.
     """
-    from congress_videos.modules.participants_db import lookup_participant_fuzzy
+    from congress_videos.modules.participants_db import lookup_participant_by_slug
 
     return {
         "congreso": {
@@ -57,9 +57,9 @@ def _get_thumbnail_config() -> dict:
                     ),
                 },
             ],
-            # Callable that resolves a participant by normalized name.
-            # Signature: (name: str) -> dict | None
-            "participants_lookup": lookup_participant_fuzzy,
+            # Callable that resolves a participant by exact stable slug.
+            # Signature: (slug: str) -> dict | None
+            "participants_lookup": lookup_participant_by_slug,
             # Optional absolute path to a fallback party logo image.
             # Set to None when no logo file is available.
             "party_logo_map": None,

--- a/congress_videos/generic_thumbnail_generator_dag.py
+++ b/congress_videos/generic_thumbnail_generator_dag.py
@@ -15,7 +15,7 @@ Usage::
         "debate_summary": "El debate ...",
         "session": "Pleno 2026-06-10",
         "domain": "<domain_key>",
-        "normalized_name": "<normalized_speaker_name>"
+        "slug": "<participant_slug>"
     }'
 """
 
@@ -48,7 +48,7 @@ _REQUIRED_CONF_KEYS = (
     "debate_summary",
     "session",
     "domain",
-    "normalized_name",
+    "slug",
 )
 
 # ---------------------------------------------------------------------------
@@ -97,7 +97,7 @@ def _task_resolve_photo(ti: TaskInstance, **context: object) -> dict:
     """Resolve participant photo to base64 support image."""
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
     domain_cfg = get_domain_config(conf["domain"])
-    return resolve_participant_photo(conf["normalized_name"], domain_cfg)
+    return resolve_participant_photo(conf["slug"], domain_cfg)
 
 
 def _task_generate_thumbnail(label: str, ti: TaskInstance, **context: object) -> dict:

--- a/congress_videos/modules/participants_db.py
+++ b/congress_videos/modules/participants_db.py
@@ -163,6 +163,21 @@ def lookup_participant(name: str) -> dict | None:
     return next((r for r in rows if r["normalized_name"] == key), None)
 
 
+def lookup_participant_by_slug(slug: str) -> dict | None:
+    """Look up a participant by its exact stable slug.
+
+    This lookup deliberately does not normalize or fuzz-match the identifier.
+
+    Args:
+        slug: Participant's stable slug.
+
+    Returns:
+        Row dict if an exact slug match is found, None otherwise.
+    """
+    rows = _get_participants_for_lookup()
+    return next((row for row in rows if row.get("slug") == slug), None)
+
+
 def lookup_participant_fuzzy(
     name: str, threshold: float = WIKIDATA_FUZZY_THRESHOLD
 ) -> dict | None:

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -55,7 +55,7 @@ TITLE_MAX_CHARS = 90
 # ---------------------------------------------------------------------------
 
 
-def resolve_participant_photo(name: str, cfg: dict) -> dict:
+def resolve_participant_photo(slug: str, cfg: dict) -> dict:
     """Resolve the support image for a participant using DB lookup then HTTP download.
 
     Resolution order:
@@ -66,7 +66,7 @@ def resolve_participant_photo(name: str, cfg: dict) -> dict:
     4. If neither source is available, raise ``ValueError``.
 
     Args:
-        name: Normalized participant name to look up.
+        slug: Stable participant slug to look up.
         cfg: Per-domain config dict from ``THUMBNAIL_CONFIG``.
 
     Returns:
@@ -78,10 +78,10 @@ def resolve_participant_photo(name: str, cfg: dict) -> dict:
         ValueError: If the participant has no photo URL and no party logo is configured.
     """
     lookup_fn = cfg["participants_lookup"]
-    participant = lookup_fn(name)
+    participant = lookup_fn(slug)
 
     if participant is None:
-        raise LookupError(f"Participant not found: {name!r}")
+        raise LookupError(f"Participant not found: {slug!r}")
 
     photo_url = participant.get("photo_url")
 
@@ -117,7 +117,7 @@ def resolve_participant_photo(name: str, cfg: dict) -> dict:
         }
 
     raise ValueError(
-        f"no photo source available for participant {name!r}: "
+        f"no photo source available for participant {slug!r}: "
         "photo_url is absent/undownloadable and no party_logo_map configured"
     )
 

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -34,6 +34,7 @@ from congress_videos.modules.thumbnail_generation import (
     generate_title,
     persist_results,
 )
+from congress_videos.modules.participants_db import lookup_participant_fuzzy
 from congress_videos.modules.pikzels_client import (
     thumbnail_from_text,
     score_thumbnail,
@@ -106,17 +107,17 @@ def _resolve_speaker_name(chapter: dict) -> str | None:
 def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     """Build the thumbnail-generation config dict for a single chapter.
 
-    Resolves the normalized speaker name and assembles the six fields
+    Resolves the raw speaker at the boundary and stores the participant slug
+    before assembling the fields
     expected by the generic thumbnail pipeline.
 
     Args:
         chapter: Chapter row from the uploadable_chapters view.
-        db: CongressionalVideoDB instance (unused for name resolution
-            but kept in signature for future participant-lookup extension).
+        db: CongressionalVideoDB instance (kept for task-call compatibility).
 
     Returns:
         Dict with keys: chapter_id, debate_summary, domain, session,
-        normalized_name (may be None on fallback).
+        slug (may be None on fallback).
     """
     chapter_id = chapter.get("chapter_id")
     title = chapter.get("chapter_title", "")
@@ -135,24 +136,27 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     else:
         session = str(session_date) if session_date else None
 
-    # Resolve normalized_name; fall back gracefully on any error
+    # Fuzzy matching is confined to this raw-speaker boundary. Downstream
+    # thumbnail code receives only the stable participant slug.
     try:
-        normalized_name = _resolve_speaker_name(chapter)
-    except (LookupError, ValueError) as exc:
+        raw_speaker = _resolve_speaker_name(chapter)
+        participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
+        slug = participant.get("slug") if participant else None
+    except Exception as exc:
         logging.warning(
             "_prepare_thumbnail_config: speaker resolution failed for "
-            "chapter_id=%s: %s — setting normalized_name=None",
+            "chapter_id=%s: %s — setting slug=None",
             chapter_id,
             exc,
         )
-        normalized_name = None
+        slug = None
 
     return {
         "chapter_id": chapter_id,
         "debate_summary": debate_summary,
         "domain": "congreso",
         "session": session,
-        "normalized_name": normalized_name,
+        "slug": slug,
     }
 
 
@@ -164,7 +168,7 @@ def _generate_thumbnail(thumbnail_config: dict, chapter_id: int) -> dict:
     ``video_thumbnails`` with ``youtube_video_id=NULL`` (back-filled post-upload).
 
     Returns ``{success: False, output_path: None, title: None}`` on any error
-    or when ``normalized_name`` is ``None`` — the DAG run continues unaffected.
+    or when ``slug`` is ``None`` — the DAG run continues unaffected.
 
     Args:
         thumbnail_config: Dict from ``_prepare_thumbnail_config``.
@@ -175,10 +179,10 @@ def _generate_thumbnail(thumbnail_config: dict, chapter_id: int) -> dict:
     """
     _FAILURE = {"chapter_id": chapter_id, "success": False, "output_path": None, "title": None}
 
-    normalized_name = thumbnail_config.get("normalized_name")
-    if normalized_name is None:
+    slug = thumbnail_config.get("slug")
+    if slug is None:
         logging.info(
-            "_generate_thumbnail: normalized_name is None for chapter_id=%s — skipping",
+            "_generate_thumbnail: slug is None for chapter_id=%s — skipping",
             chapter_id,
         )
         return _FAILURE
@@ -191,7 +195,7 @@ def _generate_thumbnail(thumbnail_config: dict, chapter_id: int) -> dict:
         styles = domain_cfg["styles"]
 
         # Resolve participant photo (base64)
-        photo_data = resolve_participant_photo(normalized_name, domain_cfg)
+        photo_data = resolve_participant_photo(slug, domain_cfg)
         support_b64 = photo_data.get("support_image_b64", "")
         support_data_url = (
             f"data:image/jpeg;base64,{support_b64}" if support_b64 else None

--- a/tests/congress_videos/modules/test_generic_thumbnail_dag.py
+++ b/tests/congress_videos/modules/test_generic_thumbnail_dag.py
@@ -194,7 +194,7 @@ VALID_CONF = {
     "debate_summary": "El debate sobre pensiones fue intenso.",
     "session": "Pleno 2026-06-10",
     "domain": "congreso",
-    "normalized_name": "garcia_lopez_maria",
+    "slug": "garcia-lopez-maria",
 }
 
 
@@ -208,7 +208,7 @@ class TestValidateInput:
         self.mod = importlib.import_module("congress_videos.generic_thumbnail_generator_dag")
 
     def test_valid_conf_does_not_raise(self) -> None:
-        """All 6 required keys present → no exception."""
+        """All required keys, including the participant slug, are accepted."""
         # Call the underlying function directly (not via Airflow trigger).
         self.mod.validate_input(VALID_CONF)
 
@@ -275,7 +275,7 @@ _FAKE_CONF = {
     "debate_summary": "El Congreso debate el presupuesto general.",
     "session": "Pleno 2026-07-31",
     "domain": "congreso",
-    "normalized_name": "garcia_lopez_maria",
+    "slug": "garcia-lopez-maria",
 }
 
 _FAKE_STYLES = [
@@ -293,7 +293,7 @@ _FAKE_STYLES = [
 
 _FAKE_DOMAIN_CFG = {
     "styles": _FAKE_STYLES,
-    "participants_lookup": lambda name: None,
+    "participants_lookup": lambda slug: None,
     "party_logo_map": None,
 }
 

--- a/tests/congress_videos/modules/test_participants_db.py
+++ b/tests/congress_videos/modules/test_participants_db.py
@@ -228,6 +228,37 @@ class TestLookupParticipant:
         assert result is None
 
 
+class TestLookupParticipantBySlug:
+
+    def test_exact_slug_match_returns_participant_without_fuzzy_matching(self, monkeypatch):
+        """Slug lookup is deterministic and does not delegate to fuzzy matching."""
+        rows = [
+            {"slug": "garcia-ana", "normalized_name": "garcia ana", "display_name": "García, Ana"},
+        ]
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(_mod, "_get_participants_for_lookup", lambda: rows)
+        monkeypatch.setattr(
+            _mod,
+            "lookup_participant_fuzzy",
+            lambda *_args, **_kwargs: pytest.fail("slug lookup must not use fuzzy matching"),
+        )
+
+        result = _mod.lookup_participant_by_slug("garcia-ana")
+
+        assert result == rows[0]
+
+    def test_non_exact_slug_returns_none(self, monkeypatch):
+        """A similar but different slug is not treated as a fuzzy match."""
+        from congress_videos.modules import participants_db as _mod
+        monkeypatch.setattr(
+            _mod,
+            "_get_participants_for_lookup",
+            lambda: [{"slug": "garcia-ana", "normalized_name": "garcia ana"}],
+        )
+
+        assert _mod.lookup_participant_by_slug("garcia-anna") is None
+
+
 class TestLookupParticipantFuzzy:
     """Tests for lookup_participant_fuzzy.
 

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -367,7 +367,7 @@ def _make_chapter(
 class TestPrepareThumbnailConfig:
 
     def test_resolved_speaker_returns_full_config(self):
-        """Happy path: chapter with key_speakers produces full config dict."""
+        """Raw speaker is resolved once at the boundary and stored as a slug."""
         from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
 
         chapter = _make_chapter(
@@ -379,16 +379,21 @@ class TestPrepareThumbnailConfig:
         )
         mock_db = MagicMock()
 
-        result = _prepare_thumbnail_config(chapter, mock_db)
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value={"slug": "garcia-ana"},
+        ) as lookup:
+            result = _prepare_thumbnail_config(chapter, mock_db)
 
-        assert result["normalized_name"] == "Ana García"
+        assert result["slug"] == "garcia-ana"
+        lookup.assert_called_once_with("Ana García")
         assert result["domain"] == "congreso"
         assert result["debate_summary"] != ""
         assert result["session"] is not None
         assert result["chapter_id"] == 42
 
-    def test_lookup_error_sets_normalized_name_to_none(self):
-        """LookupError from speaker lookup yields normalized_name=None without raise."""
+    def test_lookup_error_sets_slug_to_none(self):
+        """A speaker lookup failure yields slug=None without raising."""
         from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
 
         chapter = _make_chapter(
@@ -398,23 +403,39 @@ class TestPrepareThumbnailConfig:
         # The function catches LookupError from the name resolution path.
         # We patch the internal lookup call.
         with patch(
-            "congress_videos.youtube_upload_dag._resolve_speaker_name",
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
             side_effect=LookupError("not found"),
         ):
             result = _prepare_thumbnail_config(chapter, MagicMock())
 
-        assert result["normalized_name"] is None
+        assert result["slug"] is None
         assert result["domain"] == "congreso"
 
-    def test_empty_speakers_sets_normalized_name_to_none(self):
-        """Chapter with empty key_speakers and speakers produces normalized_name=None."""
+    def test_unmatched_speaker_sets_slug_to_none(self):
+        """An unmatched raw speaker is nonfatal and leaves the slug unset."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(key_speakers=[{"name": "Unknown Speaker"}])
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value=None,
+        ) as lookup:
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["slug"] is None
+        lookup.assert_called_once_with("Unknown Speaker")
+
+    def test_empty_speakers_sets_slug_to_none(self):
+        """Chapter with no speaker produces slug=None without fuzzy lookup."""
         from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
 
         chapter = _make_chapter(key_speakers=[], speakers=[])
 
-        result = _prepare_thumbnail_config(chapter, MagicMock())
+        with patch("congress_videos.youtube_upload_dag.lookup_participant_fuzzy") as lookup:
+            result = _prepare_thumbnail_config(chapter, MagicMock())
 
-        assert result["normalized_name"] is None
+        assert result["slug"] is None
+        lookup.assert_not_called()
 
 
 # ---------------------------------------------------------------------------
@@ -423,10 +444,10 @@ class TestPrepareThumbnailConfig:
 
 class TestGenerateThumbnail:
 
-    def _make_thumbnail_config(self, normalized_name="Ana García", chapter_id=42):
+    def _make_thumbnail_config(self, slug="garcia-ana", chapter_id=42):
         return {
             "chapter_id": chapter_id,
-            "normalized_name": normalized_name,
+            "slug": slug,
             "domain": "congreso",
             "debate_summary": "Un debate importante sobre el presupuesto",
             "session": "Sesión 80",
@@ -447,7 +468,7 @@ class TestGenerateThumbnail:
             "congress_videos.youtube_upload_dag.get_domain_config",
             return_value=mock_domain_cfg,
         )
-        mocker.patch(
+        photo_resolver = mocker.patch(
             "congress_videos.youtube_upload_dag.resolve_participant_photo",
             return_value={"support_image_b64": "base64data", "source": "photo"},
         )
@@ -488,12 +509,13 @@ class TestGenerateThumbnail:
         assert result["success"] is True
         assert result["output_path"] is not None
         assert result["title"] == "AI Generated Title"
+        photo_resolver.assert_called_once_with("garcia-ana", mock_domain_cfg)
 
-    def test_normalized_name_none_returns_failure_without_api_calls(self, mocker):
-        """When normalized_name is None, skip Pikzels/OpenAI and return failure struct."""
+    def test_missing_slug_returns_failure_without_api_calls(self, mocker):
+        """When slug is None, skip Pikzels/OpenAI and return failure struct."""
         from congress_videos.youtube_upload_dag import _generate_thumbnail
 
-        thumb_cfg = self._make_thumbnail_config(normalized_name=None)
+        thumb_cfg = self._make_thumbnail_config(slug=None)
 
         mock_pikzels = mocker.patch(
             "congress_videos.youtube_upload_dag.thumbnail_from_text",
@@ -514,7 +536,7 @@ class TestGenerateThumbnail:
         """Non-retryable Pikzels error → failure struct, no exception propagates."""
         from congress_videos.youtube_upload_dag import _generate_thumbnail
 
-        thumb_cfg = self._make_thumbnail_config(normalized_name="Ana García")
+        thumb_cfg = self._make_thumbnail_config(slug="garcia-ana")
 
         mock_domain_cfg = {"styles": [
             {"label": "option_a", "style": "s1", "persona": "p1"},


### PR DESCRIPTION
## Summary
Unifies participant identity across the thumbnail pipeline on the **stable slug** instead of a normalized name. Fuzzy speaker matching is now confined to a single boundary — the uploader's raw-speaker resolution — and everything downstream receives only the exact slug.

## Changes
- **`participants_db.py`**: add `lookup_participant_by_slug` — exact, non-fuzzy slug match.
- **`thumbnail_config.py`**: `participants_lookup` now points to the slug lookup.
- **`generic_thumbnail_generator_dag.py`**: conf key `normalized_name` → `slug`; photo resolution keyed by slug.
- **`thumbnail_generation.py`**: `resolve_participant_photo` takes a slug.
- **`youtube_upload_dag.py`**: resolve raw speaker once via fuzzy match at the boundary, store the resulting slug (nonfatal `slug=None` on any miss/error).

## Test plan
- [x] `test_participants_db.py` — new `TestLookupParticipantBySlug` (exact match, no fuzzy delegation, non-exact → None)
- [x] `test_generic_thumbnail_dag.py` — conf/domain fixtures updated to slug
- [x] `test_youtube_upload_dag.py` — boundary fuzzy lookup asserted, slug propagation, nonfatal miss paths
- [x] 107 passed locally