### PR TITLE
feat(video-editor): generic on-demand DAG to burn static text overlays (rótulos)

### DIFF
--- a/congress_videos/config/video_editor_config.py
+++ b/congress_videos/config/video_editor_config.py
@@ -2,7 +2,12 @@
 
 This module provides the domain-keyed config dict used by the video editor
 module. Each domain entry defines per-tipo overlay style keys used to
-construct ffmpeg drawtext filter arguments.
+construct ffmpeg drawtext or Pillow-rendered overlay arguments.
+
+Two renderers are supported:
+- ``"drawtext"`` (default): ffmpeg drawtext filter; keys mirror ffmpeg options.
+- ``"pillow"``: Pillow-rendered transparent PNG composited via ffmpeg overlay;
+  keys are Python/Pillow-native (RGB tuples, ints).
 
 Usage::
 
@@ -14,7 +19,7 @@ Usage::
 
 from __future__ import annotations
 
-from congress_videos.config.paths import FONT_BOLD
+from congress_videos.config.paths import FONT_BOLD, FONT_REGULAR
 
 
 class ConfigError(Exception):
@@ -23,32 +28,108 @@ class ConfigError(Exception):
 
 _VIDEO_EDITOR_CONFIG: dict = {
     "congreso": {
-        # Per-tipo overlay style dicts.  Each entry maps a tipo label to the
-        # ffmpeg drawtext arguments needed to render that overlay style.
         "tipos": {
+            # ------------------------------------------------------------------
+            # Pillow tipos: rendered as transparent PNG, composited via ffmpeg.
+            # Color values are (R, G, B) or (R, G, B, A) tuples.
+            # ------------------------------------------------------------------
+
+            # Bottom-centered 90% bar: session extract label.
+            # titulo      → main extract text (large)
+            # descripcion → optional subtitle (small, optional)
             "extracto_sesion": {
-                # Absolute path to the font file on the Airflow image.
+                "renderer": "pillow",
                 "fontfile": FONT_BOLD,
-                # Font size in pixels.
-                "fontsize": 42,
-                # Font colour (ffmpeg colour name or hex).
-                "fontcolor": "white",
-                # Draw a filled box behind the text (1 = enabled).
-                "box": 1,
-                # Box fill colour and opacity.
-                "boxcolor": "black@0.5",
-                # Padding around the text inside the box (pixels).
-                "boxborderw": 8,
-                # Horizontal position expression (ffmpeg geometry).
-                # (w-text_w)/2 centres the text horizontally.
-                "x": "(w-text_w)/2",
-                # Vertical position expression.
-                # h-th-60 places the text 60px from the bottom edge.
-                "y": "h-th-60",
-                # Minimum overlay duration in seconds (informational).
-                "min_duration_secs": 1.0,
-                # Maximum overlay duration in seconds (informational).
-                "max_duration_secs": 15.0,
+                "fontfile_sub": FONT_REGULAR,
+                "fontsize_title": 30,
+                "fontsize_sub": 18,
+                "bg_color": (12, 36, 97, 215),
+                "accent_color": (0, 120, 255, 255),
+                "title_color": (255, 255, 255, 255),
+                "sub_color": (180, 210, 255, 240),
+                "width_pct": 0.90,
+                "height": 104,
+                "margin_y": 60,
+            },
+
+            # Lower-left card: speaker name + role/party.
+            # titulo   → speaker name (large)
+            # descripcion → role · party (small, optional)
+            "speaker_id": {
+                "renderer": "pillow",
+                "fontfile": FONT_BOLD,
+                "fontfile_sub": FONT_REGULAR,
+                "fontsize_title": 34,
+                "fontsize_sub": 20,
+                "bg_color": (12, 36, 97, 215),
+                "accent_color": (0, 120, 255, 255),
+                "title_color": (255, 255, 255, 255),
+                "sub_color": (180, 210, 255, 240),
+                "width_pct": 0.46,
+                "height": 104,
+                "margin_x": 64,
+                "margin_y": 60,
+            },
+
+            # Centered large quote highlight.
+            # titulo      → quote body (large, white)
+            # descripcion → attribution, e.g. "— Juan Pérez" (small, gold)
+            "cita_destacada": {
+                "renderer": "pillow",
+                "fontfile": FONT_BOLD,
+                "fontfile_sub": FONT_REGULAR,
+                "fontsize_title": 32,
+                "fontsize_sub": 20,
+                "bg_color": (0, 0, 0, 155),
+                "accent_color": (255, 190, 0, 255),
+                "title_color": (255, 255, 255, 255),
+                "sub_color": (255, 190, 0, 230),
+                "width_pct": 0.86,
+                "padding": 28,
+            },
+
+            # Top red breaking-news banner.
+            # titulo      → news text
+            # descripcion → optional detail line (smaller)
+            "urgente": {
+                "renderer": "pillow",
+                "fontfile": FONT_BOLD,
+                "fontfile_sub": FONT_REGULAR,
+                "fontsize_label": 18,
+                "fontsize_title": 26,
+                "fontsize_sub": 17,
+                "bg_color": (180, 15, 15, 235),
+                "label_bg_color": (220, 0, 0, 255),
+                "accent_color": (255, 230, 0, 255),
+                "label_color": (255, 230, 0, 255),
+                "title_color": (255, 255, 255, 255),
+                "sub_color": (255, 210, 210, 230),
+                "label": "URGENTE",
+                "width_pct": 0.90,
+                "height": 62,
+                "margin_y": 24,
+            },
+
+            # Bottom-right compact data/context box.
+            # titulo      → headline or number (large)
+            # descripcion → context sentence (small, optional)
+            "dato_contexto": {
+                "renderer": "pillow",
+                "fontfile": FONT_BOLD,
+                "fontfile_sub": FONT_REGULAR,
+                "fontsize_header": 14,
+                "fontsize_title": 30,
+                "fontsize_sub": 16,
+                "bg_color": (12, 36, 97, 215),
+                "accent_color": (255, 190, 0, 255),
+                "header_color": (255, 190, 0, 255),
+                "title_color": (255, 255, 255, 255),
+                "sub_color": (180, 210, 255, 230),
+                "label": "DATO",
+                "width": 300,
+                "padding": 18,
+                "margin_x": 64,
+                "margin_y": 60,
             },
         },
     },

--- a/congress_videos/config/video_editor_config.py
+++ b/congress_videos/config/video_editor_config.py
@@ -1,0 +1,75 @@
+"""Per-domain configuration for generic video overlay editing.
+
+This module provides the domain-keyed config dict used by the video editor
+module. Each domain entry defines per-tipo overlay style keys used to
+construct ffmpeg drawtext filter arguments.
+
+Usage::
+
+    from congress_videos.config.video_editor_config import ConfigError, get_domain_config
+
+    cfg = get_domain_config("congreso")
+    style = cfg["tipos"]["extracto_sesion"]
+"""
+
+from __future__ import annotations
+
+from congress_videos.config.paths import FONT_BOLD
+
+
+class ConfigError(Exception):
+    """Raised when a requested domain key is absent from the video editor config."""
+
+
+_VIDEO_EDITOR_CONFIG: dict = {
+    "congreso": {
+        # Per-tipo overlay style dicts.  Each entry maps a tipo label to the
+        # ffmpeg drawtext arguments needed to render that overlay style.
+        "tipos": {
+            "extracto_sesion": {
+                # Absolute path to the font file on the Airflow image.
+                "fontfile": FONT_BOLD,
+                # Font size in pixels.
+                "fontsize": 42,
+                # Font colour (ffmpeg colour name or hex).
+                "fontcolor": "white",
+                # Draw a filled box behind the text (1 = enabled).
+                "box": 1,
+                # Box fill colour and opacity.
+                "boxcolor": "black@0.5",
+                # Padding around the text inside the box (pixels).
+                "boxborderw": 8,
+                # Horizontal position expression (ffmpeg geometry).
+                # (w-text_w)/2 centres the text horizontally.
+                "x": "(w-text_w)/2",
+                # Vertical position expression.
+                # h-th-60 places the text 60px from the bottom edge.
+                "y": "h-th-60",
+                # Minimum overlay duration in seconds (informational).
+                "min_duration_secs": 1.0,
+                # Maximum overlay duration in seconds (informational).
+                "max_duration_secs": 15.0,
+            },
+        },
+    },
+}
+
+
+def get_domain_config(domain: str) -> dict:
+    """Return the config dict for *domain*, raising ConfigError if absent.
+
+    Args:
+        domain: Domain key (e.g. ``"congreso"``).
+
+    Returns:
+        Per-domain configuration dict containing a ``tipos`` sub-dict.
+
+    Raises:
+        ConfigError: When *domain* is not present in the video editor config.
+    """
+    if domain not in _VIDEO_EDITOR_CONFIG:
+        raise ConfigError(
+            f"Unknown video editor domain: {domain!r}. "
+            f"Available domains: {list(_VIDEO_EDITOR_CONFIG.keys())}"
+        )
+    return _VIDEO_EDITOR_CONFIG[domain]

--- a/congress_videos/generic_video_editor_dag.py
+++ b/congress_videos/generic_video_editor_dag.py
@@ -1,0 +1,170 @@
+"""Generic video overlay editor DAG.
+
+On-demand (``schedule=None``) DAG that burns static drawtext overlays into a
+source video using ffmpeg, producing a new edited video file.  The output
+path is returned via XCom ``return_value`` so the caller can pass it as
+``video_file`` to ``generic_youtube_uploader``.
+
+Trigger configuration::
+
+    {
+        "domain": "congreso",
+        "source_path": "/opt/airflow/data/congress_videos/V1/C1/chapter_video.mp4",
+        "overlays": [
+            {
+                "tipo": "extracto_sesion",
+                "tiempo_inicio": 0.0,
+                "tiempo_fin": 5.0,
+                "titulo": "Extracto de sesión"
+            }
+        ]
+    }
+
+Alternatively, supply ``video_id`` + ``chapter_id`` instead of ``source_path``
+to derive the canonical path automatically.  An optional ``output_path`` key
+overrides the default ``<source_stem>_edited.mp4`` naming.
+
+Task graph::
+
+    validate_input → apply_overlays → editor_result
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+from airflow import DAG
+from airflow.models.taskinstance import TaskInstance
+from airflow.operators.python import PythonOperator
+
+from congress_videos.config.video_editor_config import get_domain_config
+from congress_videos.modules.video_editor import (
+    _default_output_path,
+    _resolve_source_path,
+    apply_overlays,
+    validate_editor_input,
+)
+
+# ---------------------------------------------------------------------------
+# Required conf keys for every DAG run.
+# ---------------------------------------------------------------------------
+
+_REQUIRED_CONF_KEYS = ("domain", "overlays")
+
+# ---------------------------------------------------------------------------
+# Public helper: validate_input
+# ---------------------------------------------------------------------------
+
+
+def validate_input(conf: dict) -> dict:
+    """Validate *conf* and return it unchanged if valid.
+
+    Delegates the detailed validation to :func:`validate_editor_input` which
+    checks required keys, source XOR, overlay fields, domain existence, tipo
+    membership, and font-file availability.
+
+    Args:
+        conf: DAG run configuration dict.
+
+    Returns:
+        The validated conf dict (unchanged) for downstream XCom hand-off.
+
+    Raises:
+        ValueError: When any required key is absent or overlays are empty.
+        ConfigError: When ``conf["domain"]`` is not registered.
+        FileNotFoundError: When the font file or resolved source is absent.
+    """
+    validate_editor_input(conf)
+    return conf
+
+
+# ---------------------------------------------------------------------------
+# Task callables
+# ---------------------------------------------------------------------------
+
+
+def _task_validate_input(**context: object) -> dict:
+    """Airflow task wrapper for :func:`validate_input`.
+
+    Reads ``dag_run.conf``, validates it, and returns the conf dict so
+    PythonOperator pushes it to XCom ``return_value`` automatically.
+    """
+    conf: dict = context["dag_run"].conf or {}
+    return validate_input(conf)
+
+
+def _task_apply_overlays(ti: TaskInstance, **context: object) -> dict:
+    """Apply drawtext overlays to the source video.
+
+    Pulls the validated conf from the ``validate_input`` XCom, resolves the
+    source path, determines the output path, loads the domain config, and
+    delegates to :func:`apply_overlays`.
+    """
+    conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
+    domain_cfg = get_domain_config(conf["domain"])
+
+    source_path = _resolve_source_path(conf)
+    output_path = conf.get("output_path") or _default_output_path(source_path)
+
+    return apply_overlays(
+        source_path=source_path,
+        output_path=output_path,
+        overlays=conf["overlays"],
+        domain_cfg=domain_cfg,
+    )
+
+
+def _task_editor_result(ti: TaskInstance, **context: object) -> dict:
+    """Collect the editing result and push it as the terminal XCom.
+
+    Returns a dict with ``success``, ``output_path``, and ``domain`` so the
+    calling workflow can forward ``output_path`` to ``generic_youtube_uploader``
+    as its ``video_file`` conf key.
+    """
+    conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
+    result: dict = ti.xcom_pull(task_ids="apply_overlays") or {}
+
+    return {
+        "success": True,
+        "output_path": result["output_path"],
+        "domain": conf["domain"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# DAG definition
+# ---------------------------------------------------------------------------
+
+_DEFAULT_ARGS = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    "start_date": datetime(2024, 1, 1, tzinfo=timezone.utc),
+}
+
+with DAG(
+    dag_id="generic_video_editor",
+    default_args=_DEFAULT_ARGS,
+    schedule=None,
+    catchup=False,
+    tags=["video", "editor", "generic"],
+    description="Burn drawtext overlays into a source video using ffmpeg.",
+) as dag:
+
+    t_validate = PythonOperator(
+        task_id="validate_input",
+        python_callable=_task_validate_input,
+    )
+
+    t_apply = PythonOperator(
+        task_id="apply_overlays",
+        python_callable=_task_apply_overlays,
+    )
+
+    t_result = PythonOperator(
+        task_id="editor_result",
+        python_callable=_task_editor_result,
+    )
+
+    t_validate >> t_apply >> t_result

--- a/congress_videos/modules/video_editor.py
+++ b/congress_videos/modules/video_editor.py
@@ -1,26 +1,30 @@
-"""Video overlay editor module for generic drawtext-based video editing.
+"""Video overlay editor module for drawtext and Pillow-based video editing.
 
 Provides pure builder functions for constructing ffmpeg drawtext commands,
-plus orchestration functions for source resolution, input validation, and
-running ffmpeg via subprocess.
+Pillow-based PNG overlay renderers, and orchestration functions for source
+resolution, input validation, and running ffmpeg via subprocess.
 
 Public API::
 
-    _escape_drawtext(text)           — escape ffmpeg drawtext metacharacters
-    _parse_time(v)                   — normalise seconds value or SRT string
-    build_drawtext_filter(overlays, domain_cfg) → str
-    build_ffmpeg_drawtext_cmd(src, out, filter_str) → list[str]
-    _resolve_source_path(conf)       → str
-    _default_output_path(source_path) → str
+    _escape_drawtext(text)                        — escape ffmpeg drawtext metacharacters
+    _parse_time(v)                                — normalise seconds value or SRT string
+    build_drawtext_filter(overlays, domain_cfg)   → str
+    build_ffmpeg_drawtext_cmd(src, out, filter)   → list[str]
+    build_ffmpeg_pillow_cmd(src, out, png_slots)  → list[str]
+    render_pillow_overlay(overlay, domain_cfg, W, H) → PIL.Image
+    _resolve_source_path(conf)                    → str
+    _default_output_path(source_path)             → str
     validate_editor_input(conf)
     apply_overlays(source_path, output_path, overlays, domain_cfg) → dict
 """
 
 from __future__ import annotations
 
+import functools
 import logging
 import os
 import subprocess
+import tempfile
 from pathlib import Path
 
 from congress_videos.config.paths import PROJECT_DATA_DIR
@@ -239,6 +243,332 @@ def _default_output_path(source_path: str) -> str:
 
 
 # ---------------------------------------------------------------------------
+# Pillow overlay renderers
+# ---------------------------------------------------------------------------
+
+
+@functools.lru_cache(maxsize=32)
+def _load_font(path: str, size: int):
+    """Load a TrueType font; fall back to Pillow default on failure."""
+    from PIL import ImageFont
+    try:
+        return ImageFont.truetype(path, size)
+    except Exception:
+        return ImageFont.load_default()
+
+
+def _draw_text_block(
+    draw,
+    tx: int,
+    box_y: int,
+    box_h: int,
+    title: str,
+    sub: str | None,
+    font_t,
+    font_s,
+    title_color: tuple,
+    sub_color: tuple,
+    gap: int = 8,
+) -> None:
+    """Draw a vertically-centered title + optional subtitle inside a box."""
+    tb = draw.textbbox((0, 0), title, font=font_t)
+    th_t = tb[3] - tb[1]
+    if sub:
+        sb = draw.textbbox((0, 0), sub, font=font_s)
+        th_s = sb[3] - sb[1]
+        ty = box_y + (box_h - th_t - gap - th_s) // 2
+        draw.text((tx, ty - tb[1]), title, font=font_t, fill=title_color)
+        draw.text((tx, ty + th_t + gap - sb[1]), sub, font=font_s, fill=sub_color)
+    else:
+        ty = box_y + (box_h - th_t) // 2
+        draw.text((tx, ty - tb[1]), title, font=font_t, fill=title_color)
+
+
+def _render_speaker_id(overlay: dict, style: dict, W: int, H: int):
+    """Lower-left card: speaker name + role/party."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    bw = int(W * style["width_pct"])
+    bh = style["height"]
+    bx, by = style["margin_x"], H - bh - style["margin_y"]
+
+    draw.rectangle([bx, by, bx + bw, by + bh], fill=style["bg_color"])
+    draw.rectangle([bx, by, bx + bw, by + 6], fill=style["accent_color"])
+    draw.rectangle([bx, by, bx + 10, by + bh], fill=style["accent_color"])
+
+    _draw_text_block(
+        draw, tx=bx + 22, box_y=by, box_h=bh,
+        title=overlay["titulo"], sub=overlay.get("descripcion"),
+        font_t=_load_font(style["fontfile"], style["fontsize_title"]),
+        font_s=_load_font(style["fontfile_sub"], style["fontsize_sub"]),
+        title_color=style["title_color"], sub_color=style["sub_color"], gap=10,
+    )
+    return img
+
+
+def _render_cita_destacada(overlay: dict, style: dict, W: int, H: int):
+    """Centered large quote box."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    font_t = _load_font(style["fontfile"], style["fontsize_title"])
+    font_s = _load_font(style["fontfile_sub"], style["fontsize_sub"])
+    pad = style["padding"]
+    quote_text = f"“{overlay['titulo']}”"
+    bw = int(W * style["width_pct"])
+    bx = (W - bw) // 2
+
+    # Size the box dynamically from measured text heights.
+    bbox_t = draw.textbbox((0, 0), quote_text, font=font_t)
+    th_title = bbox_t[3] - bbox_t[1]
+    th_sub = 0
+    if overlay.get("descripcion"):
+        bbox_s = draw.textbbox((0, 0), overlay["descripcion"], font=font_s)
+        th_sub = bbox_s[3] - bbox_s[1] + 10
+
+    bh = pad * 2 + th_title + th_sub + 6  # +6 accent bar
+    by = H - bh - 70
+
+    draw.rectangle([bx, by, bx + bw, by + 5], fill=style["accent_color"])
+    draw.rectangle([bx, by + 5, bx + bw, by + bh], fill=style["bg_color"])
+
+    tx = bx + pad
+    draw.text((tx, by + 5 + pad - bbox_t[1]), quote_text, font=font_t, fill=style["title_color"])
+    if overlay.get("descripcion"):
+        draw.text(
+            (tx, by + 5 + pad + th_title + 10 - bbox_s[1]),
+            overlay["descripcion"], font=font_s, fill=style["sub_color"],
+        )
+    return img
+
+
+def _render_urgente(overlay: dict, style: dict, W: int, H: int):
+    """Top red breaking-news banner."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    bw = int(W * style["width_pct"])
+    bx = (W - bw) // 2
+    bh = style["height"]
+    by = style["margin_y"]
+
+    font_label = _load_font(style["fontfile"], style["fontsize_label"])
+    font_t = _load_font(style["fontfile"], style["fontsize_title"])
+    font_s = _load_font(style["fontfile_sub"], style["fontsize_sub"])
+
+    label_text = style["label"]
+    lbbox = draw.textbbox((0, 0), label_text, font=font_label)
+    label_w = lbbox[2] - lbbox[0] + 28
+
+    draw.rectangle([bx, by, bx + bw, by + bh], fill=style["bg_color"])
+    draw.rectangle([bx, by, bx + label_w, by + bh], fill=style["label_bg_color"])
+
+    label_ty = by + (bh - (lbbox[3] - lbbox[1])) // 2 - lbbox[1]
+    draw.text((bx + 14, label_ty), label_text, font=font_label, fill=style["label_color"])
+
+    _draw_text_block(
+        draw, tx=bx + label_w + 18, box_y=by, box_h=bh,
+        title=overlay["titulo"], sub=overlay.get("descripcion"),
+        font_t=font_t, font_s=font_s,
+        title_color=style["title_color"], sub_color=style["sub_color"], gap=4,
+    )
+    draw.rectangle([bx, by + bh - 4, bx + bw, by + bh], fill=style["accent_color"])
+    return img
+
+
+def _render_dato_contexto(overlay: dict, style: dict, W: int, H: int):
+    """Bottom-right compact data/context box."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    font_h = _load_font(style["fontfile"], style["fontsize_header"])
+    font_t = _load_font(style["fontfile"], style["fontsize_title"])
+    font_s = _load_font(style["fontfile_sub"], style["fontsize_sub"])
+    pad = style["padding"]
+    bw = style["width"]
+
+    header_label = style["label"]
+    hbbox = draw.textbbox((0, 0), header_label, font=font_h)
+    th_header = hbbox[3] - hbbox[1]
+    tbbox = draw.textbbox((0, 0), overlay["titulo"], font=font_t)
+    th_title = tbbox[3] - tbbox[1]
+    th_sub = 0
+    if overlay.get("descripcion"):
+        sbbox = draw.textbbox((0, 0), overlay["descripcion"], font=font_s)
+        th_sub = sbbox[3] - sbbox[1] + 8
+
+    bh = pad * 2 + th_header + 8 + th_title + th_sub + 6
+    bx = W - bw - style["margin_x"]
+    by = H - bh - style["margin_y"]
+
+    draw.rectangle([bx, by, bx + bw, by + bh], fill=style["bg_color"])
+    draw.rectangle([bx, by, bx + bw, by + 5], fill=style["accent_color"])
+    draw.rectangle([bx, by, bx + 6, by + bh], fill=style["accent_color"])
+
+    tx, ty = bx + pad, by + pad
+    draw.text((tx, ty - hbbox[1]), header_label, font=font_h, fill=style["header_color"])
+    draw.text((tx, ty + th_header + 8 - tbbox[1]), overlay["titulo"], font=font_t, fill=style["title_color"])
+    if overlay.get("descripcion"):
+        draw.text(
+            (tx, ty + th_header + 8 + th_title + 8 - sbbox[1]),
+            overlay["descripcion"], font=font_s, fill=style["sub_color"],
+        )
+    return img
+
+
+def _render_extracto_sesion(overlay: dict, style: dict, W: int, H: int):
+    """Bottom-centered 90% bar: session extract label, same language as speaker_id."""
+    from PIL import Image, ImageDraw
+
+    img = Image.new("RGBA", (W, H), (0, 0, 0, 0))
+    draw = ImageDraw.Draw(img)
+
+    bw = int(W * style["width_pct"])
+    bh = style["height"]
+    bx = (W - bw) // 2
+    by = H - bh - style["margin_y"]
+
+    draw.rectangle([bx, by, bx + bw, by + bh], fill=style["bg_color"])
+    draw.rectangle([bx, by, bx + bw, by + 6], fill=style["accent_color"])
+    draw.rectangle([bx, by, bx + 10, by + bh], fill=style["accent_color"])
+
+    _draw_text_block(
+        draw, tx=bx + 22, box_y=by, box_h=bh,
+        title=overlay["titulo"], sub=overlay.get("descripcion"),
+        font_t=_load_font(style["fontfile"], style["fontsize_title"]),
+        font_s=_load_font(style["fontfile_sub"], style["fontsize_sub"]),
+        title_color=style["title_color"], sub_color=style["sub_color"], gap=10,
+    )
+    return img
+
+
+_PILLOW_RENDERERS = {
+    "extracto_sesion": _render_extracto_sesion,
+    "speaker_id": _render_speaker_id,
+    "cita_destacada": _render_cita_destacada,
+    "urgente": _render_urgente,
+    "dato_contexto": _render_dato_contexto,
+}
+
+
+def render_pillow_overlay(overlay: dict, domain_cfg: dict, W: int, H: int):
+    """Dispatch to the correct Pillow renderer for *overlay["tipo"]*.
+
+    Args:
+        overlay: Overlay dict with ``tipo``, ``titulo``, optional ``descripcion``.
+        domain_cfg: Domain config dict from :func:`get_domain_config`.
+        W: Video frame width in pixels.
+        H: Video frame height in pixels.
+
+    Returns:
+        RGBA ``PIL.Image`` the size of the video frame.
+
+    Raises:
+        KeyError: When the tipo has no registered Pillow renderer.
+    """
+    tipo = overlay["tipo"]
+    style = domain_cfg["tipos"][tipo]
+    renderer_fn = _PILLOW_RENDERERS.get(tipo)
+    if renderer_fn is None:
+        raise KeyError(f"No Pillow renderer registered for tipo {tipo!r}.")
+    return renderer_fn(overlay, style, W, H)
+
+
+# ---------------------------------------------------------------------------
+# Pillow ffmpeg command builder
+# ---------------------------------------------------------------------------
+
+
+def build_ffmpeg_pillow_cmd(
+    src: str,
+    out: str,
+    png_slots: list[tuple[str, float, float]],
+) -> list[str]:
+    """Build an ffmpeg command that composites timed PNG overlays onto *src*.
+
+    Each PNG covers the full video frame (transparent background); timing is
+    controlled via ffmpeg's ``enable='between(t,start,end)'`` expression.
+    Overlays are chained sequentially in filter_complex.
+
+    Args:
+        src: Absolute path to the source video.
+        out: Absolute path for the output video.
+        png_slots: List of ``(png_path, t_start, t_end)`` tuples in order.
+
+    Returns:
+        Argv list ready for ``subprocess.run``.
+    """
+    cmd = ["ffmpeg", "-y", "-i", src]
+    for png_path, _, _ in png_slots:
+        cmd += ["-i", png_path]
+
+    # Build filter_complex chain
+    parts: list[str] = []
+    prev = "0:v"
+    for idx, (_, t_start, t_end) in enumerate(png_slots):
+        input_label = f"{idx + 1}:v"
+        is_last = idx == len(png_slots) - 1
+        out_label = "" if is_last else f"[v{idx}]"
+        parts.append(
+            f"[{prev}][{input_label}]overlay=0:0:enable='between(t,{t_start},{t_end})'{out_label}"
+        )
+        prev = f"v{idx}"
+
+    filter_complex = ";".join(parts)
+    cmd += [
+        "-filter_complex", filter_complex,
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-crf", "20",
+        "-c:a", "copy",
+        out,
+    ]
+    return cmd
+
+
+# ---------------------------------------------------------------------------
+# Source dimensions helper
+# ---------------------------------------------------------------------------
+
+
+def _get_source_dimensions(source_path: str) -> tuple[int, int] | None:
+    """Probe *source_path* with ffprobe and return ``(width, height)``.
+
+    Returns:
+        ``(width, height)`` tuple, or ``None`` on failure.
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe", "-v", "quiet",
+                "-show_entries", "stream=width,height",
+                "-of", "csv=p=0",
+                "-select_streams", "v:0",
+                source_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            parts = result.stdout.strip().split(",")
+            if len(parts) >= 2:
+                return int(parts[0]), int(parts[1])
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ffprobe dimension probe failed for %r: %s", source_path, exc)
+    return None
+
+
+# ---------------------------------------------------------------------------
 # Input validation
 # ---------------------------------------------------------------------------
 
@@ -317,12 +647,13 @@ def validate_editor_input(conf: dict) -> None:
                 f"Available tipos: {list(tipos_cfg.keys())}"
             )
 
-        # Font file must exist on disk
-        font_path = tipos_cfg[tipo]["fontfile"]
-        if not os.path.exists(font_path):
-            raise FileNotFoundError(
-                f"Font file for tipo {tipo!r} not found: {font_path}"
-            )
+        # Font file(s) must exist on disk; pillow tipos may have fontfile_sub too.
+        for font_key in ("fontfile", "fontfile_sub"):
+            font_path = tipos_cfg[tipo].get(font_key)
+            if font_path and not os.path.exists(font_path):
+                raise FileNotFoundError(
+                    f"Font file for tipo {tipo!r} ({font_key}) not found: {font_path}"
+                )
 
 
 # ---------------------------------------------------------------------------
@@ -371,16 +702,20 @@ def apply_overlays(
     overlays: list[dict],
     domain_cfg: dict,
 ) -> dict:
-    """Burn drawtext overlays into *source_path* and write the result to *output_path*.
+    """Burn overlays into *source_path* and write the result to *output_path*.
+
+    Routes to the drawtext or Pillow renderer based on the ``renderer`` key
+    in each overlay's tipo config. All overlays in a single call must use the
+    same renderer; mixing raises ``ValueError``.
 
     Orchestration sequence:
-        1. Probe source duration via ffprobe.
-        2. Warn (do not raise) if any overlay's ``tiempo_fin`` exceeds duration.
-        3. Build the drawtext filter string.
-        4. Build the ffmpeg argv list.
-        5. Invoke ffmpeg via ``subprocess.run`` with an adaptive timeout.
-        6. Raise ``RuntimeError`` on non-zero ffmpeg exit.
-        7. Return success dict.
+        1. Probe source duration for timeout and clamp warnings.
+        2. Determine renderer from tipo config (``"drawtext"`` or ``"pillow"``).
+        3a. drawtext: build filter string → ffmpeg -vf.
+        3b. pillow: render PNGs to temp files → ffmpeg filter_complex overlay.
+        4. Run ffmpeg; raise ``RuntimeError`` on non-zero exit.
+        5. Clean up temp PNG files (pillow path only).
+        6. Return success dict.
 
     Args:
         source_path: Absolute path to the source video.
@@ -392,40 +727,79 @@ def apply_overlays(
         ``{"success": True, "output_path": output_path}``
 
     Raises:
+        ValueError: When overlays mix ``"drawtext"`` and ``"pillow"`` renderers.
         RuntimeError: When ffmpeg exits with a non-zero return code.
     """
-    # 1. Probe duration for timeout calculation and clamp warnings.
+    tipos_cfg = domain_cfg["tipos"]
+
+    # Determine renderers and enforce homogeneity.
+    renderers = {tipos_cfg[o["tipo"]].get("renderer", "drawtext") for o in overlays}
+    if len(renderers) > 1:
+        raise ValueError(
+            "All overlays in a single apply_overlays call must use the same renderer. "
+            f"Found: {renderers}. Split drawtext and pillow overlays into separate calls."
+        )
+    renderer = renderers.pop()
+
+    # 1. Probe duration.
     duration = _get_source_duration(source_path)
 
-    # 2. Warn if any overlay extends beyond the known source duration.
+    # Warn if any overlay exceeds source duration.
     if duration is not None:
         for overlay in overlays:
             t_end = _parse_time(overlay["tiempo_fin"])
             if t_end > duration:
                 logger.warning(
-                    "Overlay tiempo_fin=%.1f exceeds source duration=%.1f for %r. "
-                    "ffmpeg will clamp naturally; no explicit clamping applied.",
-                    t_end,
-                    duration,
-                    source_path,
+                    "Overlay tiempo_fin=%.1f exceeds source duration=%.1f for %r.",
+                    t_end, duration, source_path,
                 )
 
-    # 3. Build the filter string.
-    filter_str = build_drawtext_filter(overlays, domain_cfg)
-
-    # 4. Build the ffmpeg argv list.
-    cmd = build_ffmpeg_drawtext_cmd(source_path, output_path, filter_str)
-
-    # 5. Run ffmpeg.
     timeout = compute_ffmpeg_timeout(duration if duration is not None else 0)
-    logger.info("Running ffmpeg drawtext command (timeout=%ds): %s", timeout, " ".join(cmd))
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
 
-    # 6. Raise on failure.
-    if result.returncode != 0:
-        raise RuntimeError(
-            f"ffmpeg failed with return code {result.returncode}: {result.stderr}"
-        )
+    if renderer == "drawtext":
+        filter_str = build_drawtext_filter(overlays, domain_cfg)
+        cmd = build_ffmpeg_drawtext_cmd(source_path, output_path, filter_str)
+        logger.info("Running ffmpeg drawtext (timeout=%ds): %s", timeout, " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"ffmpeg failed (rc={result.returncode}): {result.stderr}"
+            )
+        logger.info("drawtext overlay applied: %r → %r", source_path, output_path)
+        return {"success": True, "output_path": output_path}
 
-    logger.info("Video overlay applied successfully: %r → %r", source_path, output_path)
+    # Pillow path: render PNGs, composite via filter_complex.
+    dims = _get_source_dimensions(source_path)
+    W, H = dims if dims is not None else (1280, 720)
+    if dims is None:
+        logger.warning("Could not probe video dimensions; defaulting to %dx%d.", W, H)
+
+    tmp_files: list[str] = []
+    try:
+        png_slots: list[tuple[str, float, float]] = []
+        for overlay in overlays:
+            img = render_pillow_overlay(overlay, domain_cfg, W, H)
+            fd, tmp_path = tempfile.mkstemp(suffix=".png")
+            os.close(fd)
+            img.save(tmp_path)
+            tmp_files.append(tmp_path)
+            t_start = _parse_time(overlay["tiempo_inicio"])
+            t_end = _parse_time(overlay["tiempo_fin"])
+            png_slots.append((tmp_path, t_start, t_end))
+
+        cmd = build_ffmpeg_pillow_cmd(source_path, output_path, png_slots)
+        logger.info("Running ffmpeg pillow composite (timeout=%ds): %s", timeout, " ".join(cmd))
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"ffmpeg failed (rc={result.returncode}): {result.stderr}"
+            )
+    finally:
+        for tmp in tmp_files:
+            try:
+                os.unlink(tmp)
+            except OSError:
+                pass
+
+    logger.info("Pillow overlay applied: %r → %r", source_path, output_path)
     return {"success": True, "output_path": output_path}

