### PR TITLE
Merge dev: skip stale re-parse replay runs in chapter_uploader

### DIFF
--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -21,7 +21,7 @@ as standalone YouTube videos.
 import logging
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 from airflow import DAG
 from airflow.models import XCom
@@ -45,6 +45,9 @@ IS_DEVELOPMENT = POSTGRES_SCHEMA == 'development'
 # 14:00: skip if queue_size <= 20 (REQ-THRESH-02)
 # 17:00: skip if queue_size < 1  (REQ-THRESH-03)
 THRESHOLD_BY_HOUR = {11: 10, 14: 20, 17: 0}
+STALE_RUN_TOLERANCE_MINUTES = int(
+    os.getenv("CHAPTER_UPLOADER_STALE_RUN_TOLERANCE_MINUTES", "30")
+)
 _THUMBNAIL_DAG_ID = "generic_thumbnail_generator"
 _THUMBNAIL_RESULT_TASK_ID = "thumbnail_result"
 
@@ -55,6 +58,17 @@ def should_upload(**context):
     Used as the python_callable for t1_skip (ShortCircuitOperator).
     Receives full Airflow context via **context (REQ-GATE-01).
     """
+    data_interval_end = context.get("data_interval_end")
+    if data_interval_end:
+        now = datetime.now(timezone.utc)
+        staleness = now - data_interval_end
+        if staleness > timedelta(minutes=STALE_RUN_TOLERANCE_MINUTES):
+            logging.info(
+                "Skipping stale re-parse replay: data_interval_end=%s is %s "
+                "behind now=%s (tolerance=%dm)",
+                data_interval_end, staleness, now, STALE_RUN_TOLERANCE_MINUTES,
+            )
+            return False
     ti = context['ti']
     upload_quota = ti.xcom_pull(key='upload_quota') or {}
     queue_size = upload_quota.get('queue_size', 0)

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -298,6 +298,56 @@ class TestShouldUpload:
         ctx = _make_context_for_should_upload(queue_size=1, hour=8)
         assert should_upload(**ctx) is True
 
+    # ---------------------------------------------------------------------------
+    # Staleness guard tests (REQ-STALE-01/02/03/04)
+    # ---------------------------------------------------------------------------
+
+    def test_stale_run_returns_false(self):
+        """data_interval_end ~2h in the past, queue above threshold → False (stale skip)."""
+        from datetime import datetime, timedelta, timezone
+        from congress_videos.youtube_upload_dag import should_upload
+
+        ctx = _make_context_for_should_upload(queue_size=11, hour=11)
+        ctx["data_interval_end"] = datetime.now(timezone.utc) - timedelta(hours=2)
+        assert should_upload(**ctx) is False
+
+    def test_fresh_run_proceeds_to_threshold(self):
+        """data_interval_end ~1 min in the past, queue above threshold → True (threshold applies)."""
+        from datetime import datetime, timedelta, timezone
+        from congress_videos.youtube_upload_dag import should_upload
+
+        ctx = _make_context_for_should_upload(queue_size=11, hour=11)
+        ctx["data_interval_end"] = datetime.now(timezone.utc) - timedelta(minutes=1)
+        assert should_upload(**ctx) is True
+
+    def test_missing_data_interval_end_falls_through(self):
+        """No data_interval_end key in context, queue above threshold → True (backward compat)."""
+        from congress_videos.youtube_upload_dag import should_upload
+
+        ctx = _make_context_for_should_upload(queue_size=11, hour=11)
+        # Explicitly ensure the key is absent (helper does not set it)
+        assert "data_interval_end" not in ctx
+        assert should_upload(**ctx) is True
+
+    def test_staleness_boundary_strictly_greater(self):
+        """data_interval_end exactly 30 min in the past → True (guard uses strict >, not >=)."""
+        from datetime import datetime, timedelta, timezone
+        from unittest.mock import patch
+        from congress_videos.youtube_upload_dag import should_upload, STALE_RUN_TOLERANCE_MINUTES
+
+        frozen_now = datetime(2026, 7, 31, 12, 0, 0, tzinfo=timezone.utc)
+        # exactly at boundary: staleness == tolerance, NOT greater
+        data_interval_end = frozen_now - timedelta(minutes=STALE_RUN_TOLERANCE_MINUTES)
+
+        ctx = _make_context_for_should_upload(queue_size=11, hour=11)
+        ctx["data_interval_end"] = data_interval_end
+
+        with patch("congress_videos.youtube_upload_dag.datetime") as mock_dt:
+            mock_dt.now.return_value = frozen_now
+            result = should_upload(**ctx)
+
+        assert result is True
+
 
 # ---------------------------------------------------------------------------
 # dry_run param


### PR DESCRIPTION
Promotes the chapter_uploader staleness-guard fix (PR #47) from `dev` to `main`.

Only change since main: the `data_interval_end` staleness guard in `should_upload` that prevents `congress_youtube_chapter_uploader` from firing on stale re-parse runs created by `git_sync_dag`'s `git reset --hard`. Verify PASS, 45/45 tests in the target file.