### PR TITLE
feat(thumbnail): diversify titles and thumbnails across recent videos

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -141,15 +141,30 @@ ART_DIRECTION_SYSTEM_PROMPT = (
     "Eres un director de arte experto en miniaturas de YouTube de alto CTR para canales políticos españoles. "
     "Tu tarea es crear un brief visual en JSON para una miniatura siguiendo estas reglas estrictas:\n\n"
     "- text: frase de 3-6 palabras, TODO EN MAYÚSCULAS, máximo 40 caracteres. Provocadora, no descriptiva.\n"
-    "- background: fondo contextual al tema (protesta callejera, fábrica cerrada, hospital, etc.). "
+    "- background: fondo contextual al tema (mercado en crisis, hospital desbordado, fábrica cerrada, "
+    "calle vacía al atardecer, etc.). "
     "NUNCA hemiciclo, cámara parlamentaria ni sala de gobierno.\n"
     "- person: persona relatable, edad/expresión/ropa concreta. Ocupa el 35-40%% del frame. "
     "Expresión emocional (indignación, miedo, sorpresa). Que cualquier ciudadano español se vea reflejado.\n"
-    "- mood: tono emocional dominante (indignación, amenaza, curiosidad, identidad, pérdida).\n\n"
+    "- mood: tono emocional dominante (curiosidad, pérdida, amenaza, indignación, identidad).\n\n"
+    "Cada brief debe ser visualmente DISTINTO al anterior: evita repetir fondos, tipos de persona o "
+    "emociones en briefs consecutivos.\n\n"
     "PROHIBICIÓN ABSOLUTA: no incluyas nunca URLs ni la palabra 'http' en ningún campo. "
     "Pikzels rechaza cualquier prompt que contenga 'http'.\n\n"
     "Responde SOLO con JSON válido, sin markdown:\n"
     '{"text": "...", "background": "...", "person": "...", "mood": "..."}'
+)
+
+# Sibling-brief injection block: appended to the art_direct user prompt when
+# recent chosen briefs are available to steer the model away from repetition.
+ART_DIRECTION_SIBLING_INSTRUCTION = (
+    "NO REPITAS estos enfoques recientes (varía fondo, persona, mood y texto):\n{sibling_list}"
+)
+
+# Sibling-titles injection block: appended to the generate_title user prompt when
+# recent chosen titles are available to prevent emotional/tonal repetition.
+THUMBNAIL_TITLE_SIBLING_INSTRUCTION = (
+    "NO REPITAS el enfoque de estos títulos recientes:\n{sibling_list}"
 )
 
 ART_DIRECTION_USER_PROMPT_TEMPLATE = (
@@ -173,6 +188,8 @@ THUMBNAIL_TITLE_SYSTEM_PROMPT = (
     "Eres un redactor político experto en titulares de alto impacto para YouTube. "
     "Creas títulos dramáticos, directos y en español que capturan la esencia del debate parlamentario. "
     "Los títulos deben generar urgencia y curiosidad sin perder rigor informativo. "
+    "Varía el registro emocional entre títulos consecutivos: alterna entre urgencia, pérdida, "
+    "amenaza, curiosidad e identidad para evitar la monotonía tonal. "
     "RESTRICCIONES ABSOLUTAS: máximo 90 caracteres; sin emojis; sin comillas; "
     "sin símbolos de canal; sin hashtags; sin los caracteres: # @ | ~ ^. "
     "Usa mayúsculas y minúsculas normales (capitalización estándar en español): "

--- a/congress_videos/generic_thumbnail_generator_dag.py
+++ b/congress_videos/generic_thumbnail_generator_dag.py
@@ -49,6 +49,7 @@ from congress_videos.modules import pikzels_client as _pkz
 from congress_videos.modules.thumbnail_generation import (
     art_direct,
     choose_best_option,
+    fetch_recent_thumbnail_history,
     generate_title,
     persist_results,
     resolve_participant_photo,
@@ -116,11 +117,29 @@ def _task_resolve_photo(ti: TaskInstance, **context: object) -> dict:
     return resolve_participant_photo(conf.get("slug"), domain_cfg)
 
 
+def _task_fetch_recent_history(ti: TaskInstance, **context: object) -> dict:
+    """Fetch the most recent chosen thumbnail briefs and titles (GLOBAL scope).
+
+    Calls fetch_recent_thumbnail_history which never raises — on DB error
+    or empty result it returns ([], []). Pushes via XCom return value.
+
+    Returns:
+        Dict with 'briefs' (list[str]) and 'titles' (list[str]).
+    """
+    briefs, titles = fetch_recent_thumbnail_history()
+    return {"briefs": briefs, "titles": titles}
+
+
 def _task_art_direction(ti: TaskInstance, **context: object) -> dict:
     """Generate the art-direction brief shared by both thumbnail options."""
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
+    history: dict = ti.xcom_pull(task_ids="fetch_recent_history") or {}
     domain_cfg = get_domain_config(conf["domain"])
-    return art_direct(conf["debate_summary"], domain_cfg)
+    return art_direct(
+        conf["debate_summary"],
+        domain_cfg,
+        sibling_briefs=history.get("briefs") or None,
+    )
 
 
 def _task_generate_thumbnail(label: str, ti: TaskInstance, **context: object) -> dict:
@@ -212,8 +231,14 @@ def _task_generate_title(ti: TaskInstance, **context: object) -> str:
     """Generate a YouTube title for the chosen thumbnail option."""
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
     best: dict = ti.xcom_pull(task_ids="choose_best_option") or {}
+    history: dict = ti.xcom_pull(task_ids="fetch_recent_history") or {}
     domain_cfg = get_domain_config(conf["domain"])
-    return generate_title(conf["debate_summary"], best, domain_cfg)
+    return generate_title(
+        conf["debate_summary"],
+        best,
+        domain_cfg,
+        sibling_titles=history.get("titles") or None,
+    )
 
 
 def _task_persist_results(ti: TaskInstance, **context: object) -> None:
@@ -271,11 +296,18 @@ def _task_art_direction_retry(ti: TaskInstance, **context: object) -> dict:
 
     Pulls the original brief from task_ids='art_direction' and passes it as
     previous_brief so art_direct injects the retry instruction.
+    Also passes sibling_briefs from fetch_recent_history to steer diversity.
     """
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
     previous_brief: dict = ti.xcom_pull(task_ids="art_direction") or {}
+    history: dict = ti.xcom_pull(task_ids="fetch_recent_history") or {}
     domain_cfg = get_domain_config(conf["domain"])
-    return art_direct(conf["debate_summary"], domain_cfg, previous_brief=previous_brief)
+    return art_direct(
+        conf["debate_summary"],
+        domain_cfg,
+        previous_brief=previous_brief,
+        sibling_briefs=history.get("briefs") or None,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -315,6 +347,11 @@ with DAG(
     t_resolve_photo = PythonOperator(
         task_id="resolve_participant_photo",
         python_callable=_task_resolve_photo,
+    )
+
+    t_fetch_recent_history = PythonOperator(
+        task_id="fetch_recent_history",
+        python_callable=_task_fetch_recent_history,
     )
 
     t_art_direction = PythonOperator(
@@ -388,16 +425,24 @@ with DAG(
     )
 
     # Task dependency graph:
-    #   validate_input → resolve_participant_photo → art_direction
+    #   validate_input → resolve_participant_photo ──────────────────────┐
+    #   validate_input → fetch_recent_history ──────────────────────────┤
+    #                                                                    ↓
+    #                                                              art_direction
     #     → generate_thumbnail_option_a → download_option_a → score_option_a
     #       → check_score_threshold [BranchPythonOperator]
-    #           ├─[score < threshold]→ art_direction_retry
+    #           ├─[score < threshold]→ art_direction_retry (also fed by fetch_recent_history)
     #           │                        → generate_thumbnail_option_b → download_option_b → score_option_b ─┐
     #           └─[score >= threshold]──────────────────────────────────────────────────────────────────────┤
     #                                  → choose_best_option (trigger_rule=none_failed_min_one_success) ◄────┘
-    #                                    → generate_title → persist_results → thumbnail_result
-    t_validate >> t_resolve_photo >> t_art_direction
+    #                                    → generate_title (also fed by fetch_recent_history)
+    #                                      → persist_results → thumbnail_result
+    t_validate >> t_resolve_photo
+    t_validate >> t_fetch_recent_history
+    [t_resolve_photo, t_fetch_recent_history] >> t_art_direction
     t_art_direction >> t_gen_a >> t_dl_a >> t_score_a >> t_check_score
     t_check_score >> t_art_direction_retry >> t_gen_b >> t_dl_b >> t_score_b >> t_choose
     t_check_score >> t_choose
+    t_fetch_recent_history >> t_art_direction_retry
+    t_fetch_recent_history >> t_title
     t_choose >> t_title >> t_persist >> t_result

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -389,11 +389,14 @@ def generate_title(
 
 
 def _summarise_sibling_brief(brief: str) -> str:
-    """Extract key visual axes from a stored Pikzels prompt and cap to 200 chars.
+    """Extract the key visual axes from a stored Pikzels prompt, cap at 200 chars.
 
-    Looks for lines starting with ``background``, ``person``, ``mood``, or
-    ``text`` (case-insensitive) and joins them into a compact summary.
-    If no such lines are found, falls back to raw truncation at 200 chars.
+    The stored ``video_thumbnails.prompt`` is the *rendered* Pikzels template,
+    whose axis lines look like ``BACKGROUND: ...``, ``SUBJECT (RIGHT HALF): ...``,
+    ``TEXT (LEFT HALF, ...): ... '<phrase>'`` and ``Overall mood: ...``. This
+    normalises each recognised axis to ``label: value`` and joins them. The
+    synthetic ``person:``/``mood:`` prefixes are also accepted for robustness.
+    When no axis line is recognised, falls back to raw truncation at 200 chars.
 
     Args:
         brief: Full Pikzels prompt string stored in ``video_thumbnails.prompt``.
@@ -401,16 +404,34 @@ def _summarise_sibling_brief(brief: str) -> str:
     Returns:
         A short string of at most 200 characters summarising the visual axes.
     """
-    _FIELD_PREFIXES = ("background", "person", "mood", "text")
-    lines = brief.splitlines()
-    extracted = [
-        line.strip()
-        for line in lines
-        if line.strip().lower().startswith(_FIELD_PREFIXES)
-    ]
-    if extracted:
-        summary = " | ".join(extracted)
-        return summary[:200]
+    # Normalised axis label -> line-prefix(es) as they appear in the rendered
+    # Pikzels template (and the synthetic field name, for tolerance).
+    _AXIS_PREFIXES: tuple[tuple[str, tuple[str, ...]], ...] = (
+        ("background", ("background",)),
+        ("person", ("subject", "person")),
+        ("mood", ("overall mood", "mood")),
+        ("text", ("text",)),
+    )
+    parts: list[str] = []
+    for raw_line in brief.splitlines():
+        line = raw_line.strip()
+        low = line.lower()
+        for label, prefixes in _AXIS_PREFIXES:
+            if not low.startswith(prefixes):
+                continue
+            value = line.split(":", 1)[1].strip() if ":" in line else line
+            if label == "text":
+                # Prefer the quoted phrase; drop the font/styling boilerplate.
+                match = re.search(r"['\"]([^'\"]+)['\"]", value)
+                if match:
+                    value = match.group(1)
+            elif label == "person":
+                # Drop the fixed "Face fills…/Looks…" boilerplate tail.
+                value = value.split(". Face fills")[0].strip()
+            parts.append(f"{label}: {value}")
+            break
+    if parts:
+        return " | ".join(parts)[:200]
     return brief[:200]
 
 

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -24,8 +24,10 @@ import requests
 
 from congress_videos.config.ai_prompts import (
     ART_DIRECTION_RETRY_INSTRUCTION,
+    ART_DIRECTION_SIBLING_INSTRUCTION,
     ART_DIRECTION_SYSTEM_PROMPT,
     ART_DIRECTION_USER_PROMPT_TEMPLATE,
+    THUMBNAIL_TITLE_SIBLING_INSTRUCTION,
     THUMBNAIL_TITLE_SYSTEM_PROMPT,
     THUMBNAIL_TITLE_USER_PROMPT_TEMPLATE,
 )
@@ -82,6 +84,7 @@ def art_direct(
     debate_summary: str,
     domain_cfg: dict,
     previous_brief: dict | None = None,
+    sibling_briefs: list[str] | None = None,
 ) -> dict:
     """Generate an art-direction brief for a Pikzels thumbnail via OpenAI.
 
@@ -95,6 +98,9 @@ def art_direct(
         previous_brief: When set, injects ART_DIRECTION_RETRY_INSTRUCTION
             into the prompt to force a DIFFERENT visual approach. Used by
             the art_direction_retry DAG task. None means first generation.
+        sibling_briefs: When non-empty, injects a "NO REPITAS" block listing
+            recent chosen briefs to steer the model away from repetition.
+            None or empty list → prompt unchanged (backward compatible).
     """
     import json
 
@@ -107,6 +113,12 @@ def art_direct(
                 previous_brief_json=json.dumps(previous_brief, ensure_ascii=False)
             )
             user_prompt += f"\n\n{retry_instruction}"
+        if sibling_briefs:
+            sibling_list = "\n".join(f"- {b}" for b in sibling_briefs)
+            sibling_block = ART_DIRECTION_SIBLING_INSTRUCTION.format(
+                sibling_list=sibling_list
+            )
+            user_prompt += f"\n\n{sibling_block}"
         if extra_instruction:
             user_prompt += f"\n\nINSTRUCCIÓN ADICIONAL: {extra_instruction}"
         try:
@@ -115,6 +127,7 @@ def art_direct(
                 user_prompt=user_prompt,
                 model="gpt-4o-mini",
                 max_tokens=400,
+                temperature=0.7,
             )
         except Exception as exc:
             logger.warning("art_direct: generate_json_completion raised: %s", exc)
@@ -251,7 +264,12 @@ def choose_best_option(options: list[dict]) -> dict:
     return {**best, "is_chosen": True}
 
 
-def generate_title(summary: str, best: dict, cfg: dict) -> str:
+def generate_title(
+    summary: str,
+    best: dict,
+    cfg: dict,
+    sibling_titles: list[str] | None = None,
+) -> str:
     """Generate a YouTube title for the chosen thumbnail option via OpenAI.
 
     Validates the returned title against constraints (≤90 chars, no emojis,
@@ -263,6 +281,9 @@ def generate_title(summary: str, best: dict, cfg: dict) -> str:
         summary: Debate summary text used to contextualise the title.
         best: The chosen option dict (must contain ``style`` and ``prompt``).
         cfg: Per-domain config dict (currently unused but kept for future extensibility).
+        sibling_titles: When non-empty, injects a "NO REPITAS" block listing
+            recent chosen titles to prevent tonal repetition.
+            None or empty list → prompt unchanged (backward compatible).
 
     Returns:
         A YouTube title string (≤90 chars, no emojis, no forbidden chars).
@@ -306,6 +327,12 @@ def generate_title(summary: str, best: dict, cfg: dict) -> str:
             style=style_text,
             prompt=prompt_text,
         )
+        if sibling_titles:
+            sibling_list = "\n".join(f"- {t}" for t in sibling_titles)
+            sibling_block = THUMBNAIL_TITLE_SIBLING_INSTRUCTION.format(
+                sibling_list=sibling_list
+            )
+            user_prompt += f"\n\n{sibling_block}"
         if extra_instruction:
             user_prompt += f"\n\nINSTRUCCIÓN ADICIONAL: {extra_instruction}"
 
@@ -314,6 +341,7 @@ def generate_title(summary: str, best: dict, cfg: dict) -> str:
             user_prompt=user_prompt,
             model="gpt-4o-mini",
             max_tokens=120,
+            temperature=0.7,
         )
         if result.get("error"):
             logger.warning("generate_title: OpenAI error: %s", result["error"])
@@ -358,6 +386,77 @@ def generate_title(summary: str, best: dict, cfg: dict) -> str:
         candidate,
     )
     return sanitised
+
+
+def _summarise_sibling_brief(brief: str) -> str:
+    """Extract key visual axes from a stored Pikzels prompt and cap to 200 chars.
+
+    Looks for lines starting with ``background``, ``person``, ``mood``, or
+    ``text`` (case-insensitive) and joins them into a compact summary.
+    If no such lines are found, falls back to raw truncation at 200 chars.
+
+    Args:
+        brief: Full Pikzels prompt string stored in ``video_thumbnails.prompt``.
+
+    Returns:
+        A short string of at most 200 characters summarising the visual axes.
+    """
+    _FIELD_PREFIXES = ("background", "person", "mood", "text")
+    lines = brief.splitlines()
+    extracted = [
+        line.strip()
+        for line in lines
+        if line.strip().lower().startswith(_FIELD_PREFIXES)
+    ]
+    if extracted:
+        summary = " | ".join(extracted)
+        return summary[:200]
+    return brief[:200]
+
+
+def fetch_recent_thumbnail_history(
+    limit: int = 5,
+) -> tuple[list[str], list[str]]:
+    """Return the most recent chosen thumbnail briefs and titles, GLOBAL scope.
+
+    Queries ``video_thumbnails`` for the last ``limit`` rows where
+    ``is_chosen = TRUE``, ordered by ``chapter_id DESC``. Returns two parallel
+    lists: summarised brief strings and non-null title strings.
+
+    MUST NEVER RAISE: on any exception or empty result, returns ``([], [])``
+    and logs a WARNING.
+
+    Args:
+        limit: Maximum number of history rows to fetch (default 5).
+
+    Returns:
+        Tuple of (briefs, titles). briefs uses ``_summarise_sibling_brief``
+        on each stored prompt. titles excludes NULL/empty openai_title values.
+    """
+    try:
+        pg = PostgresConnection()
+        table = pg.get_qualified_table("video_thumbnails")
+        sql = (
+            f"SELECT prompt, openai_title FROM {table} "
+            f"WHERE is_chosen = TRUE ORDER BY chapter_id DESC LIMIT %s"
+        )
+        with pg.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(sql, (limit,))
+                rows = cur.fetchall()
+
+        if not rows:
+            return [], []
+
+        briefs = [_summarise_sibling_brief(row[0] or "") for row in rows]
+        titles = [row[1] for row in rows if row[1]]
+        return briefs, titles
+
+    except Exception as exc:
+        logger.warning(
+            "fetch_recent_thumbnail_history: failed to load history — %s", exc
+        )
+        return [], []
 
 
 def persist_results(

--- a/tests/congress_videos/modules/test_generic_thumbnail_dag.py
+++ b/tests/congress_videos/modules/test_generic_thumbnail_dag.py
@@ -100,6 +100,7 @@ class TestDagSchedule:
 EXPECTED_TASK_IDS = {
     "validate_input",
     "resolve_participant_photo",
+    "fetch_recent_history",
     "art_direction",
     "generate_thumbnail_option_a",
     "download_option_a",
@@ -119,14 +120,18 @@ EXPECTED_TASK_IDS = {
 def test_art_direction_task_delegates_to_art_direct(mocker) -> None:
     """The DAG task wrapper supplies its run context to art_direct."""
     dag_mod = importlib.import_module("congress_videos.generic_thumbnail_generator_dag")
-    ti = _make_fake_ti({"validate_input": _FAKE_CONF})
+    ti = _make_fake_ti({"validate_input": _FAKE_CONF, "fetch_recent_history": None})
     domain_cfg = {"styles": []}
 
     mocker.patch.object(dag_mod, "get_domain_config", return_value=domain_cfg)
     art_direct = mocker.patch.object(dag_mod, "art_direct", return_value={"text": "BRIEF"})
 
     assert dag_mod._task_art_direction(ti) == {"text": "BRIEF"}
-    art_direct.assert_called_once_with(_FAKE_CONF["debate_summary"], domain_cfg)
+    art_direct.assert_called_once_with(
+        _FAKE_CONF["debate_summary"],
+        domain_cfg,
+        sibling_briefs=None,
+    )
 
 
 class TestDagTaskIds:
@@ -170,8 +175,11 @@ class TestDagDependencies:
     def test_resolve_participant_photo_upstream_is_validate_input(self) -> None:
         assert self._upstream_ids("resolve_participant_photo") == {"validate_input"}
 
-    def test_art_direction_upstream_is_resolve_participant_photo(self) -> None:
-        assert self._upstream_ids("art_direction") == {"resolve_participant_photo"}
+    def test_art_direction_upstream_is_resolve_participant_photo_and_fetch_history(self) -> None:
+        assert self._upstream_ids("art_direction") == {
+            "resolve_participant_photo",
+            "fetch_recent_history",
+        }
 
     def test_generate_thumbnail_option_a_upstream_is_art_direction(self) -> None:
         assert self._upstream_ids("generate_thumbnail_option_a") == {"art_direction"}
@@ -194,14 +202,20 @@ class TestDagDependencies:
     def test_check_score_threshold_upstream_is_score_option_a(self) -> None:
         assert self._upstream_ids("check_score_threshold") == {"score_option_a"}
 
-    def test_art_direction_retry_upstream_is_check_score_threshold(self) -> None:
-        assert self._upstream_ids("art_direction_retry") == {"check_score_threshold"}
+    def test_art_direction_retry_upstream_is_check_score_threshold_and_fetch_history(self) -> None:
+        assert self._upstream_ids("art_direction_retry") == {
+            "check_score_threshold",
+            "fetch_recent_history",
+        }
 
     def test_choose_best_option_upstream_is_check_score_threshold_and_score_option_b(self) -> None:
         assert self._upstream_ids("choose_best_option") == {"check_score_threshold", "score_option_b"}
 
-    def test_generate_title_upstream_is_choose_best_option(self) -> None:
-        assert self._upstream_ids("generate_title") == {"choose_best_option"}
+    def test_generate_title_upstream_is_choose_best_option_and_fetch_history(self) -> None:
+        assert self._upstream_ids("generate_title") == {
+            "choose_best_option",
+            "fetch_recent_history",
+        }
 
     def test_persist_results_upstream_is_generate_title(self) -> None:
         assert self._upstream_ids("persist_results") == {"generate_title"}
@@ -972,3 +986,121 @@ class TestTaskPersistResultsEmptyFilter:
         assert options_list is not None, "persist_results must be called with options argument"
         assert len(options_list) == 1, f"persist_results options must have 1 item, got {len(options_list)}"
         assert options_list[0]["label"] == "option_a"
+
+
+# ---------------------------------------------------------------------------
+# Phase 6: fetch_recent_history DAG task wiring
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRecentHistoryDagTask:
+    """Phase 6: DAG must include fetch_recent_history as a root pre-task wired to
+    art_direction, art_direction_retry, and generate_title.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _dag_mod(self) -> None:
+        if "congress_videos.generic_thumbnail_generator_dag" in sys.modules:
+            del sys.modules["congress_videos.generic_thumbnail_generator_dag"]
+        self.mod = importlib.import_module("congress_videos.generic_thumbnail_generator_dag")
+        self.dag = self.mod.dag
+
+    def _upstream_ids(self, task_id: str) -> set[str]:
+        task = self.dag.get_task(task_id)
+        return {t.task_id for t in task.upstream_list}
+
+    def test_dag_has_fetch_recent_history_task(self) -> None:
+        """DAG must contain a task with task_id='fetch_recent_history'."""
+        task_ids = {task.task_id for task in self.dag.tasks}
+        assert "fetch_recent_history" in task_ids, (
+            f"DAG must have 'fetch_recent_history' task, got: {task_ids}"
+        )
+
+    def test_fetch_recent_history_is_upstream_of_art_direction(self) -> None:
+        """fetch_recent_history must be in the upstream set of art_direction."""
+        upstream = self._upstream_ids("art_direction")
+        assert "fetch_recent_history" in upstream, (
+            f"art_direction upstream must include 'fetch_recent_history', got: {upstream}"
+        )
+
+    def test_fetch_recent_history_is_upstream_of_art_direction_retry(self) -> None:
+        """fetch_recent_history must be in the upstream set of art_direction_retry."""
+        upstream = self._upstream_ids("art_direction_retry")
+        assert "fetch_recent_history" in upstream, (
+            f"art_direction_retry upstream must include 'fetch_recent_history', got: {upstream}"
+        )
+
+    def test_fetch_recent_history_is_upstream_of_generate_title(self) -> None:
+        """fetch_recent_history must be in the upstream set of generate_title."""
+        upstream = self._upstream_ids("generate_title")
+        assert "fetch_recent_history" in upstream, (
+            f"generate_title upstream must include 'fetch_recent_history', got: {upstream}"
+        )
+
+    def test_fetch_recent_history_callable_returns_briefs_and_titles(self, mocker) -> None:
+        """_task_fetch_recent_history must call fetch_recent_thumbnail_history and
+        push {briefs: [...], titles: [...]} via XCom return value."""
+        dag_mod = self.mod
+
+        mocker.patch.object(
+            dag_mod,
+            "fetch_recent_thumbnail_history",
+            return_value=(["brief A", "brief B"], ["Title A"]),
+        )
+
+        ti = MagicMock(name="TaskInstance")
+        result = dag_mod._task_fetch_recent_history(ti)
+
+        assert result == {"briefs": ["brief A", "brief B"], "titles": ["Title A"]}, (
+            f"_task_fetch_recent_history must return {{briefs: [...], titles: [...]}}, got: {result}"
+        )
+
+    def test_task_art_direction_passes_sibling_briefs(self, mocker) -> None:
+        """_task_art_direction must pull fetch_recent_history XCom and pass sibling_briefs."""
+        dag_mod = self.mod
+
+        history_data = {"briefs": ["brief A sobre mercado"], "titles": ["Title A"]}
+        ti = _make_fake_ti(
+            {
+                "validate_input": _FAKE_CONF,
+                "fetch_recent_history": history_data,
+            }
+        )
+
+        mocker.patch.object(dag_mod, "get_domain_config", return_value=_FAKE_DOMAIN_CFG)
+        mock_art_direct = mocker.patch.object(dag_mod, "art_direct", return_value=_FAKE_ART_BRIEF)
+
+        dag_mod._task_art_direction(ti)
+
+        mock_art_direct.assert_called_once()
+        _, kwargs = mock_art_direct.call_args
+        assert "sibling_briefs" in kwargs, (
+            "_task_art_direction must pass sibling_briefs= to art_direct"
+        )
+        assert kwargs["sibling_briefs"] == ["brief A sobre mercado"]
+
+    def test_task_generate_title_passes_sibling_titles(self, mocker) -> None:
+        """_task_generate_title must pull fetch_recent_history XCom and pass sibling_titles."""
+        dag_mod = self.mod
+
+        history_data = {"briefs": ["brief A"], "titles": ["Title X", "Title Y"]}
+        best = {"style": "A", "prompt": "mercado", "label": "option_a", "main_score": 77.0}
+        ti = _make_fake_ti(
+            {
+                "validate_input": _FAKE_CONF,
+                "choose_best_option": best,
+                "fetch_recent_history": history_data,
+            }
+        )
+
+        mocker.patch.object(dag_mod, "get_domain_config", return_value=_FAKE_DOMAIN_CFG)
+        mock_generate_title = mocker.patch.object(dag_mod, "generate_title", return_value="Un título")
+
+        dag_mod._task_generate_title(ti)
+
+        mock_generate_title.assert_called_once()
+        _, kwargs = mock_generate_title.call_args
+        assert "sibling_titles" in kwargs, (
+            "_task_generate_title must pass sibling_titles= to generate_title"
+        )
+        assert kwargs["sibling_titles"] == ["Title X", "Title Y"]

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -997,3 +997,478 @@ class TestScoreRetryThreshold:
         # This test uses a synthetic config dict to confirm the fallback works.
         cfg_without_threshold = {}
         assert cfg_without_threshold.get("score_retry_threshold", 60) == 60
+
+
+# ---------------------------------------------------------------------------
+# Phase 1: Prompt Constants — diversity / de-anchoring
+# ---------------------------------------------------------------------------
+
+
+class TestArtDirectionPromptDiversity:
+    """Phase 1: ART_DIRECTION_SYSTEM_PROMPT must not anchor on specific moods/backgrounds."""
+
+    def test_art_direction_prompt_mood_not_anchored_on_indignacion(self) -> None:
+        """Mood list MUST NOT start with 'indignación' as the first entry."""
+        from congress_videos.config.ai_prompts import ART_DIRECTION_SYSTEM_PROMPT
+
+        # Find the mood line — look for a parenthetical list after "mood:"
+        # The constraint: indignación must not be the FIRST item in the mood list
+        prompt_lower = ART_DIRECTION_SYSTEM_PROMPT.lower()
+        # Find the mood field description section
+        mood_idx = prompt_lower.find("mood:")
+        assert mood_idx != -1, "ART_DIRECTION_SYSTEM_PROMPT must contain 'mood:' field"
+        # Get the text after "mood:" up to end of that sentence/parenthetical
+        after_mood = ART_DIRECTION_SYSTEM_PROMPT[mood_idx:]
+        # Extract the parenthetical list content (between parentheses)
+        paren_start = after_mood.find("(")
+        paren_end = after_mood.find(")")
+        assert paren_start != -1, "mood field must have a parenthetical list"
+        mood_list_text = after_mood[paren_start + 1:paren_end]
+        first_mood = mood_list_text.split(",")[0].strip().lower()
+        assert first_mood != "indignación", (
+            f"Mood list MUST NOT start with 'indignación'; first entry is {first_mood!r}"
+        )
+
+    def test_art_direction_prompt_background_not_anchored_on_protesta(self) -> None:
+        """Background parenthetical MUST NOT start with 'protesta callejera'."""
+        from congress_videos.config.ai_prompts import ART_DIRECTION_SYSTEM_PROMPT
+
+        prompt_lower = ART_DIRECTION_SYSTEM_PROMPT.lower()
+        background_idx = prompt_lower.find("background:")
+        assert background_idx != -1, "ART_DIRECTION_SYSTEM_PROMPT must contain 'background:' field"
+        after_background = ART_DIRECTION_SYSTEM_PROMPT[background_idx:]
+        paren_start = after_background.find("(")
+        paren_end = after_background.find(")")
+        assert paren_start != -1, "background field must have a parenthetical example list"
+        bg_list_text = after_background[paren_start + 1:paren_end]
+        first_bg = bg_list_text.split(",")[0].strip().lower()
+        assert "protesta callejera" not in first_bg, (
+            f"Background parenthetical MUST NOT start with 'protesta callejera'; first entry is {first_bg!r}"
+        )
+
+    def test_art_direction_prompt_contains_variety_instruction(self) -> None:
+        """ART_DIRECTION_SYSTEM_PROMPT MUST contain an explicit visual-variety instruction."""
+        from congress_videos.config.ai_prompts import ART_DIRECTION_SYSTEM_PROMPT
+
+        assert "DISTINTO" in ART_DIRECTION_SYSTEM_PROMPT, (
+            "ART_DIRECTION_SYSTEM_PROMPT must contain 'DISTINTO' (visual variety instruction)"
+        )
+
+    def test_title_prompt_contains_variety_note(self) -> None:
+        """THUMBNAIL_TITLE_SYSTEM_PROMPT MUST contain a variety note about emotional register."""
+        from congress_videos.config.ai_prompts import THUMBNAIL_TITLE_SYSTEM_PROMPT
+
+        prompt_lower = THUMBNAIL_TITLE_SYSTEM_PROMPT.lower()
+        has_variety = (
+            "varía" in prompt_lower
+            or "varia" in prompt_lower
+            or "varied" in prompt_lower
+            or "distinto" in prompt_lower
+            or "registr" in prompt_lower
+        )
+        assert has_variety, (
+            "THUMBNAIL_TITLE_SYSTEM_PROMPT must contain a variety note about emotional register"
+        )
+
+    def test_art_direction_prompt_http_prohibition_intact(self) -> None:
+        """The http prohibition MUST still be present after the rewrite."""
+        from congress_videos.config.ai_prompts import ART_DIRECTION_SYSTEM_PROMPT
+
+        assert "http" in ART_DIRECTION_SYSTEM_PROMPT.lower(), (
+            "ART_DIRECTION_SYSTEM_PROMPT must still contain the http prohibition"
+        )
+
+    def test_art_direction_prompt_json_only_rule_intact(self) -> None:
+        """The JSON-only response rule MUST still be present after the rewrite."""
+        from congress_videos.config.ai_prompts import ART_DIRECTION_SYSTEM_PROMPT
+
+        assert "JSON" in ART_DIRECTION_SYSTEM_PROMPT, (
+            "ART_DIRECTION_SYSTEM_PROMPT must still contain the JSON-only rule"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 2: Temperature Tuning
+# ---------------------------------------------------------------------------
+
+
+class TestTemperatureTuning:
+    """Phase 2: art_direct and generate_title must pass temperature=0.7."""
+
+    def _make_cfg(self) -> dict:
+        return {
+            "styles": [
+                {"label": "option_a", "layout": "A"},
+                {"label": "option_b", "layout": "B"},
+            ],
+            "participants_lookup": lambda slug: None,
+            "party_logo_map": None,
+        }
+
+    def _valid_brief_response(self) -> dict:
+        return {
+            "data": {
+                "text": "CRISIS TOTAL",
+                "background": "mercado en crisis, gente preocupada",
+                "person": "ciudadano de mediana edad, expresión tensa",
+                "mood": "amenaza",
+            },
+            "error": None,
+        }
+
+    def test_art_direct_passes_temperature_07(self, mocker) -> None:
+        """art_direct must call generate_json_completion with temperature=0.7."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        captured_kwargs: list[dict] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_kwargs.append(kw)
+            return self._valid_brief_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        art_direct("Un debate sobre pensiones", self._make_cfg())
+
+        assert captured_kwargs, "generate_json_completion must be called at least once"
+        assert captured_kwargs[0].get("temperature") == 0.7, (
+            f"art_direct must pass temperature=0.7, got {captured_kwargs[0].get('temperature')!r}"
+        )
+
+    def test_generate_title_passes_temperature_07(self, mocker) -> None:
+        """generate_title must call generate_json_completion with temperature=0.7."""
+        from congress_videos.modules.thumbnail_generation import generate_title
+
+        captured_kwargs: list[dict] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_kwargs.append(kw)
+            return {"data": {"title": "Un título válido de longitud normal"}, "error": None}
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        best = {"style": "A", "prompt": "mercado en crisis"}
+        generate_title("debate summary", best, self._make_cfg())
+
+        assert captured_kwargs, "generate_json_completion must be called at least once"
+        assert captured_kwargs[0].get("temperature") == 0.7, (
+            f"generate_title must pass temperature=0.7, got {captured_kwargs[0].get('temperature')!r}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: Sibling-Brief Helper
+# ---------------------------------------------------------------------------
+
+
+class TestSummariseSiblingBrief:
+    """Phase 3: _summarise_sibling_brief extracts key fields and caps at 200 chars."""
+
+    def test_summarise_sibling_brief_extracts_fields(self) -> None:
+        """Should extract background/person/mood/text lines and cap to 200 chars."""
+        from congress_videos.modules.thumbnail_generation import _summarise_sibling_brief
+
+        brief = (
+            "background: mercado en crisis, gente desesperada\n"
+            "person: ciudadano de mediana edad, expresión tensa\n"
+            "mood: amenaza\n"
+            "text: TODO SE DERRUMBA\n"
+            "some other line that should be ignored\n"
+        )
+        result = _summarise_sibling_brief(brief)
+        assert len(result) <= 200, f"Result must be ≤ 200 chars, got {len(result)}"
+        assert "mercado en crisis" in result
+        assert "amenaza" in result
+
+    def test_summarise_sibling_brief_raw_truncates_when_no_match(self) -> None:
+        """When no recognisable field prefixes, raw-truncate fallback to 200 chars."""
+        from congress_videos.modules.thumbnail_generation import _summarise_sibling_brief
+
+        long_prompt = "x" * 500
+        result = _summarise_sibling_brief(long_prompt)
+        assert len(result) <= 200, f"Fallback must truncate to 200 chars, got {len(result)}"
+        assert result == long_prompt[:200]
+
+
+# ---------------------------------------------------------------------------
+# Phase 4: Sibling Injection on art_direct and generate_title
+# ---------------------------------------------------------------------------
+
+
+class TestArtDirectSiblingInjection:
+    """Phase 4: art_direct optional sibling_briefs injection."""
+
+    def _make_cfg(self) -> dict:
+        return {
+            "styles": [
+                {"label": "option_a", "layout": "A"},
+                {"label": "option_b", "layout": "B"},
+            ],
+            "participants_lookup": lambda slug: None,
+            "party_logo_map": None,
+        }
+
+    def _valid_brief_response(self) -> dict:
+        return {
+            "data": {
+                "text": "NUEVA CRISIS",
+                "background": "hospital desbordado",
+                "person": "enfermero exhausto, expresión preocupada",
+                "mood": "pérdida",
+            },
+            "error": None,
+        }
+
+    def test_art_direct_injects_sibling_briefs_when_nonempty(self, mocker) -> None:
+        """When sibling_briefs is non-empty, 'NO REPITAS' must appear in user_prompt."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        captured_prompts: list[str] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_prompts.append(user_prompt)
+            return self._valid_brief_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        art_direct(
+            "debate summary",
+            self._make_cfg(),
+            sibling_briefs=["brief A sobre plaza pública", "brief B con fábrica cerrada"],
+        )
+
+        assert captured_prompts, "generate_json_completion must be called"
+        assert "NO REPITAS" in captured_prompts[0], (
+            "sibling_briefs block must appear in user_prompt"
+        )
+        assert "brief A sobre plaza pública" in captured_prompts[0]
+        assert "brief B con fábrica cerrada" in captured_prompts[0]
+
+    def test_art_direct_no_injection_when_sibling_briefs_none(self, mocker) -> None:
+        """When sibling_briefs=None (default), 'NO REPITAS' must NOT appear in user_prompt."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        captured_prompts: list[str] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_prompts.append(user_prompt)
+            return self._valid_brief_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        art_direct("debate summary", self._make_cfg())
+
+        assert captured_prompts, "generate_json_completion must be called"
+        assert "NO REPITAS" not in captured_prompts[0], (
+            "sibling_briefs block must NOT appear when sibling_briefs=None"
+        )
+
+    def test_art_direct_no_injection_when_sibling_briefs_empty(self, mocker) -> None:
+        """When sibling_briefs=[], 'NO REPITAS' must NOT appear in user_prompt."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        captured_prompts: list[str] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_prompts.append(user_prompt)
+            return self._valid_brief_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        art_direct("debate summary", self._make_cfg(), sibling_briefs=[])
+
+        assert captured_prompts, "generate_json_completion must be called"
+        assert "NO REPITAS" not in captured_prompts[0], (
+            "sibling_briefs block must NOT appear when sibling_briefs=[]"
+        )
+
+
+class TestGenerateTitleSiblingInjection:
+    """Phase 4: generate_title optional sibling_titles injection."""
+
+    def _make_cfg(self) -> dict:
+        return {
+            "styles": [],
+            "participants_lookup": lambda slug: None,
+            "party_logo_map": None,
+        }
+
+    def _valid_title_response(self, title: str = "Un título válido") -> dict:
+        return {"data": {"title": title}, "error": None}
+
+    def test_generate_title_injects_sibling_titles_when_nonempty(self, mocker) -> None:
+        """When sibling_titles is non-empty, a do-not-repeat block must appear in user_prompt."""
+        from congress_videos.modules.thumbnail_generation import generate_title
+
+        captured_prompts: list[str] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_prompts.append(user_prompt)
+            return self._valid_title_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        best = {"style": "A", "prompt": "hospital desbordado"}
+        generate_title(
+            "debate summary",
+            best,
+            self._make_cfg(),
+            sibling_titles=["Title A: La crisis sanitaria", "Title B: El colapso del sistema"],
+        )
+
+        assert captured_prompts, "generate_json_completion must be called"
+        assert "NO REPITAS" in captured_prompts[0], (
+            "sibling_titles block must appear in user_prompt"
+        )
+        assert "Title A: La crisis sanitaria" in captured_prompts[0]
+        assert "Title B: El colapso del sistema" in captured_prompts[0]
+
+    def test_generate_title_no_injection_when_sibling_titles_none(self, mocker) -> None:
+        """When sibling_titles=None (default), no sibling block in user_prompt."""
+        from congress_videos.modules.thumbnail_generation import generate_title
+
+        captured_prompts: list[str] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_prompts.append(user_prompt)
+            return self._valid_title_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        best = {"style": "A", "prompt": "mercado"}
+        generate_title("debate summary", best, self._make_cfg())
+
+        assert captured_prompts, "generate_json_completion must be called"
+        assert "NO REPITAS" not in captured_prompts[0], (
+            "sibling_titles block must NOT appear when sibling_titles=None"
+        )
+
+    def test_generate_title_no_injection_when_sibling_titles_empty(self, mocker) -> None:
+        """When sibling_titles=[], no sibling block in user_prompt."""
+        from congress_videos.modules.thumbnail_generation import generate_title
+
+        captured_prompts: list[str] = []
+
+        def _capture(system_prompt, user_prompt, **kw):
+            captured_prompts.append(user_prompt)
+            return self._valid_title_response()
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_capture,
+        )
+        best = {"style": "A", "prompt": "mercado"}
+        generate_title("debate summary", best, self._make_cfg(), sibling_titles=[])
+
+        assert captured_prompts, "generate_json_completion must be called"
+        assert "NO REPITAS" not in captured_prompts[0], (
+            "sibling_titles block must NOT appear when sibling_titles=[]"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Phase 5: fetch_recent_thumbnail_history
+# ---------------------------------------------------------------------------
+
+
+class TestFetchRecentThumbnailHistory:
+    """Phase 5: fetch_recent_thumbnail_history — happy path, empty, and never-raises."""
+
+    def _make_cursor_mock(self, rows: list[tuple]) -> MagicMock:
+        """Return a mock cursor whose fetchall() returns `rows`."""
+        cursor = MagicMock()
+        cursor.__enter__ = MagicMock(return_value=cursor)
+        cursor.__exit__ = MagicMock(return_value=False)
+        cursor.fetchall.return_value = rows
+        return cursor
+
+    def _make_conn_mock(self, cursor_mock: MagicMock) -> MagicMock:
+        conn = MagicMock()
+        conn.__enter__ = MagicMock(return_value=conn)
+        conn.__exit__ = MagicMock(return_value=False)
+        conn.cursor.return_value = cursor_mock
+        return conn
+
+    def test_fetch_recent_thumbnail_history_happy_path(self, mocker) -> None:
+        """Happy path: 3 rows returned; briefs are summarised, None titles excluded."""
+        from congress_videos.modules.thumbnail_generation import fetch_recent_thumbnail_history
+
+        rows = [
+            ("background: mercado en crisis\nperson: ciudadano\nmood: amenaza\ntext: TODO CAE", "Título A"),
+            ("background: hospital lleno\nperson: enfermero\nmood: pérdida\ntext: COLAPSO", "Título B"),
+            ("background: fábrica cerrada\nperson: obrero\nmood: tristeza\ntext: SIN TRABAJO", None),
+        ]
+
+        cursor_mock = self._make_cursor_mock(rows)
+        conn_mock = self._make_conn_mock(cursor_mock)
+        pg_mock = MagicMock()
+        pg_mock.get_qualified_table.return_value = "public.video_thumbnails"
+        pg_mock.get_connection.return_value = conn_mock
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.PostgresConnection",
+            return_value=pg_mock,
+        )
+
+        briefs, titles = fetch_recent_thumbnail_history(limit=5)
+
+        assert len(briefs) == 3, f"Expected 3 briefs, got {len(briefs)}"
+        assert len(titles) == 2, f"Expected 2 titles (None excluded), got {len(titles)}"
+        assert "Título A" in titles
+        assert "Título B" in titles
+        # Each brief must be a summarised version (≤200 chars)
+        for b in briefs:
+            assert len(b) <= 200, f"Brief must be ≤ 200 chars, got {len(b)}"
+
+    def test_fetch_recent_thumbnail_history_empty_returns_empty_lists(self, mocker) -> None:
+        """When cursor returns no rows, return ([], [])."""
+        from congress_videos.modules.thumbnail_generation import fetch_recent_thumbnail_history
+
+        cursor_mock = self._make_cursor_mock([])
+        conn_mock = self._make_conn_mock(cursor_mock)
+        pg_mock = MagicMock()
+        pg_mock.get_qualified_table.return_value = "public.video_thumbnails"
+        pg_mock.get_connection.return_value = conn_mock
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.PostgresConnection",
+            return_value=pg_mock,
+        )
+
+        briefs, titles = fetch_recent_thumbnail_history()
+
+        assert briefs == []
+        assert titles == []
+
+    def test_fetch_recent_thumbnail_history_db_error_never_raises(self, mocker, caplog) -> None:
+        """When PostgresConnection raises, return ([], []) and log WARNING."""
+        import logging
+        from congress_videos.modules.thumbnail_generation import fetch_recent_thumbnail_history
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.PostgresConnection",
+            side_effect=Exception("DB connection failed"),
+        )
+
+        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+            briefs, titles = fetch_recent_thumbnail_history()
+
+        assert briefs == []
+        assert titles == []
+        assert any(r.levelno >= logging.WARNING for r in caplog.records), (
+            "A WARNING must be logged when DB raises"
+        )

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -1193,6 +1193,41 @@ class TestSummariseSiblingBrief:
         assert len(result) <= 200, f"Fallback must truncate to 200 chars, got {len(result)}"
         assert result == long_prompt[:200]
 
+    def test_summarise_sibling_brief_extracts_from_real_pikzels_format(self) -> None:
+        """Must capture person and mood from the REAL rendered Pikzels prompt.
+
+        The stored ``video_thumbnails.prompt`` uses ``SUBJECT (...):`` for the
+        person axis and ``Overall mood:`` for the mood axis — not the synthetic
+        ``person:``/``mood:`` field names. These are exactly the axes that were
+        converging in production, so they must survive summarisation. The TEXT
+        phrase must be extracted from its quotes without the styling boilerplate.
+        """
+        from congress_videos.modules.thumbnail_generation import _summarise_sibling_brief
+
+        brief = (
+            "A thick gold (#C9A84C) border frames the entire image edge.\n\n"
+            "BACKGROUND: protesta callejera con pancartas.\n\n"
+            "SUBJECT (RIGHT HALF): mujer de unos 30 años, con expresión de "
+            "indignación, ropa casual. Face fills 35-40%. Looks at camera.\n\n"
+            "TEXT (LEFT HALF, 42% from top): Bold ALL-CAPS white (#FFFFFF) "
+            "'¡BASTA DE CORRUPCIÓN!'.\n"
+            "Font: bold compressed sans-serif (Impact / Bebas Neue).\n\n"
+            "Overall mood: indignación.\n"
+            "16:9 YouTube thumbnail."
+        )
+        result = _summarise_sibling_brief(brief)
+
+        assert len(result) <= 200, f"Result must be ≤ 200 chars, got {len(result)}"
+        # Person axis captured, boilerplate tail dropped.
+        assert "mujer de unos 30 años" in result
+        assert "Face fills" not in result
+        # Mood axis captured (from "Overall mood:", not "mood:").
+        assert "indignación" in result
+        # Text phrase captured from quotes, styling boilerplate dropped.
+        assert "¡BASTA DE CORRUPCIÓN!" in result
+        assert "Bold ALL-CAPS" not in result
+        assert "protesta callejera" in result
+
 
 # ---------------------------------------------------------------------------
 # Phase 4: Sibling Injection on art_direct and generate_title


### PR DESCRIPTION
## Problem
The last ~5 YouTube videos had near-identical thumbnails **and** titles. Confirmed in `production.video_thumbnails` (chapters 402–413): chosen art briefs were verbatim near-identical (`background=protesta callejera`, `person=mujer de unos 30 años… indignación`, `mood=indignación`) and titles all revolved around "corrupción / Sánchez / crisis". It was **not** the `_DEFAULT_ART_BRIEF` fallback — it was real model output collapsing to one mode.

## Root cause (two of three diagnosed causes, attacked here)
1. **Prompt anchoring + low temperature** — `ART_DIRECTION_SYSTEM_PROMPT` led its background examples with "protesta callejera" and its mood list with "indignación", and both `art_direct`/`generate_title` inherited `generate_json_completion`'s implicit `temperature=0.3` (near-deterministic).
2. **No cross-sibling diversity constraint** — each chapter's brief/title was generated in isolation; the existing retry-for-diversity only fired on low Pikzels score, never on similarity to recent videos.

_(Out of scope: cause 3 — chapter selection/segmentation topic convergence.)_

## Changes
- **De-anchor prompts**: reorder background/mood examples, add an explicit visual-variety instruction to `ART_DIRECTION_SYSTEM_PROMPT`, and a tonal-variety note to `THUMBNAIL_TITLE_SYSTEM_PROMPT`. http-prohibition + JSON-only rules kept intact.
- **Temperature 0.7** at both `generate_json_completion` call sites.
- **`fetch_recent_thumbnail_history(limit=5)`**: global last-5 chosen `(prompt, openai_title)` rows via the existing `PostgresConnection` helper. Never raises → returns `([], [])` on error/empty, so history unavailability never blocks the DAG.
- **`sibling_briefs` / `sibling_titles`** optional params on `art_direct` / `generate_title`: inject a "NO REPITAS" block when non-empty; **byte-identical prompt when None/empty** (backward compat). Sibling briefs truncated via `_summarise_sibling_brief` to protect the token budget.
- **DAG wiring**: new `fetch_recent_history` root pre-task threaded into `art_direction`, `art_direction_retry`, and `generate_title`.

## Testing
- Strict TDD; **1647 tests pass** (1 pre-existing unrelated skip), no regressions.
- +27 new unit tests (temperature at both sites, injection present/absent for both functions, `_summarise_sibling_brief` truncation, `fetch_recent_thumbnail_history` happy-path + never-raises) and +8 DAG wiring tests.
- Docker e2e smoke (`scripts/test-airflow-e2e.sh`): PASS — `airflow dags list-import-errors` empty.

## Notes for review
- History scope is **global across videos** (not per session/`youtube_video_id`) — matches the observed convergence spanning different videos.
- 4 pre-existing DAG upstream-edge tests were updated to reflect the new `fetch_recent_history` root task (intentional, not regressions).

Delivered via SDD (explore → propose → spec → design → tasks → apply → verify).