--- a/congress_videos/modules/video_editor.py
+++ b/congress_videos/modules/video_editor.py
@@ -1,0 +1,431 @@
+"""Video overlay editor module for generic drawtext-based video editing.
+
+Provides pure builder functions for constructing ffmpeg drawtext commands,
+plus orchestration functions for source resolution, input validation, and
+running ffmpeg via subprocess.
+
+Public API::
+
+    _escape_drawtext(text)           — escape ffmpeg drawtext metacharacters
+    _parse_time(v)                   — normalise seconds value or SRT string
+    build_drawtext_filter(overlays, domain_cfg) → str
+    build_ffmpeg_drawtext_cmd(src, out, filter_str) → list[str]
+    _resolve_source_path(conf)       → str
+    _default_output_path(source_path) → str
+    validate_editor_input(conf)
+    apply_overlays(source_path, output_path, overlays, domain_cfg) → dict
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+from pathlib import Path
+
+from congress_videos.config.paths import PROJECT_DATA_DIR
+from congress_videos.config.video_editor_config import ConfigError, get_domain_config
+from congress_videos.modules.video_splitter import (
+    compute_ffmpeg_timeout,
+    convert_srt_time_to_seconds,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: drawtext escaping
+# ---------------------------------------------------------------------------
+
+
+def _escape_drawtext(text: str) -> str:
+    """Escape *text* for safe embedding inside an ffmpeg drawtext filter.
+
+    ffmpeg's drawtext option parser is sensitive to several metacharacters.
+    The escaping order matters — backslash must be escaped first so that
+    subsequent replacements do not double-escape newly inserted backslashes.
+
+    Escape order:
+        1. ``\\``  → ``\\\\``
+        2. ``%``   → ``\\%``
+        3. ``:``   → ``\\:``
+        4. ``'``   → ``\\'``
+        5. ``{``   → ``\\{``
+        6. ``}``   → ``\\}``
+        7. newline → ``\\n``
+
+    Spanish characters (á, é, í, ó, ú, ñ, Ñ, ¿, ¡, etc.) are valid UTF-8
+    and pass through unescaped — freetype renders them directly.
+
+    Args:
+        text: Raw overlay text string.
+
+    Returns:
+        Escaped string safe for inclusion in a drawtext ``text='...'`` clause.
+    """
+    text = text.replace("\\", "\\\\")
+    text = text.replace("%", "\\%")
+    text = text.replace(":", "\\:")
+    text = text.replace("'", "\\'")
+    text = text.replace("{", "\\{")
+    text = text.replace("}", "\\}")
+    text = text.replace("\n", "\\n")
+    return text
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: time normalisation
+# ---------------------------------------------------------------------------
+
+
+def _parse_time(v: int | float | str) -> float:
+    """Normalise a time value to float seconds.
+
+    Args:
+        v: Seconds as ``int`` or ``float``, or an SRT timestamp string in
+           ``HH:MM:SS,mmm`` or ``HH:MM:SS`` format.
+
+    Returns:
+        Time in seconds as ``float``.
+    """
+    if isinstance(v, (int, float)):
+        return float(v)
+    return convert_srt_time_to_seconds(str(v))
+
+
+# ---------------------------------------------------------------------------
+# Pure builder: drawtext filter string
+# ---------------------------------------------------------------------------
+
+
+def build_drawtext_filter(overlays: list[dict], domain_cfg: dict) -> str:
+    """Build a comma-joined ffmpeg drawtext filter string for *overlays*.
+
+    Each overlay is looked up by ``tipo`` in ``domain_cfg["tipos"]``. Text is
+    built from ``titulo`` + optional ``descripcion`` joined with the drawtext
+    newline escape (``\\n``), then passed through :func:`_escape_drawtext`.
+
+    Args:
+        overlays: List of overlay dicts with keys ``tipo``, ``tiempo_inicio``,
+            ``tiempo_fin``, ``titulo``, and optional ``descripcion``.
+        domain_cfg: Domain config dict (from :func:`get_domain_config`) with a
+            ``tipos`` sub-dict mapping tipo names to style dicts.
+
+    Returns:
+        Comma-joined drawtext filter string suitable for ffmpeg ``-vf``.
+
+    Raises:
+        KeyError: When an overlay's ``tipo`` is not in ``domain_cfg["tipos"]``.
+    """
+    clauses: list[str] = []
+    tipos_cfg: dict = domain_cfg["tipos"]
+
+    for overlay in overlays:
+        tipo = overlay["tipo"]
+        if tipo not in tipos_cfg:
+            raise KeyError(
+                f"Unknown tipo {tipo!r}. "
+                f"Available tipos: {list(tipos_cfg.keys())}"
+            )
+        style = tipos_cfg[tipo]
+
+        # Build combined text (titulo + optional descripcion)
+        raw_text = overlay["titulo"]
+        if overlay.get("descripcion"):
+            raw_text = raw_text + "\n" + overlay["descripcion"]
+        escaped_text = _escape_drawtext(raw_text)
+
+        start = _parse_time(overlay["tiempo_inicio"])
+        end = _parse_time(overlay["tiempo_fin"])
+
+        clause = (
+            f"drawtext="
+            f"fontfile={style['fontfile']}"
+            f":text='{escaped_text}'"
+            f":x={style['x']}"
+            f":y={style['y']}"
+            f":fontsize={style['fontsize']}"
+            f":fontcolor={style['fontcolor']}"
+            f":box={style['box']}"
+            f":boxcolor={style['boxcolor']}"
+            f":boxborderw={style['boxborderw']}"
+            f":enable='between(t,{start},{end})'"
+        )
+        clauses.append(clause)
+
+    return ",".join(clauses)
+
+
+# ---------------------------------------------------------------------------
+# Pure builder: ffmpeg argv list
+# ---------------------------------------------------------------------------
+
+
+def build_ffmpeg_drawtext_cmd(src: str, out: str, filter_str: str) -> list[str]:
+    """Build an ffmpeg drawtext command as a pure argv list.
+
+    The source file is never mutated; the output is written to a new path.
+    Video is re-encoded with libx264/veryfast/crf20; audio is stream-copied.
+
+    Args:
+        src: Absolute path to the source video.
+        out: Absolute path where the edited video will be written.
+        filter_str: Comma-joined drawtext filter string (from
+            :func:`build_drawtext_filter`).
+
+    Returns:
+        Argv list ready for ``subprocess.run``.  No shell string, no
+        ``shell=True``.
+    """
+    return [
+        "ffmpeg",
+        "-y",
+        "-i", src,
+        "-vf", filter_str,
+        "-c:v", "libx264",
+        "-preset", "veryfast",
+        "-crf", "20",
+        "-c:a", "copy",
+        out,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Source resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def _resolve_source_path(conf: dict) -> str:
+    """Resolve the absolute path to the source video from *conf*.
+
+    Either ``source_path`` is provided directly, or the path is derived from
+    ``video_id`` + ``chapter_id`` using the standard chapter video layout:
+    ``{PROJECT_DATA_DIR}/{video_id}/{chapter_id}/chapter_video.mp4``.
+
+    Args:
+        conf: DAG run conf dict.
+
+    Returns:
+        Absolute path to the source video file.
+
+    Raises:
+        FileNotFoundError: When the resolved path does not exist on disk.
+    """
+    if "source_path" in conf:
+        path = conf["source_path"]
+    else:
+        video_id = conf["video_id"]
+        chapter_id = conf["chapter_id"]
+        path = f"{PROJECT_DATA_DIR}/{video_id}/{chapter_id}/chapter_video.mp4"
+
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Source video not found: {path}")
+    return path
+
+
+def _default_output_path(source_path: str) -> str:
+    """Derive a default output path by appending ``_edited`` before the extension.
+
+    Example: ``/data/V1/C1/chapter_video.mp4`` → ``/data/V1/C1/chapter_video_edited.mp4``
+
+    Args:
+        source_path: Absolute path to the source video.
+
+    Returns:
+        Absolute path for the edited output video in the same directory.
+    """
+    p = Path(source_path)
+    return str(p.parent / f"{p.stem}_edited{p.suffix}")
+
+
+# ---------------------------------------------------------------------------
+# Input validation
+# ---------------------------------------------------------------------------
+
+_REQUIRED_OVERLAY_KEYS = ("tipo", "tiempo_inicio", "tiempo_fin", "titulo")
+
+
+def validate_editor_input(conf: dict) -> None:
+    """Validate the DAG run conf dict for the video editor.
+
+    Checks:
+        - ``domain`` key is present.
+        - ``overlays`` key is present and non-empty.
+        - Exactly one of ``source_path`` OR (``video_id`` + ``chapter_id``).
+        - Each overlay has all required keys and valid time ordering.
+        - The ``tipo`` in each overlay exists in the domain config.
+        - The ``fontfile`` for every referenced ``tipo`` exists on disk.
+
+    Args:
+        conf: DAG run conf dict.
+
+    Raises:
+        ValueError: On missing/invalid required keys or XOR source violation.
+        ConfigError: On unknown domain or unknown tipo.
+        FileNotFoundError: When the font file referenced by a tipo is absent.
+    """
+    # Required top-level key: domain
+    if "domain" not in conf:
+        raise ValueError("Missing required conf key: 'domain'")
+
+    # Required top-level key: overlays
+    if "overlays" not in conf:
+        raise ValueError("Missing required conf key: 'overlays'")
+
+    overlays = conf["overlays"]
+    if not overlays:
+        raise ValueError("'overlays' must not be empty")
+
+    # XOR source: exactly one of source_path OR (video_id + chapter_id)
+    has_source_path = "source_path" in conf
+    has_id_pair = "video_id" in conf and "chapter_id" in conf
+    if has_source_path and has_id_pair:
+        raise ValueError(
+            "Provide either 'source_path' OR ('video_id' + 'chapter_id'), not both."
+        )
+    if not has_source_path and not has_id_pair:
+        raise ValueError(
+            "One of 'source_path' or ('video_id' + 'chapter_id') is required."
+        )
+
+    # Domain config lookup — raises ConfigError for unknown domain
+    domain_cfg = get_domain_config(conf["domain"])
+    tipos_cfg = domain_cfg["tipos"]
+
+    for i, overlay in enumerate(overlays):
+        # Required overlay keys
+        for key in _REQUIRED_OVERLAY_KEYS:
+            if key not in overlay:
+                raise ValueError(
+                    f"Overlay[{i}] is missing required field: '{key}'"
+                )
+
+        # Time ordering
+        t_start = _parse_time(overlay["tiempo_inicio"])
+        t_end = _parse_time(overlay["tiempo_fin"])
+        if t_end <= t_start:
+            raise ValueError(
+                f"Overlay[{i}]: 'tiempo_fin' ({t_end}) must be greater than "
+                f"'tiempo_inicio' ({t_start})"
+            )
+
+        # Tipo must exist in domain config
+        tipo = overlay["tipo"]
+        if tipo not in tipos_cfg:
+            raise ValueError(
+                f"Overlay[{i}]: unknown tipo {tipo!r}. "
+                f"Available tipos: {list(tipos_cfg.keys())}"
+            )
+
+        # Font file must exist on disk
+        font_path = tipos_cfg[tipo]["fontfile"]
+        if not os.path.exists(font_path):
+            raise FileNotFoundError(
+                f"Font file for tipo {tipo!r} not found: {font_path}"
+            )
+
+
+# ---------------------------------------------------------------------------
+# ffprobe duration helper
+# ---------------------------------------------------------------------------
+
+
+def _get_source_duration(source_path: str) -> float | None:
+    """Probe *source_path* with ffprobe and return the duration in seconds.
+
+    Args:
+        source_path: Absolute path to the source video.
+
+    Returns:
+        Duration as float, or ``None`` if ffprobe fails or the value cannot
+        be parsed (benign degradation — caller warns and skips clamping).
+    """
+    try:
+        result = subprocess.run(
+            [
+                "ffprobe",
+                "-v", "quiet",
+                "-show_entries", "format=duration",
+                "-of", "default=noprint_wrappers=1:nokey=1",
+                source_path,
+            ],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode == 0:
+            return float(result.stdout.strip())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("ffprobe duration probe failed for %r: %s", source_path, exc)
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator: apply_overlays
+# ---------------------------------------------------------------------------
+
+
+def apply_overlays(
+    source_path: str,
+    output_path: str,
+    overlays: list[dict],
+    domain_cfg: dict,
+) -> dict:
+    """Burn drawtext overlays into *source_path* and write the result to *output_path*.
+
+    Orchestration sequence:
+        1. Probe source duration via ffprobe.
+        2. Warn (do not raise) if any overlay's ``tiempo_fin`` exceeds duration.
+        3. Build the drawtext filter string.
+        4. Build the ffmpeg argv list.
+        5. Invoke ffmpeg via ``subprocess.run`` with an adaptive timeout.
+        6. Raise ``RuntimeError`` on non-zero ffmpeg exit.
+        7. Return success dict.
+
+    Args:
+        source_path: Absolute path to the source video.
+        output_path: Absolute path where the edited video will be written.
+        overlays: List of overlay dicts (tipo, tiempo_inicio, tiempo_fin, titulo, …).
+        domain_cfg: Domain config dict (from :func:`get_domain_config`).
+
+    Returns:
+        ``{"success": True, "output_path": output_path}``
+
+    Raises:
+        RuntimeError: When ffmpeg exits with a non-zero return code.
+    """
+    # 1. Probe duration for timeout calculation and clamp warnings.
+    duration = _get_source_duration(source_path)
+
+    # 2. Warn if any overlay extends beyond the known source duration.
+    if duration is not None:
+        for overlay in overlays:
+            t_end = _parse_time(overlay["tiempo_fin"])
+            if t_end > duration:
+                logger.warning(
+                    "Overlay tiempo_fin=%.1f exceeds source duration=%.1f for %r. "
+                    "ffmpeg will clamp naturally; no explicit clamping applied.",
+                    t_end,
+                    duration,
+                    source_path,
+                )
+
+    # 3. Build the filter string.
+    filter_str = build_drawtext_filter(overlays, domain_cfg)
+
+    # 4. Build the ffmpeg argv list.
+    cmd = build_ffmpeg_drawtext_cmd(source_path, output_path, filter_str)
+
+    # 5. Run ffmpeg.
+    timeout = compute_ffmpeg_timeout(duration if duration is not None else 0)
+    logger.info("Running ffmpeg drawtext command (timeout=%ds): %s", timeout, " ".join(cmd))
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+
+    # 6. Raise on failure.
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg failed with return code {result.returncode}: {result.stderr}"
+        )
+
+    logger.info("Video overlay applied successfully: %r → %r", source_path, output_path)
+    return {"success": True, "output_path": output_path}

--- a/tests/congress_videos/modules/test_video_editor.py
+++ b/tests/congress_videos/modules/test_video_editor.py
@@ -83,14 +83,16 @@ class TestVideoEditorConfig:
         assert len(result["tipos"]) >= 1
 
     def test_congreso_extracto_sesion_has_required_style_fields(self) -> None:
-        """The extracto_sesion tipo must have all required style keys."""
+        """The extracto_sesion tipo must have all required Pillow style keys."""
         from congress_videos.config.video_editor_config import get_domain_config
 
         result = get_domain_config("congreso")
         assert "extracto_sesion" in result["tipos"]
         style = result["tipos"]["extracto_sesion"]
-        for key in ("fontfile", "fontsize", "fontcolor", "box", "boxcolor", "x", "y"):
+        for key in ("renderer", "fontfile", "fontfile_sub", "fontsize_title", "fontsize_sub",
+                    "bg_color", "accent_color", "title_color", "width_pct", "height"):
             assert key in style, f"Missing required style key: {key}"
+        assert style["renderer"] == "pillow"
 
     def test_unknown_domain_raises_config_error(self) -> None:
         """get_domain_config('unknown_domain') must raise ConfigError."""
@@ -642,3 +644,468 @@ class TestApplyOverlays:
             domain_cfg=_MINIMAL_DOMAIN_CFG,
         )
         mock_timeout.assert_called_once_with(300.0)
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers for Pillow tests
+# ---------------------------------------------------------------------------
+
+_W, _H = 320, 180  # small frame keeps render tests fast
+
+_PILLOW_OVERLAY_SPEAKER = {
+    "tipo": "speaker_id",
+    "tiempo_inicio": 1.0,
+    "tiempo_fin": 8.0,
+    "titulo": "María García López",
+    "descripcion": "Portavoz · Grupo Socialista",
+}
+_PILLOW_OVERLAY_CITA = {
+    "tipo": "cita_destacada",
+    "tiempo_inicio": 2.0,
+    "tiempo_fin": 15.0,
+    "titulo": "Esta ley afecta a tres millones de familias",
+    "descripcion": "— María García López",
+}
+_PILLOW_OVERLAY_URGENTE = {
+    "tipo": "urgente",
+    "tiempo_inicio": 0.5,
+    "tiempo_fin": 10.0,
+    "titulo": "El Congreso rechaza los Presupuestos",
+    "descripcion": "187 en contra · 163 a favor",
+}
+_PILLOW_OVERLAY_DATO = {
+    "tipo": "dato_contexto",
+    "tiempo_inicio": 3.0,
+    "tiempo_fin": 18.0,
+    "titulo": "63%",
+    "descripcion": "del gasto es en pensiones",
+}
+
+_PILLOW_OVERLAY_EXTRACTO = {
+    "tipo": "extracto_sesion",
+    "tiempo_inicio": 1.0,
+    "tiempo_fin": 9.0,
+    "titulo": "Extracto de la Sesión Plenaria",
+    "descripcion": "15 de enero de 2026",
+}
+
+_ALL_PILLOW_OVERLAYS = [
+    _PILLOW_OVERLAY_EXTRACTO,
+    _PILLOW_OVERLAY_SPEAKER,
+    _PILLOW_OVERLAY_CITA,
+    _PILLOW_OVERLAY_URGENTE,
+    _PILLOW_OVERLAY_DATO,
+]
+
+_PILLOW_TIPO_NAMES = ["extracto_sesion", "speaker_id", "cita_destacada", "urgente", "dato_contexto"]
+
+# Minimal domain cfg with a fake pillow tipo (avoids font-file checks in unit tests)
+_MINIMAL_PILLOW_STYLE = {
+    "renderer": "pillow",
+    "fontfile": "/nonexistent/Bold.ttf",
+    "fontfile_sub": "/nonexistent/Regular.ttf",
+    "fontsize_title": 24,
+    "fontsize_sub": 14,
+    "bg_color": (10, 20, 80, 200),
+    "accent_color": (0, 100, 255, 255),
+    "title_color": (255, 255, 255, 255),
+    "sub_color": (180, 210, 255, 240),
+    "width_pct": 0.46,
+    "height": 80,
+    "margin_x": 20,
+    "margin_y": 20,
+}
+_MINIMAL_PILLOW_DOMAIN_CFG = {
+    "tipos": {
+        "speaker_id": _MINIMAL_PILLOW_STYLE,
+    }
+}
+
+
+# ---------------------------------------------------------------------------
+# T-09: TestVideoEditorConfigPilloTipos — Pillow tipo registration
+# ---------------------------------------------------------------------------
+
+
+class TestVideoEditorConfigPilloTipos:
+    """T-09: The 4 Pillow tipos must be registered in the congreso domain config."""
+
+    def _cfg(self):
+        from congress_videos.config.video_editor_config import get_domain_config
+        return get_domain_config("congreso")
+
+    @pytest.mark.parametrize("tipo", _PILLOW_TIPO_NAMES)
+    def test_pillow_tipo_exists_in_congreso(self, tipo: str) -> None:
+        """Each Pillow tipo must be present under congreso.tipos."""
+        assert tipo in self._cfg()["tipos"]
+
+    @pytest.mark.parametrize("tipo", _PILLOW_TIPO_NAMES)
+    def test_pillow_tipo_has_renderer_pillow(self, tipo: str) -> None:
+        """Each Pillow tipo must declare renderer='pillow'."""
+        style = self._cfg()["tipos"][tipo]
+        assert style.get("renderer") == "pillow"
+
+    @pytest.mark.parametrize("tipo", _PILLOW_TIPO_NAMES)
+    def test_pillow_tipo_has_fontfile(self, tipo: str) -> None:
+        """Each Pillow tipo must define a fontfile key."""
+        assert "fontfile" in self._cfg()["tipos"][tipo]
+
+    @pytest.mark.parametrize("tipo", _PILLOW_TIPO_NAMES)
+    def test_pillow_tipo_has_bg_and_accent_colors(self, tipo: str) -> None:
+        """Each Pillow tipo must define bg_color and accent_color as tuples."""
+        style = self._cfg()["tipos"][tipo]
+        assert "bg_color" in style
+        assert "accent_color" in style
+        assert isinstance(style["bg_color"], tuple)
+        assert isinstance(style["accent_color"], tuple)
+
+    def test_urgente_has_label_bg_color(self) -> None:
+        """urgente must have a distinct label_bg_color for the badge."""
+        assert "label_bg_color" in self._cfg()["tipos"]["urgente"]
+
+    def test_urgente_label_is_config_driven(self) -> None:
+        """urgente must carry a 'label' key so the badge text is not hardcoded."""
+        assert "label" in self._cfg()["tipos"]["urgente"]
+
+    def test_dato_contexto_has_header_color(self) -> None:
+        """dato_contexto must have a header_color for the label."""
+        assert "header_color" in self._cfg()["tipos"]["dato_contexto"]
+
+    def test_dato_contexto_label_is_config_driven(self) -> None:
+        """dato_contexto must carry a 'label' key so the header text is not hardcoded."""
+        assert "label" in self._cfg()["tipos"]["dato_contexto"]
+
+
+# ---------------------------------------------------------------------------
+# T-10: TestRenderPillowOverlay — render dispatch and output shape
+# ---------------------------------------------------------------------------
+
+
+class TestRenderPillowOverlay:
+    """T-10: render_pillow_overlay must return an RGBA PIL Image of the correct size."""
+
+    @pytest.mark.parametrize("overlay", _ALL_PILLOW_OVERLAYS, ids=_PILLOW_TIPO_NAMES)
+    def test_returns_rgba_image_of_correct_size(self, overlay: dict) -> None:
+        """Each renderer must return a PIL Image in RGBA mode sized (W, H)."""
+        from congress_videos.config.video_editor_config import get_domain_config
+        from congress_videos.modules.video_editor import render_pillow_overlay
+
+        cfg = get_domain_config("congreso")
+        img = render_pillow_overlay(overlay, cfg, _W, _H)
+        assert img.size == (_W, _H)
+        assert img.mode == "RGBA"
+
+    @pytest.mark.parametrize("overlay", _ALL_PILLOW_OVERLAYS, ids=_PILLOW_TIPO_NAMES)
+    def test_image_is_not_fully_transparent(self, overlay: dict) -> None:
+        """The rendered image must contain at least one non-transparent pixel."""
+        from congress_videos.config.video_editor_config import get_domain_config
+        from congress_videos.modules.video_editor import render_pillow_overlay
+
+        cfg = get_domain_config("congreso")
+        img = render_pillow_overlay(overlay, cfg, _W, _H)
+        pixels = list(img.getdata())
+        assert any(px[3] > 0 for px in pixels), "All pixels are transparent — nothing was drawn."
+
+    @pytest.mark.parametrize("overlay,tipo", [
+        ({**_PILLOW_OVERLAY_EXTRACTO, "descripcion": None}, "extracto_sesion"),
+        ({**_PILLOW_OVERLAY_SPEAKER,  "descripcion": None}, "speaker_id"),
+        ({**_PILLOW_OVERLAY_CITA,     "descripcion": None}, "cita_destacada"),
+        ({**_PILLOW_OVERLAY_URGENTE,  "descripcion": None}, "urgente"),
+        ({**_PILLOW_OVERLAY_DATO,     "descripcion": None}, "dato_contexto"),
+    ], ids=_PILLOW_TIPO_NAMES)
+    def test_renders_without_descripcion(self, overlay: dict, tipo: str) -> None:
+        """Each renderer must succeed when 'descripcion' is absent or None."""
+        from congress_videos.config.video_editor_config import get_domain_config
+        from congress_videos.modules.video_editor import render_pillow_overlay
+
+        cfg = get_domain_config("congreso")
+        img = render_pillow_overlay(overlay, cfg, _W, _H)
+        assert img.size == (_W, _H)
+
+    def test_unknown_tipo_raises_key_error(self) -> None:
+        """A tipo with no registered Pillow renderer must raise KeyError."""
+        from congress_videos.config.video_editor_config import get_domain_config
+        from congress_videos.modules.video_editor import render_pillow_overlay
+
+        cfg = get_domain_config("congreso")
+        overlay = {**_PILLOW_OVERLAY_SPEAKER, "tipo": "tipo_inexistente"}
+        with pytest.raises(KeyError, match="tipo_inexistente"):
+            render_pillow_overlay(overlay, cfg, _W, _H)
+
+    def test_render_dispatch_importable(self) -> None:
+        """render_pillow_overlay must be importable from the module."""
+        from congress_videos.modules.video_editor import render_pillow_overlay  # noqa: F401
+
+
+# ---------------------------------------------------------------------------
+# T-11: TestBuildFfmpegPillowCmd — command builder
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFfmpegPillowCmd:
+    """T-11: build_ffmpeg_pillow_cmd must build a valid filter_complex ffmpeg argv."""
+
+    def test_single_overlay_has_source_and_png_inputs(self) -> None:
+        """A single-overlay command must have exactly 2 -i inputs (video + PNG)."""
+        from congress_videos.modules.video_editor import build_ffmpeg_pillow_cmd
+
+        cmd = build_ffmpeg_pillow_cmd("/src.mp4", "/out.mp4", [("/o.png", 2.0, 10.0)])
+        assert cmd.count("-i") == 2
+        assert "/src.mp4" in cmd
+        assert "/o.png" in cmd
+
+    def test_single_overlay_contains_between_expr(self) -> None:
+        """filter_complex must contain enable='between(t,start,end)'."""
+        from congress_videos.modules.video_editor import build_ffmpeg_pillow_cmd
+
+        cmd = build_ffmpeg_pillow_cmd("/src.mp4", "/out.mp4", [("/o.png", 2.0, 10.0)])
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        assert "between(t,2.0,10.0)" in fc
+
+    def test_two_overlays_chains_filter(self) -> None:
+        """Two overlays must produce a chained filter_complex with an intermediate label."""
+        from congress_videos.modules.video_editor import build_ffmpeg_pillow_cmd
+
+        cmd = build_ffmpeg_pillow_cmd(
+            "/src.mp4", "/out.mp4",
+            [("/a.png", 0.0, 5.0), ("/b.png", 6.0, 12.0)],
+        )
+        fc = cmd[cmd.index("-filter_complex") + 1]
+        # First segment must produce an intermediate label
+        assert "[v0]" in fc
+        # Both timing expressions present
+        assert "between(t,0.0,5.0)" in fc
+        assert "between(t,6.0,12.0)" in fc
+
+    def test_output_path_is_last_positional_arg(self) -> None:
+        """The output path must be the last element of the argv list."""
+        from congress_videos.modules.video_editor import build_ffmpeg_pillow_cmd
+
+        cmd = build_ffmpeg_pillow_cmd("/src.mp4", "/out.mp4", [("/o.png", 1.0, 5.0)])
+        assert cmd[-1] == "/out.mp4"
+
+    def test_command_starts_with_ffmpeg(self) -> None:
+        """The command must start with 'ffmpeg'."""
+        from congress_videos.modules.video_editor import build_ffmpeg_pillow_cmd
+
+        cmd = build_ffmpeg_pillow_cmd("/src.mp4", "/out.mp4", [("/o.png", 1.0, 5.0)])
+        assert cmd[0] == "ffmpeg"
+
+    def test_libx264_codec_present(self) -> None:
+        """Output must be encoded with libx264."""
+        from congress_videos.modules.video_editor import build_ffmpeg_pillow_cmd
+
+        cmd = build_ffmpeg_pillow_cmd("/src.mp4", "/out.mp4", [("/o.png", 1.0, 5.0)])
+        assert "libx264" in cmd
+
+
+# ---------------------------------------------------------------------------
+# T-12: TestGetSourceDimensions — ffprobe dimensions helper
+# ---------------------------------------------------------------------------
+
+
+class TestGetSourceDimensions:
+    """T-12: _get_source_dimensions must parse ffprobe output or return None on failure."""
+
+    def test_returns_width_height_tuple(self, mocker) -> None:
+        """Valid ffprobe output '1280,720' must return (1280, 720)."""
+        from congress_videos.modules.video_editor import _get_source_dimensions
+
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = "1280,720\n"
+        mocker.patch("congress_videos.modules.video_editor.subprocess.run", return_value=completed)
+
+        result = _get_source_dimensions("/any/video.mp4")
+        assert result == (1280, 720)
+
+    def test_returns_none_on_non_zero_returncode(self, mocker) -> None:
+        """A non-zero ffprobe exit must return None (benign degradation)."""
+        from congress_videos.modules.video_editor import _get_source_dimensions
+
+        completed = MagicMock()
+        completed.returncode = 1
+        completed.stdout = ""
+        mocker.patch("congress_videos.modules.video_editor.subprocess.run", return_value=completed)
+
+        result = _get_source_dimensions("/any/video.mp4")
+        assert result is None
+
+    def test_returns_none_on_subprocess_exception(self, mocker) -> None:
+        """A subprocess exception must return None (benign degradation)."""
+        from congress_videos.modules.video_editor import _get_source_dimensions
+
+        mocker.patch(
+            "congress_videos.modules.video_editor.subprocess.run",
+            side_effect=OSError("ffprobe not found"),
+        )
+        result = _get_source_dimensions("/any/video.mp4")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# T-13: TestApplyOverlaysPillow — apply_overlays with Pillow renderer
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOverlaysPillow:
+    """T-13: apply_overlays must route pillow overlays through the PNG composite path."""
+
+    @pytest.fixture()
+    def mock_subprocess(self, mocker):
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = ""
+        completed.stderr = ""
+        return mocker.patch(
+            "congress_videos.modules.video_editor.subprocess.run",
+            return_value=completed,
+        )
+
+    @pytest.fixture()
+    def mock_duration_and_dims(self, mocker):
+        mocker.patch("congress_videos.modules.video_editor._get_source_duration", return_value=60.0)
+        mocker.patch("congress_videos.modules.video_editor._get_source_dimensions", return_value=(1280, 720))
+
+    @pytest.fixture()
+    def mock_pillow_render(self, mocker):
+        """Return a small blank RGBA Image instead of rendering real overlays."""
+        from PIL import Image
+        fake_img = Image.new("RGBA", (1280, 720), (0, 0, 0, 0))
+        return mocker.patch(
+            "congress_videos.modules.video_editor.render_pillow_overlay",
+            return_value=fake_img,
+        )
+
+    def test_pillow_overlay_returns_success_dict(
+        self, mock_subprocess, mock_duration_and_dims, mock_pillow_render
+    ) -> None:
+        """apply_overlays with a pillow tipo must return {success: True, output_path}."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        result = apply_overlays(
+            source_path="/data/in.mp4",
+            output_path="/data/out.mp4",
+            overlays=[{**_PILLOW_OVERLAY_SPEAKER}],
+            domain_cfg=_MINIMAL_PILLOW_DOMAIN_CFG,
+        )
+        assert result["success"] is True
+        assert result["output_path"] == "/data/out.mp4"
+
+    def test_pillow_overlay_calls_render_once_per_overlay(
+        self, mock_subprocess, mock_duration_and_dims, mock_pillow_render
+    ) -> None:
+        """render_pillow_overlay must be called once for each overlay."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        apply_overlays(
+            source_path="/data/in.mp4",
+            output_path="/data/out.mp4",
+            overlays=[{**_PILLOW_OVERLAY_SPEAKER}],
+            domain_cfg=_MINIMAL_PILLOW_DOMAIN_CFG,
+        )
+        assert mock_pillow_render.call_count == 1
+
+    def test_pillow_non_zero_ffmpeg_raises_runtime_error(
+        self, mock_subprocess, mock_duration_and_dims, mock_pillow_render
+    ) -> None:
+        """A non-zero ffmpeg exit in the Pillow path must raise RuntimeError."""
+        mock_subprocess.return_value.returncode = 1
+        mock_subprocess.return_value.stderr = "pillow ffmpeg error"
+
+        from congress_videos.modules.video_editor import apply_overlays
+
+        with pytest.raises(RuntimeError, match="pillow ffmpeg error"):
+            apply_overlays(
+                source_path="/data/in.mp4",
+                output_path="/data/out.mp4",
+                overlays=[{**_PILLOW_OVERLAY_SPEAKER}],
+                domain_cfg=_MINIMAL_PILLOW_DOMAIN_CFG,
+            )
+
+    def test_pillow_temp_files_cleaned_up_on_success(
+        self, mock_subprocess, mock_duration_and_dims, mock_pillow_render, mocker
+    ) -> None:
+        """Temp PNG files must be unlinked after a successful ffmpeg run."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        unlink_calls: list[str] = []
+        original_unlink = __import__("os").unlink
+
+        def tracking_unlink(path):
+            unlink_calls.append(path)
+
+        mocker.patch("congress_videos.modules.video_editor.os.unlink", side_effect=tracking_unlink)
+
+        apply_overlays(
+            source_path="/data/in.mp4",
+            output_path="/data/out.mp4",
+            overlays=[{**_PILLOW_OVERLAY_SPEAKER}],
+            domain_cfg=_MINIMAL_PILLOW_DOMAIN_CFG,
+        )
+        assert len(unlink_calls) == 1
+
+    def test_pillow_temp_files_cleaned_up_on_ffmpeg_failure(
+        self, mock_subprocess, mock_duration_and_dims, mock_pillow_render, mocker
+    ) -> None:
+        """Temp PNG files must be unlinked even when ffmpeg fails."""
+        mock_subprocess.return_value.returncode = 1
+        mock_subprocess.return_value.stderr = "boom"
+
+        from congress_videos.modules.video_editor import apply_overlays
+
+        unlink_calls: list[str] = []
+        mocker.patch("congress_videos.modules.video_editor.os.unlink", side_effect=lambda p: unlink_calls.append(p))
+
+        with pytest.raises(RuntimeError):
+            apply_overlays(
+                source_path="/data/in.mp4",
+                output_path="/data/out.mp4",
+                overlays=[{**_PILLOW_OVERLAY_SPEAKER}],
+                domain_cfg=_MINIMAL_PILLOW_DOMAIN_CFG,
+            )
+        assert len(unlink_calls) == 1
+
+    def test_mixed_renderers_raises_value_error(self) -> None:
+        """Mixing drawtext and pillow overlays in one call must raise ValueError."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        mixed_cfg = {
+            "tipos": {
+                "extracto_sesion": {**_MINIMAL_STYLE, "renderer": "drawtext"},
+                "speaker_id": {**_MINIMAL_PILLOW_STYLE, "renderer": "pillow"},
+            }
+        }
+        with pytest.raises(ValueError, match="renderer"):
+            apply_overlays(
+                source_path="/data/in.mp4",
+                output_path="/data/out.mp4",
+                overlays=[
+                    {**_VALID_OVERLAY},
+                    {**_PILLOW_OVERLAY_SPEAKER},
+                ],
+                domain_cfg=mixed_cfg,
+            )
+
+    def test_fallback_dimensions_when_probe_fails(
+        self, mock_subprocess, mock_pillow_render, mocker
+    ) -> None:
+        """When _get_source_dimensions returns None, must default to 1280×720."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        mocker.patch("congress_videos.modules.video_editor._get_source_duration", return_value=None)
+        mocker.patch("congress_videos.modules.video_editor._get_source_dimensions", return_value=None)
+
+        result = apply_overlays(
+            source_path="/data/in.mp4",
+            output_path="/data/out.mp4",
+            overlays=[{**_PILLOW_OVERLAY_SPEAKER}],
+            domain_cfg=_MINIMAL_PILLOW_DOMAIN_CFG,
+        )
+        # Must succeed with fallback dimensions, not raise
+        assert result["success"] is True
+        # render must have been called with the 1280×720 fallback
+        _, call_kwargs = mock_pillow_render.call_args
+        call_args = mock_pillow_render.call_args[0]
+        assert 1280 in call_args
+        assert 720 in call_args

