### PR TITLE
fix(thumbnail): resolve_participant_photo returns EMPTY_RESULT instead of raising

### DIFF
--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -183,7 +183,11 @@ def resolve_participant_photo(slug: str, cfg: dict) -> dict:
     participant = lookup_fn(slug)
 
     if participant is None:
-        raise LookupError(f"Participant not found: {slug!r}")
+        logger.warning(
+            "resolve_participant_photo: participant not found for slug %r — returning empty result",
+            slug,
+        )
+        return EMPTY_RESULT
 
     photo_url = participant.get("photo_url")
 
@@ -222,9 +226,11 @@ def resolve_participant_photo(slug: str, cfg: dict) -> dict:
             "source": "party_logo",
         }
 
-    raise ValueError(
-        f"no photo source available for participant {slug!r}: "
-        "photo_url is absent/undownloadable and no party_logo_map configured"
+    logger.warning(
+        "resolve_participant_photo: no photo source available for participant %r "
+        "(photo_url absent/undownloadable and no party_logo_map configured) — "
+        "returning empty result",
+        slug,
     )
     return EMPTY_RESULT
 


### PR DESCRIPTION
## Contexto
Detectado durante el review de #44 (preexistente). `resolve_participant_photo` lanzaba excepción en vez de devolver `EMPTY_RESULT` como prometen su docstring y los tests.

## Cambios
En `congress_videos/modules/thumbnail_generation.py`:
- Participante no encontrado: `raise LookupError` → WARNING + `return EMPTY_RESULT`.
- Sin fuente de foto (ni `photo_url` ni `party_logo_map`): `raise ValueError` + `return` inalcanzable → WARNING + `return EMPTY_RESULT`.

Implementación, docstring y tests quedan alineados. En producción, un slug desconocido o una foto no disponible ahora cae al thumbnail genérico en vez de fallar la task.

## Test plan
- [x] Los 6 tests del issue pasan (`TestResolveParticipantPhoto`, `TestSlugResolution`).
- [x] `test_thumbnail_generation.py` completo: 47 passed.
- [x] Suite completa: 1621 passed, 1 skipped, cobertura 85.48%.

Closes #45