--- a/tests/congress_videos/modules/test_video_editor.py
+++ b/tests/congress_videos/modules/test_video_editor.py
@@ -1,0 +1,644 @@
+"""Tests for congress_videos.modules.video_editor and video_editor_config.
+
+Strict TDD — all tests are written BEFORE the production modules exist.
+First run must produce ImportError failures.
+
+Test groups:
+    TestVideoEditorConfig     — T-01 config module (REQ-02)
+    TestEscapeDrawtext        — T-02 _escape_drawtext (REQ-04)
+    TestParseTime             — T-03 _parse_time helper
+    TestBuildDrawtextFilter   — T-04 build_drawtext_filter (REQ-05)
+    TestBuildFfmpegCmd        — T-05 build_ffmpeg_drawtext_cmd (REQ-06)
+    TestResolveSourcePath     — T-06 _resolve_source_path + _default_output_path (REQ-03, REQ-10)
+    TestValidateEditorInput   — T-07 validate_editor_input (REQ-01, REQ-02, REQ-08)
+    TestApplyOverlays         — T-08 apply_overlays (REQ-07)
+"""
+
+from __future__ import annotations
+
+import logging
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared test helpers
+# ---------------------------------------------------------------------------
+
+_MINIMAL_STYLE = {
+    "fontfile": "/fonts/LiberationSans-Bold.ttf",
+    "fontsize": 42,
+    "fontcolor": "white",
+    "box": 1,
+    "boxcolor": "black@0.5",
+    "boxborderw": 8,
+    "x": "(w-text_w)/2",
+    "y": "h-th-60",
+}
+
+_MINIMAL_DOMAIN_CFG = {
+    "tipos": {
+        "extracto_sesion": _MINIMAL_STYLE,
+    }
+}
+
+_VALID_OVERLAY = {
+    "tipo": "extracto_sesion",
+    "tiempo_inicio": 0.0,
+    "tiempo_fin": 5.0,
+    "titulo": "Extracto",
+}
+
+_VALID_CONF = {
+    "domain": "congreso",
+    "source_path": "/data/chapter_video.mp4",
+    "overlays": [_VALID_OVERLAY],
+}
+
+
+# ---------------------------------------------------------------------------
+# T-01: TestVideoEditorConfig — REQ-02
+# ---------------------------------------------------------------------------
+
+
+class TestVideoEditorConfig:
+    """T-01: Config module must export get_domain_config and ConfigError."""
+
+    def test_config_error_importable(self) -> None:
+        """ConfigError must be importable from the config module."""
+        from congress_videos.config.video_editor_config import ConfigError  # noqa: F401
+
+    def test_get_domain_config_importable(self) -> None:
+        """get_domain_config must be importable from the config module."""
+        from congress_videos.config.video_editor_config import get_domain_config  # noqa: F401
+
+    def test_congreso_domain_returns_dict(self) -> None:
+        """get_domain_config('congreso') must return a dict with at least one tipo key."""
+        from congress_videos.config.video_editor_config import get_domain_config
+
+        result = get_domain_config("congreso")
+        assert isinstance(result, dict)
+        assert "tipos" in result
+        assert len(result["tipos"]) >= 1
+
+    def test_congreso_extracto_sesion_has_required_style_fields(self) -> None:
+        """The extracto_sesion tipo must have all required style keys."""
+        from congress_videos.config.video_editor_config import get_domain_config
+
+        result = get_domain_config("congreso")
+        assert "extracto_sesion" in result["tipos"]
+        style = result["tipos"]["extracto_sesion"]
+        for key in ("fontfile", "fontsize", "fontcolor", "box", "boxcolor", "x", "y"):
+            assert key in style, f"Missing required style key: {key}"
+
+    def test_unknown_domain_raises_config_error(self) -> None:
+        """get_domain_config('unknown_domain') must raise ConfigError."""
+        from congress_videos.config.video_editor_config import ConfigError, get_domain_config
+
+        with pytest.raises(ConfigError, match="unknown_domain"):
+            get_domain_config("unknown_domain")
+
+    def test_config_error_message_lists_available_domains(self) -> None:
+        """ConfigError message must list available domains."""
+        from congress_videos.config.video_editor_config import ConfigError, get_domain_config
+
+        with pytest.raises(ConfigError) as exc_info:
+            get_domain_config("bogus")
+        assert "congreso" in str(exc_info.value)
+
+
+# ---------------------------------------------------------------------------
+# T-02: TestEscapeDrawtext — REQ-04
+# ---------------------------------------------------------------------------
+
+
+class TestEscapeDrawtext:
+    """T-02: _escape_drawtext must escape ffmpeg drawtext metacharacters in the correct order."""
+
+    def test_colon_is_escaped(self) -> None:
+        """Colons must be escaped as \\:."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        result = _escape_drawtext("hello: world")
+        assert r"\:" in result
+
+    def test_single_quote_is_escaped(self) -> None:
+        """Single quotes must be escaped as \\'."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        result = _escape_drawtext("it's")
+        assert r"\'" in result
+
+    def test_colon_and_single_quote_together(self) -> None:
+        """Sesión: 'especial' — colon and quote both escaped."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        result = _escape_drawtext("Sesión: 'especial'")
+        assert r"\:" in result
+        assert r"\'" in result
+        # Spanish chars pass through
+        assert "Sesión" in result
+
+    def test_backslash_escaped_before_percent(self) -> None:
+        """Backslash must be escaped first, then percent — order matters."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        # Input has a literal backslash then a percent sign
+        result = _escape_drawtext("50% del\\total")
+        # backslash → \\; percent → \%
+        assert r"\%" in result
+        assert r"\\" in result
+
+    def test_spanish_chars_pass_through(self) -> None:
+        """ñ, ó, á, ¿ and other Spanish chars must not be escaped."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        text = "señor Ñoño: ¿cómo está?"
+        result = _escape_drawtext(text)
+        assert "ñ" in result
+        assert "Ñ" in result
+        assert "ó" in result
+        assert "á" in result
+        assert "¿" in result
+        # But colon is escaped
+        assert r"\:" in result
+
+    def test_curly_braces_escaped(self) -> None:
+        """{key} must have both braces escaped."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        result = _escape_drawtext("{key}")
+        assert r"\{" in result
+        assert r"\}" in result
+
+    def test_newline_to_literal_backslash_n(self) -> None:
+        """Actual newline character must become the literal two-char sequence \\n."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        result = _escape_drawtext("line1\nline2")
+        assert "\\n" in result
+        assert "\n" not in result
+
+    def test_adversarial_injection_cant_break_single_quote_clause(self) -> None:
+        """Text containing ':fontfile=/etc/passwd cannot break the single-quoted clause."""
+        from congress_videos.modules.video_editor import _escape_drawtext
+
+        malicious = "':fontfile=/etc/passwd"
+        result = _escape_drawtext(malicious)
+        # The single quote must be escaped so it cannot end the text='...' clause
+        assert "\\'" in result
+        # The colon must be escaped so it cannot introduce a new option
+        assert "\\:" in result
+
+
+# ---------------------------------------------------------------------------
+# T-03: TestParseTime — design spec
+# ---------------------------------------------------------------------------
+
+
+class TestParseTime:
+    """T-03: _parse_time normalises int/float seconds and SRT timestamp strings."""
+
+    def test_int_passthrough(self) -> None:
+        """Integer seconds must be returned as float."""
+        from congress_videos.modules.video_editor import _parse_time
+
+        assert _parse_time(10) == 10.0
+
+    def test_float_passthrough(self) -> None:
+        """Float seconds pass through unchanged."""
+        from congress_videos.modules.video_editor import _parse_time
+
+        assert _parse_time(5.5) == 5.5
+
+    def test_srt_string_with_milliseconds(self) -> None:
+        """HH:MM:SS,mmm must be converted to total seconds."""
+        from congress_videos.modules.video_editor import _parse_time
+
+        assert _parse_time("00:01:30,000") == pytest.approx(90.0)
+
+    def test_srt_string_without_milliseconds(self) -> None:
+        """HH:MM:SS without milliseconds must also be parsed correctly."""
+        from congress_videos.modules.video_editor import _parse_time
+
+        assert _parse_time("00:00:05") == pytest.approx(5.0)
+
+
+# ---------------------------------------------------------------------------
+# T-04: TestBuildDrawtextFilter — REQ-05
+# ---------------------------------------------------------------------------
+
+
+class TestBuildDrawtextFilter:
+    """T-04: build_drawtext_filter must produce a valid comma-joined drawtext string."""
+
+    def test_single_overlay_contains_enable_expr(self) -> None:
+        """Single overlay must contain enable='between(t,...)' with correct times."""
+        from congress_videos.modules.video_editor import build_drawtext_filter
+
+        overlays = [{**_VALID_OVERLAY}]
+        result = build_drawtext_filter(overlays, _MINIMAL_DOMAIN_CFG)
+        assert "enable='between(t,0.0,5.0)'" in result
+
+    def test_single_overlay_contains_titulo(self) -> None:
+        """Single overlay filter must embed the escaped titulo text."""
+        from congress_videos.modules.video_editor import build_drawtext_filter
+
+        overlays = [{"tipo": "extracto_sesion", "tiempo_inicio": 0.0, "tiempo_fin": 3.0, "titulo": "Sesión"}]
+        result = build_drawtext_filter(overlays, _MINIMAL_DOMAIN_CFG)
+        assert "Sesi" in result  # Spanish chars pass through
+
+    def test_single_overlay_contains_required_style_keys(self) -> None:
+        """Filter string must include fontfile, fontsize, fontcolor, box, boxcolor, x, y."""
+        from congress_videos.modules.video_editor import build_drawtext_filter
+
+        overlays = [{**_VALID_OVERLAY}]
+        result = build_drawtext_filter(overlays, _MINIMAL_DOMAIN_CFG)
+        assert "fontfile=" in result
+        assert "fontsize=" in result
+        assert "fontcolor=" in result
+        assert "box=1" in result
+        assert "boxcolor=" in result
+        assert "x=" in result
+        assert "y=" in result
+
+    def test_two_overlays_comma_joined(self) -> None:
+        """Two overlays must produce exactly one comma between the two drawtext segments."""
+        from congress_videos.modules.video_editor import build_drawtext_filter
+
+        overlays = [
+            {"tipo": "extracto_sesion", "tiempo_inicio": 0.0, "tiempo_fin": 3.0, "titulo": "First"},
+            {"tipo": "extracto_sesion", "tiempo_inicio": 5.0, "tiempo_fin": 8.0, "titulo": "Second"},
+        ]
+        result = build_drawtext_filter(overlays, _MINIMAL_DOMAIN_CFG)
+        # Should have exactly 2 drawtext= segments
+        segments = result.split(",drawtext=")
+        assert len(segments) == 2, f"Expected 2 segments, got {len(segments)}: {result[:200]}"
+
+    def test_descripcion_joined_with_newline_escape(self) -> None:
+        """When descripcion is present, filter text must contain both joined with \\n."""
+        from congress_videos.modules.video_editor import build_drawtext_filter
+
+        overlays = [
+            {
+                "tipo": "extracto_sesion",
+                "tiempo_inicio": 0.0,
+                "tiempo_fin": 5.0,
+                "titulo": "Titulo",
+                "descripcion": "Descripcion extra",
+            }
+        ]
+        result = build_drawtext_filter(overlays, _MINIMAL_DOMAIN_CFG)
+        # Both texts should be present and joined with the drawtext newline escape
+        assert "Titulo" in result
+        assert "Descripcion" in result
+        # The literal \\n escape (backslash-n) must appear between them
+        assert "\\n" in result
+
+    def test_unknown_tipo_raises(self) -> None:
+        """An overlay with a tipo not in domain_cfg must raise KeyError or ValueError."""
+        from congress_videos.modules.video_editor import build_drawtext_filter
+
+        overlays = [{"tipo": "nonexistent_tipo", "tiempo_inicio": 0.0, "tiempo_fin": 5.0, "titulo": "X"}]
+        with pytest.raises((KeyError, ValueError)):
+            build_drawtext_filter(overlays, _MINIMAL_DOMAIN_CFG)
+
+
+# ---------------------------------------------------------------------------
+# T-05: TestBuildFfmpegCmd — REQ-06
+# ---------------------------------------------------------------------------
+
+
+class TestBuildFfmpegCmd:
+    """T-05: build_ffmpeg_drawtext_cmd must return a pure argv list."""
+
+    def test_returns_list_not_string(self) -> None:
+        """The result must be a list[str], not a single shell string."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/in.mp4", "/out.mp4", "drawtext=text='Hello'")
+        assert isinstance(result, list)
+        for token in result:
+            assert isinstance(token, str)
+
+    def test_contains_overwrite_flag(self) -> None:
+        """Command must include '-y' to overwrite the output."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/in.mp4", "/out.mp4", "drawtext=text='X'")
+        assert "-y" in result
+
+    def test_contains_input_file(self) -> None:
+        """Command must include '-i' followed by the source path."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/data/in.mp4", "/data/out.mp4", "drawtext=text='X'")
+        assert "-i" in result
+        idx = result.index("-i")
+        assert result[idx + 1] == "/data/in.mp4"
+
+    def test_contains_vf_filter(self) -> None:
+        """Command must include '-vf' followed by the filter string."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        filter_str = "drawtext=text='Hello World'"
+        result = build_ffmpeg_drawtext_cmd("/in.mp4", "/out.mp4", filter_str)
+        assert "-vf" in result
+        idx = result.index("-vf")
+        assert result[idx + 1] == filter_str
+
+    def test_contains_video_codec_flags(self) -> None:
+        """Command must include -c:v libx264 -preset veryfast -crf 20."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/in.mp4", "/out.mp4", "drawtext=text='X'")
+        assert "-c:v" in result
+        assert "libx264" in result
+        assert "-preset" in result
+        assert "veryfast" in result
+        assert "-crf" in result
+        assert "20" in result
+
+    def test_contains_audio_copy_flag(self) -> None:
+        """Command must include -c:a copy to avoid re-encoding audio."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/in.mp4", "/out.mp4", "drawtext=text='X'")
+        assert "-c:a" in result
+        idx = result.index("-c:a")
+        assert result[idx + 1] == "copy"
+
+    def test_output_path_is_last_token(self) -> None:
+        """Output path must be the last token in the command list."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/data/in.mp4", "/data/out.mp4", "drawtext=text='X'")
+        assert result[-1] == "/data/out.mp4"
+
+    def test_no_shell_string(self) -> None:
+        """The list must not contain any token that looks like a joined shell string."""
+        from congress_videos.modules.video_editor import build_ffmpeg_drawtext_cmd
+
+        result = build_ffmpeg_drawtext_cmd("/in.mp4", "/out.mp4", "drawtext=text='X'")
+        # Each token should be a distinct argument — no spaces except inside the filter
+        for token in result:
+            if token.startswith("drawtext="):
+                continue  # filter string may contain spaces
+            assert " " not in token, f"Shell-string token found: {token!r}"
+
+
+# ---------------------------------------------------------------------------
+# T-06: TestResolveSourcePath + TestDefaultOutputPath — REQ-03, REQ-10
+# ---------------------------------------------------------------------------
+
+
+class TestResolveSourcePath:
+    """T-06: _resolve_source_path resolves explicit path or video_id/chapter_id derivation."""
+
+    def test_explicit_source_path_returned_verbatim(self, mocker) -> None:
+        """When source_path is provided and exists, it must be returned verbatim."""
+        from congress_videos.modules.video_editor import _resolve_source_path
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {"source_path": "/data/video.mp4"}
+        result = _resolve_source_path(conf)
+        assert result == "/data/video.mp4"
+
+    def test_video_id_and_chapter_id_derive_path(self, mocker) -> None:
+        """video_id + chapter_id must derive the canonical path."""
+        from congress_videos.modules.video_editor import _resolve_source_path
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {"video_id": "V1", "chapter_id": "C1"}
+        result = _resolve_source_path(conf)
+        assert "V1" in result
+        assert "C1" in result
+        assert result.endswith("chapter_video.mp4")
+
+    def test_missing_file_raises_file_not_found_error(self, mocker) -> None:
+        """When the resolved path does not exist, FileNotFoundError must be raised."""
+        from congress_videos.modules.video_editor import _resolve_source_path
+
+        mocker.patch("os.path.exists", return_value=False)
+        conf = {"source_path": "/nonexistent/video.mp4"}
+        with pytest.raises(FileNotFoundError):
+            _resolve_source_path(conf)
+
+
+class TestDefaultOutputPath:
+    """T-06b: _default_output_path appends _edited before the extension."""
+
+    def test_edited_suffix_added(self) -> None:
+        """chapter_video.mp4 → chapter_video_edited.mp4 in the same dir."""
+        from congress_videos.modules.video_editor import _default_output_path
+
+        result = _default_output_path("/data/V1/C1/chapter_video.mp4")
+        assert result == "/data/V1/C1/chapter_video_edited.mp4"
+
+    def test_extension_preserved(self) -> None:
+        """The output extension must match the source extension."""
+        from congress_videos.modules.video_editor import _default_output_path
+
+        result = _default_output_path("/tmp/test.mp4")
+        assert result.endswith(".mp4")
+        assert "_edited" in result
+
+
+# ---------------------------------------------------------------------------
+# T-07: TestValidateEditorInput — REQ-01, REQ-02, REQ-08
+# ---------------------------------------------------------------------------
+
+
+class TestValidateEditorInput:
+    """T-07: validate_editor_input must enforce all conf requirements."""
+
+    def test_happy_path_does_not_raise(self, mocker) -> None:
+        """A fully valid conf must complete without raising."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        validate_editor_input(_VALID_CONF)
+
+    def test_missing_domain_raises_value_error(self, mocker) -> None:
+        """Missing 'domain' key must raise ValueError naming domain."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {k: v for k, v in _VALID_CONF.items() if k != "domain"}
+        with pytest.raises(ValueError, match="domain"):
+            validate_editor_input(conf)
+
+    def test_empty_overlays_raises_value_error(self, mocker) -> None:
+        """An empty overlays list must raise ValueError."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {**_VALID_CONF, "overlays": []}
+        with pytest.raises(ValueError):
+            validate_editor_input(conf)
+
+    def test_overlay_missing_titulo_raises_value_error(self, mocker) -> None:
+        """An overlay without 'titulo' must raise ValueError identifying the field."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {
+            **_VALID_CONF,
+            "overlays": [{"tipo": "extracto_sesion", "tiempo_inicio": 0.0, "tiempo_fin": 5.0}],
+        }
+        with pytest.raises(ValueError, match="titulo"):
+            validate_editor_input(conf)
+
+    def test_tiempo_fin_equal_tiempo_inicio_raises_value_error(self, mocker) -> None:
+        """tiempo_fin == tiempo_inicio must raise ValueError."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {
+            **_VALID_CONF,
+            "overlays": [{"tipo": "extracto_sesion", "tiempo_inicio": 5.0, "tiempo_fin": 5.0, "titulo": "X"}],
+        }
+        with pytest.raises(ValueError):
+            validate_editor_input(conf)
+
+    def test_both_source_path_and_video_id_raises_value_error(self, mocker) -> None:
+        """Providing both source_path and video_id must raise ValueError."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {**_VALID_CONF, "video_id": "V1", "chapter_id": "C1"}
+        with pytest.raises(ValueError):
+            validate_editor_input(conf)
+
+    def test_unknown_domain_raises_config_error(self, mocker) -> None:
+        """An unknown domain must propagate ConfigError from get_domain_config."""
+        from congress_videos.config.video_editor_config import ConfigError
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {**_VALID_CONF, "domain": "nonexistent"}
+        with pytest.raises(ConfigError):
+            validate_editor_input(conf)
+
+    def test_font_file_missing_raises_file_not_found_error(self, mocker) -> None:
+        """When the font file for a tipo is absent, FileNotFoundError must be raised."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        # Font file does not exist
+        mocker.patch("os.path.exists", return_value=False)
+        with pytest.raises(FileNotFoundError):
+            validate_editor_input(_VALID_CONF)
+
+    def test_unknown_tipo_in_overlay_raises(self, mocker) -> None:
+        """An overlay with a tipo not in the domain config must raise ValueError or KeyError."""
+        from congress_videos.modules.video_editor import validate_editor_input
+
+        mocker.patch("os.path.exists", return_value=True)
+        conf = {
+            **_VALID_CONF,
+            "overlays": [{"tipo": "unknown_tipo", "tiempo_inicio": 0.0, "tiempo_fin": 5.0, "titulo": "X"}],
+        }
+        with pytest.raises((ValueError, KeyError)):
+            validate_editor_input(conf)
+
+
+# ---------------------------------------------------------------------------
+# T-08: TestApplyOverlays — REQ-07
+# ---------------------------------------------------------------------------
+
+
+class TestApplyOverlays:
+    """T-08: apply_overlays orchestrates the full ffmpeg call."""
+
+    @pytest.fixture()
+    def mock_video_editor_subprocess(self, mocker):
+        """Patch subprocess.run in the video_editor module."""
+        completed = MagicMock()
+        completed.returncode = 0
+        completed.stdout = ""
+        completed.stderr = ""
+        return mocker.patch(
+            "congress_videos.modules.video_editor.subprocess.run",
+            return_value=completed,
+        )
+
+    @pytest.fixture()
+    def mock_get_source_duration(self, mocker):
+        """Patch _get_source_duration to return a fixed 300.0s duration."""
+        return mocker.patch(
+            "congress_videos.modules.video_editor._get_source_duration",
+            return_value=300.0,
+        )
+
+    def test_success_returns_output_dict(
+        self, mock_video_editor_subprocess, mock_get_source_duration
+    ) -> None:
+        """On returncode=0, apply_overlays must return {output_path, success: True}."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        result = apply_overlays(
+            source_path="/data/in.mp4",
+            output_path="/data/out.mp4",
+            overlays=[_VALID_OVERLAY],
+            domain_cfg=_MINIMAL_DOMAIN_CFG,
+        )
+        assert result["success"] is True
+        assert result["output_path"] == "/data/out.mp4"
+
+    def test_non_zero_exit_raises_runtime_error(
+        self, mock_video_editor_subprocess, mock_get_source_duration
+    ) -> None:
+        """On returncode=1, apply_overlays must raise RuntimeError with stderr text."""
+        mock_video_editor_subprocess.return_value.returncode = 1
+        mock_video_editor_subprocess.return_value.stderr = "error msg from ffmpeg"
+
+        from congress_videos.modules.video_editor import apply_overlays
+
+        with pytest.raises(RuntimeError, match="error msg from ffmpeg"):
+            apply_overlays(
+                source_path="/data/in.mp4",
+                output_path="/data/out.mp4",
+                overlays=[_VALID_OVERLAY],
+                domain_cfg=_MINIMAL_DOMAIN_CFG,
+            )
+
+    def test_tiempo_fin_beyond_duration_emits_warning(
+        self, mock_video_editor_subprocess, mock_get_source_duration, caplog
+    ) -> None:
+        """tiempo_fin > source_duration must emit a warning but must not raise."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        long_overlay = {**_VALID_OVERLAY, "tiempo_fin": 9999.0}
+        with caplog.at_level(logging.WARNING):
+            result = apply_overlays(
+                source_path="/data/in.mp4",
+                output_path="/data/out.mp4",
+                overlays=[long_overlay],
+                domain_cfg=_MINIMAL_DOMAIN_CFG,
+            )
+        # Must not raise; must return success
+        assert result["success"] is True
+        # Warning must have been emitted
+        assert any("9999" in msg or "duration" in msg.lower() for msg in caplog.messages), (
+            f"Expected a warning about tiempo_fin > duration, got: {caplog.messages}"
+        )
+
+    def test_compute_ffmpeg_timeout_called_with_duration(
+        self, mock_video_editor_subprocess, mock_get_source_duration, mocker
+    ) -> None:
+        """compute_ffmpeg_timeout must be called with the source duration."""
+        from congress_videos.modules.video_editor import apply_overlays
+
+        mock_timeout = mocker.patch(
+            "congress_videos.modules.video_editor.compute_ffmpeg_timeout",
+            return_value=999,
+        )
+
+        apply_overlays(
+            source_path="/data/in.mp4",
+            output_path="/data/out.mp4",
+            overlays=[_VALID_OVERLAY],
+            domain_cfg=_MINIMAL_DOMAIN_CFG,
+        )
+        mock_timeout.assert_called_once_with(300.0)

--- a/tests/congress_videos/test_generic_video_editor_dag.py
+++ b/tests/congress_videos/test_generic_video_editor_dag.py
@@ -1,0 +1,265 @@
+"""Tests for congress_videos.generic_video_editor_dag (T-09 — REQ-09).
+
+Strict TDD — all tests are written BEFORE the production DAG file exists.
+First run must produce ImportError failures.
+
+Test groups:
+    TestDagImport           — T-09a DAG imports cleanly
+    TestDagSchedule         — T-09b schedule is None
+    TestDagTaskIds          — T-09c exact task-id set
+    TestDagDependencies     — T-09d task dependency graph shape
+    TestTaskValidateInput   — T-09e _task_validate_input callable behaviour
+    TestTaskEditorResult    — T-09f _task_editor_result XCom shape
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Shared helpers and fixtures
+# ---------------------------------------------------------------------------
+
+_VALID_CONF = {
+    "domain": "congreso",
+    "source_path": "/data/chapter_video.mp4",
+    "overlays": [
+        {
+            "tipo": "extracto_sesion",
+            "tiempo_inicio": 0.0,
+            "tiempo_fin": 5.0,
+            "titulo": "Extracto de sesión",
+        }
+    ],
+}
+
+
+def _get_dag_mod():
+    """Force a fresh import of the DAG module."""
+    mod_name = "congress_videos.generic_video_editor_dag"
+    if mod_name in sys.modules:
+        del sys.modules[mod_name]
+    return importlib.import_module(mod_name)
+
+
+def _make_fake_ti(xcom_map: dict) -> MagicMock:
+    """Return a TaskInstance double whose xcom_pull dispatches by task_ids kwarg."""
+    ti = MagicMock(name="TaskInstance")
+    xcom_store: dict = {}
+
+    def _pull(task_ids=None, key="return_value", **_kw):
+        return xcom_map.get(task_ids)
+
+    def _push(key: str, value, **_kw):
+        xcom_store[key] = value
+
+    ti.xcom_pull.side_effect = _pull
+    ti.xcom_push.side_effect = _push
+    ti.xcom_store = xcom_store
+    return ti
+
+
+# ---------------------------------------------------------------------------
+# T-09a: DAG imports cleanly
+# ---------------------------------------------------------------------------
+
+
+class TestDagImport:
+    """T-09a: The DAG module must import without raising any exception."""
+
+    def test_dag_imports_cleanly(self) -> None:
+        """Importing the DAG module must not raise any exception."""
+        mod = _get_dag_mod()
+        assert mod is not None
+
+
+# ---------------------------------------------------------------------------
+# T-09b: schedule is None
+# ---------------------------------------------------------------------------
+
+
+class TestDagSchedule:
+    """T-09b: The DAG must have schedule=None (trigger-only)."""
+
+    def test_schedule_is_none(self) -> None:
+        """dag.schedule_interval must be None."""
+        mod = _get_dag_mod()
+        dag = mod.dag
+        assert dag.schedule_interval is None
+
+
+# ---------------------------------------------------------------------------
+# T-09c: Exact task-id set
+# ---------------------------------------------------------------------------
+
+_EXPECTED_TASK_IDS = {"validate_input", "apply_overlays", "editor_result"}
+
+
+class TestDagTaskIds:
+    """T-09c: DAG must contain exactly three tasks — no more, no fewer."""
+
+    def test_exact_task_id_set(self) -> None:
+        """Task IDs must be exactly {validate_input, apply_overlays, editor_result}."""
+        mod = _get_dag_mod()
+        dag = mod.dag
+        actual_ids = {task.task_id for task in dag.tasks}
+        assert actual_ids == _EXPECTED_TASK_IDS, (
+            f"Task ID mismatch.\n"
+            f"  Extra:   {actual_ids - _EXPECTED_TASK_IDS}\n"
+            f"  Missing: {_EXPECTED_TASK_IDS - actual_ids}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-09d: Task dependency graph
+# ---------------------------------------------------------------------------
+
+
+class TestDagDependencies:
+    """T-09d: Verify the task dependency chain."""
+
+    def _upstream_ids(self, dag, task_id: str) -> set[str]:
+        task = dag.get_task(task_id)
+        return {t.task_id for t in task.upstream_list}
+
+    def test_apply_overlays_upstream_is_validate_input(self) -> None:
+        """apply_overlays must have validate_input as its upstream task."""
+        mod = _get_dag_mod()
+        assert self._upstream_ids(mod.dag, "apply_overlays") == {"validate_input"}
+
+    def test_editor_result_upstream_is_apply_overlays(self) -> None:
+        """editor_result must have apply_overlays as its upstream task."""
+        mod = _get_dag_mod()
+        assert self._upstream_ids(mod.dag, "editor_result") == {"apply_overlays"}
+
+    def test_validate_input_has_no_upstream(self) -> None:
+        """validate_input must be the entry task with no upstream dependencies."""
+        mod = _get_dag_mod()
+        assert self._upstream_ids(mod.dag, "validate_input") == set()
+
+
+# ---------------------------------------------------------------------------
+# T-09e: _task_validate_input callable behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestTaskValidateInput:
+    """T-09e: _task_validate_input must read dag_run.conf and call validate_editor_input."""
+
+    def test_valid_conf_returns_conf_dict(self, mocker) -> None:
+        """A valid conf must be returned from the task wrapper."""
+        mod = _get_dag_mod()
+        mocker.patch.object(mod, "validate_editor_input")
+
+        dag_run = MagicMock()
+        dag_run.conf = _VALID_CONF.copy()
+
+        result = mod._task_validate_input(dag_run=dag_run)
+        assert result == _VALID_CONF
+
+    def test_calls_validate_editor_input(self, mocker) -> None:
+        """The task wrapper must call validate_editor_input with the conf dict."""
+        mod = _get_dag_mod()
+        mock_validate = mocker.patch.object(mod, "validate_editor_input")
+
+        dag_run = MagicMock()
+        dag_run.conf = _VALID_CONF.copy()
+
+        mod._task_validate_input(dag_run=dag_run)
+        mock_validate.assert_called_once_with(_VALID_CONF)
+
+    def test_empty_conf_defaults_to_empty_dict(self, mocker) -> None:
+        """When dag_run.conf is None, an empty dict is used."""
+        mod = _get_dag_mod()
+        mock_validate = mocker.patch.object(mod, "validate_editor_input")
+
+        dag_run = MagicMock()
+        dag_run.conf = None
+
+        # Should not raise — validate_editor_input handles the error
+        try:
+            mod._task_validate_input(dag_run=dag_run)
+        except Exception:
+            pass  # validate_editor_input may raise; that's fine
+
+        # Must have been called with an empty dict, not None
+        mock_validate.assert_called_once_with({})
+
+
+# ---------------------------------------------------------------------------
+# T-09f: _task_editor_result XCom shape
+# ---------------------------------------------------------------------------
+
+
+class TestTaskEditorResult:
+    """T-09f: _task_editor_result must return the correct result shape via XCom."""
+
+    def test_result_shape_contains_success_output_path_domain(self, mocker) -> None:
+        """The return dict must contain success, output_path, and domain."""
+        mod = _get_dag_mod()
+
+        ti = _make_fake_ti(
+            {
+                "validate_input": _VALID_CONF,
+                "apply_overlays": {"output_path": "/data/out_edited.mp4", "success": True},
+            }
+        )
+
+        result = mod._task_editor_result(ti=ti)
+        assert result["success"] is True
+        assert result["output_path"] == "/data/out_edited.mp4"
+        assert result["domain"] == "congreso"
+
+    def test_result_output_path_matches_apply_overlays(self, mocker) -> None:
+        """output_path in result must come from the apply_overlays XCom."""
+        mod = _get_dag_mod()
+
+        ti = _make_fake_ti(
+            {
+                "validate_input": _VALID_CONF,
+                "apply_overlays": {"output_path": "/custom/path/edited.mp4", "success": True},
+            }
+        )
+
+        result = mod._task_editor_result(ti=ti)
+        assert result["output_path"] == "/custom/path/edited.mp4"
+
+    def test_domain_comes_from_validate_input_xcom(self, mocker) -> None:
+        """domain in result must come from the validate_input XCom conf."""
+        mod = _get_dag_mod()
+
+        conf = {**_VALID_CONF, "domain": "congreso"}
+        ti = _make_fake_ti(
+            {
+                "validate_input": conf,
+                "apply_overlays": {"output_path": "/out.mp4", "success": True},
+            }
+        )
+
+        result = mod._task_editor_result(ti=ti)
+        assert result["domain"] == "congreso"
+
+
+# ---------------------------------------------------------------------------
+# T-09g: _REQUIRED_CONF_KEYS module-level constant
+# ---------------------------------------------------------------------------
+
+
+class TestRequiredConfKeys:
+    """T-09g: _REQUIRED_CONF_KEYS must expose the expected keys at module level."""
+
+    def test_required_conf_keys_contains_domain_and_overlays(self) -> None:
+        """_REQUIRED_CONF_KEYS must include 'domain' and 'overlays'."""
+        mod = _get_dag_mod()
+        assert "domain" in mod._REQUIRED_CONF_KEYS
+        assert "overlays" in mod._REQUIRED_CONF_KEYS
+
+    def test_required_conf_keys_is_tuple_or_sequence(self) -> None:
+        """_REQUIRED_CONF_KEYS must be a tuple or other sequence."""
+        mod = _get_dag_mod()
+        assert hasattr(mod._REQUIRED_CONF_KEYS, "__iter__")


### PR DESCRIPTION
## Contexto
Implementa el issue #34 (parte del epic #16) vía flujo SDD. DAG genérico on-demand para insertar rótulos (texto en pantalla estático) en un vídeo antes de subirlo a YouTube, encadenable con `generic_youtube_uploader`.

## Decisión de scope
El issue mencionaba config "por YAML", pero se optó por **dict de Python** (`video_editor_config.py` con `get_domain_config`), siguiendo la convención existente del repo (`thumbnail_config.py`). Cero deps nuevas, patrón ya testeado. Migrar a YAML queda como posible follow-up.

## Cambios
- `congress_videos/config/video_editor_config.py` — config de estilo por dominio (dict Python), `get_domain_config` + `ConfigError`.
- `congress_videos/modules/video_editor.py` — builders puros (`_escape_drawtext`, `_parse_time`, `build_drawtext_filter`, `build_ffmpeg_drawtext_cmd`, `_resolve_source_path`, `_default_output_path`, `validate_editor_input`) + orquestador `apply_overlays` (reutiliza `compute_ffmpeg_timeout`).
- `congress_videos/generic_video_editor_dag.py` — DAG de 3 tareas `validate_input` → `apply_overlays` → `editor_result`, `schedule=None`, path de salida vía XCom `return_value`. Espeja `generic_thumbnail_generator_dag.py`.

Motor de render: ffmpeg `drawtext` con `enable='between(t,inicio,fin)'` para tiempos. Escape de drawtext cubre caracteres españoles (tildes, ñ) y metacaracteres (`: ' \ %`).

## Criterios de aceptación
- [x] DAG recibe vídeo + lista de rótulos (tipo + tiempos + título/descripción) y produce vídeo editado en disco.
- [x] Rótulo simple se renderiza al inicio; tiempos de aparición/desaparición respetados.
- [x] Estilo por dominio, no hardcodeado.
- [x] Path resultante expuesto vía XCom para encadenar con la subida a YouTube.

## Test plan
- [x] 64 tests nuevos cubriendo los 26 escenarios del spec.
- [x] Suite completa: 1679 passed, 1 skipped, coverage 85.67% (gate 80%).
- [x] e2e Docker smoke (`scripts/test-airflow-e2e.sh`): exit 0, sin import errors.

## Nota de tamaño
size:exception — 1585 líneas (676 código / 909 tests). Feature cohesiva; la mayoría son tests.

Closes #34