### PR TITLE
feat: topic-aware thumbnail demographics (#54) + de-conflicted upload schedule

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -54,9 +54,7 @@ Devuelve SOLO el JSON, sin markdown."""
 
 
 # YouTube Title Generation
-YOUTUBE_TITLE_SYSTEM_PROMPT = (
-    "Eres un experto en crear títulos atractivos para contenido político español en YouTube."
-)
+YOUTUBE_TITLE_SYSTEM_PROMPT = "Eres un experto en crear títulos atractivos para contenido político español en YouTube."
 
 YOUTUBE_TITLE_USER_PROMPT_TEMPLATE = """
 Genera un título optimizado para YouTube de un vídeo del Congreso de España. El título debe ser:
@@ -135,6 +133,14 @@ IMPORTANTE: Si la frase supera {max_length} caracteres, acórtala eliminando pal
 
 Devuelve SOLO la frase, sin explicaciones."""
 
+# Manually maintained YouTube Analytics audience profile. This is deliberately
+# static configuration: do not replace it with a database, API, or live-analytics lookup.
+YOUTUBE_ANALYTICS_AUDIENCE_PROFILE = {
+    "source": "YouTube Analytics",
+    "male_percentage": 80,
+    "aged_65_plus_percentage": 63,
+}
+
 # Art Direction — produces a JSON brief ({text, background, person, mood}) used by
 # build_pikzels_prompt to fill Template A/B/C from the congress-thumbnail skill.
 ART_DIRECTION_SYSTEM_PROMPT = (
@@ -145,8 +151,24 @@ ART_DIRECTION_SYSTEM_PROMPT = (
     "calle vacía al atardecer, etc.). "
     "NUNCA hemiciclo, cámara parlamentaria ni sala de gobierno.\n"
     "- person: persona relatable, edad/expresión/ropa concreta. Ocupa el 35-40%% del frame. "
-    "Expresión emocional (indignación, miedo, sorpresa). Que cualquier ciudadano español se vea reflejado.\n"
+    "Expresión emocional (indignación, miedo, sorpresa). Que cualquier ciudadano español se vea reflejado. "
+    "Representa a un espectador o ciudadano relatable, nunca el ponente ni la foto de un participante.\n"
     "- mood: tono emocional dominante (curiosidad, pérdida, amenaza, indignación, identidad).\n\n"
+    "POLÍTICA DE SELECCIÓN DE PERSONA:\n"
+    f"- Datos de {YOUTUBE_ANALYTICS_AUDIENCE_PROFILE['source']}: "
+    f"{YOUTUBE_ANALYTICS_AUDIENCE_PROFILE['male_percentage']}% de audiencia masculina y "
+    f"{YOUTUBE_ANALYTICS_AUDIENCE_PROFILE['aged_65_plus_percentage']}% de audiencia de 65+. "
+    "Son configuración manual; no consultes base de datos, API ni analíticas en tiempo real.\n"
+    "- Para maternidad, embarazo o conciliación, elige una mujer en edad de tener hijos; "
+    "esta regla prevalece sobre la regla general.\n"
+    "- Para pensiones, dependencia o atención sanitaria geriátrica, elige una persona mayor; "
+    "esta regla prevalece sobre la regla general.\n"
+    "- Para desempleo juvenil, vivienda joven o educación universitaria, elige una persona joven; "
+    "esta regla prevalece sobre la regla general.\n"
+    "- Para resúmenes generales o ambiguos, favorece hombres mayores aproximadamente el 80% de los casos, "
+    "permitiendo también mujeres y adultos jóvenes.\n"
+    "Las restricciones de repetición entre hermanos prevalecen sobre la regla general: evita repetir "
+    "tipos de persona aunque el fallback favorezca hombres mayores.\n\n"
     "Cada brief debe ser visualmente DISTINTO al anterior: evita repetir fondos, tipos de persona o "
     "emociones en briefs consecutivos.\n\n"
     "PROHIBICIÓN ABSOLUTA: no incluyas nunca URLs ni la palabra 'http' en ningún campo. "
@@ -157,9 +179,7 @@ ART_DIRECTION_SYSTEM_PROMPT = (
 
 # Sibling-brief injection block: appended to the art_direct user prompt when
 # recent chosen briefs are available to steer the model away from repetition.
-ART_DIRECTION_SIBLING_INSTRUCTION = (
-    "NO REPITAS estos enfoques recientes (varía fondo, persona, mood y texto):\n{sibling_list}"
-)
+ART_DIRECTION_SIBLING_INSTRUCTION = "NO REPITAS estos enfoques recientes (varía fondo, persona, mood y texto):\n{sibling_list}"
 
 # Sibling-titles injection block: appended to the generate_title user prompt when
 # recent chosen titles are available to prevent emotional/tonal repetition.
@@ -494,8 +514,8 @@ SPEAKER_MATCH_SYSTEM_PROMPT = (
     "Given a dirty speaker name extracted from a transcript and a candidate participant from the "
     "congress_participants database, decide whether they refer to the same person. "
     "Always respond with a strict JSON object and NOTHING else. "
-    "JSON schema: {\"decision\": \"match\" | \"no_match\" | \"needs_manual\", "
-    "\"confidence\": <float 0-1>, \"reason\": \"<one sentence>\"}"
+    'JSON schema: {"decision": "match" | "no_match" | "needs_manual", '
+    '"confidence": <float 0-1>, "reason": "<one sentence>"}'
 )
 
 SPEAKER_MATCH_USER_PROMPT_TEMPLATE = """Dirty speaker name (from transcript): {dirty_name}

--- a/congress_videos/reap_shorts_uploader_dag.py
+++ b/congress_videos/reap_shorts_uploader_dag.py
@@ -32,19 +32,29 @@ from utils.whisper_helpers import transcribe_audio_file
 
 load_env_if_local()
 
-POSTGRES_SCHEMA = os.getenv('POSTGRES_SCHEMA', 'development')
+POSTGRES_SCHEMA = os.getenv("POSTGRES_SCHEMA", "development")
 
 
 def _resolve_speakers(ch: dict) -> tuple[str, str]:
-    speakers = ch.get('key_speakers') or ch.get('speakers') or []
+    speakers = ch.get("key_speakers") or ch.get("speakers") or []
     if not speakers:
-        return ('', '')
-    return (speakers[0].strip(), ', '.join(speakers[1:]))
+        return ("", "")
+    return (speakers[0].strip(), ", ".join(speakers[1:]))
 
 
 _MONTHS = [
-    'enero', 'febrero', 'marzo', 'abril', 'mayo', 'junio',
-    'julio', 'agosto', 'septiembre', 'octubre', 'noviembre', 'diciembre',
+    "enero",
+    "febrero",
+    "marzo",
+    "abril",
+    "mayo",
+    "junio",
+    "julio",
+    "agosto",
+    "septiembre",
+    "octubre",
+    "noviembre",
+    "diciembre",
 ]
 
 
@@ -55,58 +65,62 @@ def _format_own_channel_footer(youtube_video_id: str | None) -> str:
     There is NO fallback to the source video URL.
     """
     if not youtube_video_id:
-        return ''
-    return f'\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v={youtube_video_id}'
+        return ""
+    return f"\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v={youtube_video_id}"
 
 
 def _format_session_line(session_number: int | None, session_date: date | None) -> str:
     """Return a Spanish attribution line for a congressional session, or '' if both args are falsy."""
-    number_part = f'Sesión nº {session_number} del Congreso' if session_number else ''
+    number_part = f"Sesión nº {session_number} del Congreso" if session_number else ""
     date_part = (
-        f'{session_date.day} de {_MONTHS[session_date.month - 1]} de {session_date.year}'
-        if session_date else ''
+        f"{session_date.day} de {_MONTHS[session_date.month - 1]} de {session_date.year}"
+        if session_date
+        else ""
     )
-    body = ' - '.join(p for p in (number_part, date_part) if p)
-    return f'\n\n🏛️ {body}' if body else ''
+    body = " - ".join(p for p in (number_part, date_part) if p)
+    return f"\n\n🏛️ {body}" if body else ""
 
 
 default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=5),
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
 }
 
 with DAG(
-    'reap_shorts_uploader',
+    "reap_shorts_uploader",
     default_args=default_args,
-    description='Upload one Reap Short to YouTube per run with AI-generated title/description',
-    schedule='0 8,10,13,15,18,20,22 * * *',
+    description="Upload one Reap Short to YouTube per run with AI-generated title/description",
+    # Maintain a three-hour buffer around the 19:00 UTC long upload: 15→19 and 19→22.
+    schedule="0 8,10,13,15,22 * * *",
     start_date=datetime(2025, 11, 14),
     catchup=False,
-    tags=['congress', 'youtube', 'shorts', 'reap'],
+    tags=["congress", "youtube", "shorts", "reap"],
     params={
-        'max_shorts_per_run': 1,
-        'min_virality_score': 0.0,
-    }
+        "max_shorts_per_run": 1,
+        "min_virality_score": 0.0,
+    },
 ) as dag:
 
     def _get_pending_shorts(ti, **context):
-        max_shorts = context['params'].get('max_shorts_per_run', 1)
-        min_virality = context['params'].get('min_virality_score', 0.0)
+        max_shorts = context["params"].get("max_shorts_per_run", 1)
+        min_virality = context["params"].get("min_virality_score", 0.0)
 
         db = CongressionalVideoDB()
-        shorts = db.get_pending_shorts(limit=max_shorts, min_virality_score=min_virality)
+        shorts = db.get_pending_shorts(
+            limit=max_shorts, min_virality_score=min_virality
+        )
 
         if not shorts:
             logging.info("No pending shorts to upload")
 
-        ti.xcom_push(key='pending_shorts', value=shorts)
+        ti.xcom_push(key="pending_shorts", value=shorts)
 
     t1 = PythonOperator(
-        task_id='get_pending_shorts',
+        task_id="get_pending_shorts",
         python_callable=_get_pending_shorts,
     )
 
@@ -114,66 +128,85 @@ with DAG(
         import subprocess
         import tempfile
 
-        pending_shorts = ti.xcom_pull(key='pending_shorts') or []
+        pending_shorts = ti.xcom_pull(key="pending_shorts") or []
 
         if not pending_shorts:
-            ti.xcom_push(key='shorts_metadata', value=[])
+            ti.xcom_push(key="shorts_metadata", value=[])
             return
 
         db = CongressionalVideoDB()
         metadata_list = []
 
         for short in pending_shorts:
-            short_id = short.get('id')
-            chapter_id = short.get('chapter_id')
-            video_path = short.get('local_file_path')
+            short_id = short.get("id")
+            chapter_id = short.get("chapter_id")
+            video_path = short.get("local_file_path")
 
             ch = db.get_chapter_metadata(chapter_id) if chapter_id else {}
             ch = ch or {}
 
-            chapter_title = ch.get('title') or f'Short clip {short_id}'
+            chapter_title = ch.get("title") or f"Short clip {short_id}"
             primary_speaker, secondary_speakers = _resolve_speakers(ch)
-            topics = ', '.join(ch.get('topics') or []) or 'Debate parlamentario'
-            scoring_reasoning = ch.get('scoring_reasoning') or ''
+            topics = ", ".join(ch.get("topics") or []) or "Debate parlamentario"
+            scoring_reasoning = ch.get("scoring_reasoning") or ""
 
             # Fallback metadata — used if Whisper or GPT fail
             title = truncate_text(
-                f"{primary_speaker}: {chapter_title} #Shorts" if primary_speaker else f"{chapter_title} #Shorts",
+                f"{primary_speaker}: {chapter_title} #Shorts"
+                if primary_speaker
+                else f"{chapter_title} #Shorts",
                 max_length=100,
             )
-            description = '🏛️ Debate en el Congreso de los Diputados.\n\n#Congreso #España #Política #Shorts'
+            description = "🏛️ Debate en el Congreso de los Diputados.\n\n#Congreso #España #Política #Shorts"
 
             transcript = None
             if video_path and os.path.exists(video_path):
                 try:
-                    with tempfile.NamedTemporaryFile(suffix='.wav', delete=True) as tmp:
+                    with tempfile.NamedTemporaryFile(suffix=".wav", delete=True) as tmp:
                         ffmpeg_result = subprocess.run(
                             [
-                                'ffmpeg', '-i', video_path,
-                                '-vn', '-acodec', 'pcm_s16le', '-ar', '16000', '-ac', '1',
-                                tmp.name, '-y',
+                                "ffmpeg",
+                                "-i",
+                                video_path,
+                                "-vn",
+                                "-acodec",
+                                "pcm_s16le",
+                                "-ar",
+                                "16000",
+                                "-ac",
+                                "1",
+                                tmp.name,
+                                "-y",
                             ],
                             capture_output=True,
                             timeout=60,
                         )
                         if ffmpeg_result.returncode == 0:
                             whisper_result = transcribe_audio_file(
-                                tmp.name, language='es',
-                                use_local_whisper=True, model_size='tiny',
+                                tmp.name,
+                                language="es",
+                                use_local_whisper=True,
+                                model_size="tiny",
                                 save_srt=False,
                             )
-                            if whisper_result.get('success'):
-                                transcript = whisper_result.get('text', '').strip()
-                                logging.info(f"Transcribed short {short_id}: {len(transcript)} chars")
+                            if whisper_result.get("success"):
+                                transcript = whisper_result.get("text", "").strip()
+                                logging.info(
+                                    f"Transcribed short {short_id}: {len(transcript)} chars"
+                                )
                         else:
                             logging.warning(
                                 f"ffmpeg failed for short {short_id}: "
                                 f"{ffmpeg_result.stderr.decode()[:200]}"
                             )
                 except Exception as e:
-                    logging.warning(f"Audio extraction failed for short {short_id}: {e}")
+                    logging.warning(
+                        f"Audio extraction failed for short {short_id}: {e}"
+                    )
             else:
-                logging.warning(f"Video file not found for short {short_id}: {video_path}")
+                logging.warning(
+                    f"Video file not found for short {short_id}: {video_path}"
+                )
 
             if transcript:
                 user_prompt = SHORTS_METADATA_USER_PROMPT_TEMPLATE.format(
@@ -187,12 +220,12 @@ with DAG(
                 ai_result = generate_json_completion(
                     system_prompt=SHORTS_METADATA_SYSTEM_PROMPT,
                     user_prompt=user_prompt,
-                    model='gpt-4o-mini',
+                    model="gpt-4o-mini",
                     max_tokens=400,
                 )
-                if ai_result.get('data'):
-                    ai_title = ai_result['data'].get('title', '').strip()
-                    ai_description = ai_result['data'].get('description', '').strip()
+                if ai_result.get("data"):
+                    ai_title = ai_result["data"].get("title", "").strip()
+                    ai_description = ai_result["data"].get("description", "").strip()
                     if ai_title:
                         title = truncate_text(ai_title, max_length=100)
                     if ai_description:
@@ -204,19 +237,23 @@ with DAG(
                         f"{ai_result.get('error')}"
                     )
 
-            description += _format_own_channel_footer(ch.get('youtube_video_id'))
-            description += _format_session_line(ch.get('session_number'), ch.get('session_date'))
+            description += _format_own_channel_footer(ch.get("youtube_video_id"))
+            description += _format_session_line(
+                ch.get("session_number"), ch.get("session_date")
+            )
 
-            metadata_list.append({
-                'short_id': short_id,
-                'title': title,
-                'description': description,
-            })
+            metadata_list.append(
+                {
+                    "short_id": short_id,
+                    "title": title,
+                    "description": description,
+                }
+            )
 
-        ti.xcom_push(key='shorts_metadata', value=metadata_list)
+        ti.xcom_push(key="shorts_metadata", value=metadata_list)
 
     t2 = PythonOperator(
-        task_id='generate_metadata',
+        task_id="generate_metadata",
         python_callable=_generate_metadata,
     )
 
@@ -224,39 +261,39 @@ with DAG(
         import time
         from airflow.models import DagRun, XCom
 
-        pending_shorts = ti.xcom_pull(key='pending_shorts') or []
-        shorts_metadata = ti.xcom_pull(key='shorts_metadata') or []
+        pending_shorts = ti.xcom_pull(key="pending_shorts") or []
+        shorts_metadata = ti.xcom_pull(key="shorts_metadata") or []
 
         if not pending_shorts:
             logging.info("No pending shorts — skipping upload")
-            ti.xcom_push(key='upload_results', value={'upload_details': []})
+            ti.xcom_push(key="upload_results", value={"upload_details": []})
             return None
 
         videos = []
         for short, meta in zip(pending_shorts, shorts_metadata):
-            short_id = short.get('id')
+            short_id = short.get("id")
 
             video_config = {
-                'short_id': short_id,
-                'reap_clip_id': short.get('reap_clip_id'),
-                'video_file': short.get('local_file_path'),
-                'title': meta.get('title') or f'Short clip {short_id} #Shorts',
-                'description': meta.get('description') or '#Shorts',
-                'category_id': '25',
-                'privacy_status': 'public',
-                'tags': ['shorts', 'congress', 'politics', 'españa', 'congreso'],
-                'made_for_kids': False,
+                "short_id": short_id,
+                "reap_clip_id": short.get("reap_clip_id"),
+                "video_file": short.get("local_file_path"),
+                "title": meta.get("title") or f"Short clip {short_id} #Shorts",
+                "description": meta.get("description") or "#Shorts",
+                "category_id": "25",
+                "privacy_status": "public",
+                "tags": ["shorts", "congress", "politics", "españa", "congreso"],
+                "made_for_kids": False,
             }
             videos.append(video_config)
 
         config = {
-            'token_file': YOUTUBE_TOKEN_FILE,
-            'videos': videos,
+            "token_file": YOUTUBE_TOKEN_FILE,
+            "videos": videos,
         }
 
         logging.info(f"Triggering generic_youtube_uploader with {len(videos)} shorts")
         dag_run = trigger_dag_api(
-            dag_id='generic_youtube_uploader',
+            dag_id="generic_youtube_uploader",
             conf=config,
             run_id=f"shorts_upload_{context['run_id']}",
         )
@@ -268,54 +305,66 @@ with DAG(
             time.sleep(10)
             dag_run.refresh_from_db()
 
-            if dag_run.state in ['success', 'failed']:
+            if dag_run.state in ["success", "failed"]:
                 logging.info(f"Upload DAG completed with state: {dag_run.state}")
 
                 upload_results = XCom.get_many(
                     execution_date=dag_run.execution_date,
-                    dag_ids=['generic_youtube_uploader'],
-                    task_ids=['upload_videos'],
-                    key='return_value',
+                    dag_ids=["generic_youtube_uploader"],
+                    task_ids=["upload_videos"],
+                    key="return_value",
                     limit=1,
                 )
 
                 if upload_results:
                     results_data = upload_results[0].value
                     logging.info(f"Retrieved upload results: {results_data}")
-                    file_to_meta = {v['video_file']: v for v in videos}
+                    file_to_meta = {v["video_file"]: v for v in videos}
                     enriched = []
-                    for detail in results_data.get('upload_details', []):
-                        meta = file_to_meta.get(detail.get('video_file'), {})
-                        enriched.append({**detail, 'reap_clip_id': meta.get('reap_clip_id'), 'short_id': meta.get('short_id')})
-                    results_data = {**results_data, 'upload_details': enriched}
-                    ti.xcom_push(key='upload_results', value=results_data)
+                    for detail in results_data.get("upload_details", []):
+                        meta = file_to_meta.get(detail.get("video_file"), {})
+                        enriched.append(
+                            {
+                                **detail,
+                                "reap_clip_id": meta.get("reap_clip_id"),
+                                "short_id": meta.get("short_id"),
+                            }
+                        )
+                    results_data = {**results_data, "upload_details": enriched}
+                    ti.xcom_push(key="upload_results", value=results_data)
                 else:
                     logging.warning("No upload results found from triggered DAG")
                     upload_details = []
                     for video_config in videos:
-                        upload_details.append({
-                            'short_id': video_config.get('short_id'),
-                            'reap_clip_id': video_config.get('reap_clip_id'),
-                            'video_file': video_config.get('video_file'),
-                            'success': dag_run.state == 'success',
-                            'youtube_video_id': None,
-                            'error': 'Upload failed - no results available' if dag_run.state == 'failed' else None,
-                        })
-                    ti.xcom_push(key='upload_results', value={'upload_details': upload_details})
+                        upload_details.append(
+                            {
+                                "short_id": video_config.get("short_id"),
+                                "reap_clip_id": video_config.get("reap_clip_id"),
+                                "video_file": video_config.get("video_file"),
+                                "success": dag_run.state == "success",
+                                "youtube_video_id": None,
+                                "error": "Upload failed - no results available"
+                                if dag_run.state == "failed"
+                                else None,
+                            }
+                        )
+                    ti.xcom_push(
+                        key="upload_results", value={"upload_details": upload_details}
+                    )
 
-                if dag_run.state == 'failed':
+                if dag_run.state == "failed":
                     raise Exception(f"Upload DAG failed: {dag_run.run_id}")
 
                 return dag_run.run_id
 
     t3 = PythonOperator(
-        task_id='trigger_youtube_upload',
+        task_id="trigger_youtube_upload",
         python_callable=_trigger_youtube_upload,
     )
 
     def _mark_shorts_uploaded(ti, **context):
-        upload_results = ti.xcom_pull(key='upload_results') or {}
-        upload_details = upload_results.get('upload_details', [])
+        upload_results = ti.xcom_pull(key="upload_results") or {}
+        upload_details = upload_results.get("upload_details", [])
 
         if not upload_details:
             logging.info("No upload results to process")
@@ -326,31 +375,36 @@ with DAG(
         failed = 0
 
         for detail in upload_details:
-            reap_clip_id = detail.get('reap_clip_id')
-            youtube_video_id = detail.get('youtube_video_id')
-            if detail.get('success') and reap_clip_id and youtube_video_id:
+            reap_clip_id = detail.get("reap_clip_id")
+            youtube_video_id = detail.get("youtube_video_id")
+            if detail.get("success") and reap_clip_id and youtube_video_id:
                 db.mark_short_uploaded(reap_clip_id, youtube_video_id)
                 successful += 1
             else:
                 failed += 1
                 if reap_clip_id:
-                    db.record_short_upload_failure(reap_clip_id, detail.get('error'))
+                    db.record_short_upload_failure(reap_clip_id, detail.get("error"))
                 else:
-                    logging.warning(f"Skipping failure recording — detail without reap_clip_id: {detail}")
+                    logging.warning(
+                        f"Skipping failure recording — detail without reap_clip_id: {detail}"
+                    )
 
         logging.info(f"Upload summary: {successful} successful, {failed} failed")
 
     def _check_short_upload_failures(ti, **context):
-        upload_results = ti.xcom_pull(key='upload_results')
+        upload_results = ti.xcom_pull(key="upload_results")
         if upload_results is None:
             raise Exception("Upload results XCom missing — data integrity unknown")
-        upload_details = upload_results.get('upload_details', [])
+        upload_details = upload_results.get("upload_details", [])
         if not upload_details:
             logging.info("No upload results to check")
             return
         failed = [
-            d for d in upload_details
-            if not (d.get('success') and d.get('reap_clip_id') and d.get('youtube_video_id'))
+            d
+            for d in upload_details
+            if not (
+                d.get("success") and d.get("reap_clip_id") and d.get("youtube_video_id")
+            )
         ]
         if failed:
             raise Exception(
@@ -359,12 +413,12 @@ with DAG(
         logging.info("All shorts uploaded successfully")
 
     t4 = PythonOperator(
-        task_id='mark_shorts_uploaded',
+        task_id="mark_shorts_uploaded",
         python_callable=_mark_shorts_uploaded,
     )
 
     t5 = PythonOperator(
-        task_id='check_short_upload_failures',
+        task_id="check_short_upload_failures",
         python_callable=_check_short_upload_failures,
     )
 

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -4,7 +4,7 @@ Congress YouTube Chapter Uploader DAG
 This DAG uploads individual chapters from congressional videos to YouTube:
 
 1. Ensure data directory exists
-2. Query top 5 uploadable chapters from uploadable_chapters view
+2. Query the highest-priority uploadable chapter from uploadable_chapters view
    - Ordered by relevance_score DESC (highest relevance first)
    - Then by created_at DESC (most recent first)
    - Only chapters not yet uploaded to YouTube
@@ -37,13 +37,14 @@ from utils.env_loader import load_env_if_local
 load_env_if_local()
 
 # Check if running in development environment
-POSTGRES_SCHEMA = os.getenv('POSTGRES_SCHEMA', 'development')
-IS_DEVELOPMENT = POSTGRES_SCHEMA == 'development'
+POSTGRES_SCHEMA = os.getenv("POSTGRES_SCHEMA", "development")
+IS_DEVELOPMENT = POSTGRES_SCHEMA == "development"
 
-# Upload thresholds by hour — skip upload unless queue_size strictly exceeds the threshold.
-# 11:00: skip if queue_size <= 10 (REQ-THRESH-01)
-# 14:00: skip if queue_size <= 20 (REQ-THRESH-02)
-# 17:00: skip if queue_size < 1  (REQ-THRESH-03)
+# The scheduled 19:00 UTC run uploads only when at least one chapter is queued.
+# This is a calendar-day cap for long-form chapter uploads; database quota data
+# reports successful uploads_today, while limit=1 remains a selection safeguard.
+DAILY_LONG_FORM_UPLOAD_LIMIT = 1
+# Retain legacy thresholds for manually triggered runs using their logical hours.
 THRESHOLD_BY_HOUR = {11: 10, 14: 20, 17: 0}
 STALE_RUN_TOLERANCE_MINUTES = int(
     os.getenv("CHAPTER_UPLOADER_STALE_RUN_TOLERANCE_MINUTES", "30")
@@ -66,13 +67,26 @@ def should_upload(**context):
             logging.info(
                 "Skipping stale re-parse replay: data_interval_end=%s is %s "
                 "behind now=%s (tolerance=%dm)",
-                data_interval_end, staleness, now, STALE_RUN_TOLERANCE_MINUTES,
+                data_interval_end,
+                staleness,
+                now,
+                STALE_RUN_TOLERANCE_MINUTES,
             )
             return False
-    ti = context['ti']
-    upload_quota = ti.xcom_pull(key='upload_quota') or {}
-    queue_size = upload_quota.get('queue_size', 0)
-    hour = context['logical_date'].hour
+    ti = context["ti"]
+    upload_quota = ti.xcom_pull(key="upload_quota") or {}
+    queue_size = upload_quota.get("queue_size", 0)
+    uploads_today = upload_quota.get("uploads_today", 0)
+    if uploads_today >= DAILY_LONG_FORM_UPLOAD_LIMIT:
+        logging.info(
+            "Skipping upload: %d long-form chapter upload(s) already recorded today "
+            "(daily limit=%d)",
+            uploads_today,
+            DAILY_LONG_FORM_UPLOAD_LIMIT,
+        )
+        return False
+
+    hour = context["logical_date"].hour
     threshold = THRESHOLD_BY_HOUR.get(hour, 0)
     return queue_size > threshold
 
@@ -80,6 +94,7 @@ def should_upload(**context):
 # ---------------------------------------------------------------------------
 # Thumbnail pipeline helpers
 # ---------------------------------------------------------------------------
+
 
 def _resolve_speaker_name(chapter: dict) -> str | None:
     """Extract the first speaker name from key_speakers or speakers.
@@ -130,9 +145,7 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     session_date = chapter.get("session_date")
 
     # debate_summary: title + description (D6)
-    debate_summary = (
-        f"{title}\n{description}" if description else title
-    )
+    debate_summary = f"{title}\n{description}" if description else title
 
     # session label (D6)
     if session_number is not None:
@@ -165,7 +178,12 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
 
 
 def _thumbnail_failure(chapter_id: int | None) -> dict:
-    return {"chapter_id": chapter_id, "success": False, "output_path": None, "title": None}
+    return {
+        "chapter_id": chapter_id,
+        "success": False,
+        "output_path": None,
+        "title": None,
+    }
 
 
 def trigger_thumbnail_generation(ti, **context) -> str | None:
@@ -193,7 +211,9 @@ def trigger_thumbnail_generation(ti, **context) -> str | None:
             run_id=f"chapter_thumbnail_{context['run_id']}",
         )
     except Exception as exc:
-        logging.warning("Could not trigger thumbnail DAG for chapter_id=%s: %s", chapter_id, exc)
+        logging.warning(
+            "Could not trigger thumbnail DAG for chapter_id=%s: %s", chapter_id, exc
+        )
         ti.xcom_push(key="thumbnail_result", value=_thumbnail_failure(chapter_id))
         return None
 
@@ -227,7 +247,9 @@ def trigger_thumbnail_generation(ti, **context) -> str | None:
             and isinstance(result.get("title"), str)
             and result["title"]
         ):
-            logging.warning("Thumbnail DAG run %s returned no valid result", child_run_id)
+            logging.warning(
+                "Thumbnail DAG run %s returned no valid result", child_run_id
+            )
             ti.xcom_push(key="thumbnail_result", value=_thumbnail_failure(chapter_id))
             return child_run_id
 
@@ -277,6 +299,7 @@ def _backfill_thumbnail_video_id(ti, db=None) -> None:
 
     if db is None:
         from congress_videos.modules.database import CongressionalVideoDB
+
         db = CongressionalVideoDB()
 
     db.update_thumbnail_youtube_video_id(
@@ -284,42 +307,44 @@ def _backfill_thumbnail_video_id(ti, db=None) -> None:
     )
     logging.info(
         "_backfill_thumbnail_video_id: chapter_id=%s → %r",
-        chapter_id, youtube_video_id,
+        chapter_id,
+        youtube_video_id,
     )
 
 
 default_args = {
-    'owner': 'airflow',
-    'depends_on_past': False,
-    'email_on_failure': False,
-    'email_on_retry': False,
-    'retries': 1,
-    'retry_delay': timedelta(minutes=5),
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
 }
 
-with DAG(
-    'congress_youtube_chapter_uploader',
-    default_args=default_args,
-    description='Upload top congressional video chapters to YouTube based on relevance score',
-    schedule='0 11,14,17 * * *',  # Run at 11:00, 14:00, and 17:00 UTC daily
-    start_date=datetime(2025, 11, 14),
-    catchup=False,
-    tags=['congress', 'youtube', 'chapters'],
-    params={
-        "max_chapters": 1,
-        "min_relevance_score": 2,
-        "isTesting": False,
-        "dry_run": False,  # Set to True to run the full pipeline without triggering the YouTube upload
-    }
-) as dag:
-
+with (
+    DAG(
+        "congress_youtube_chapter_uploader",
+        default_args=default_args,
+        description="Upload top congressional video chapters to YouTube based on relevance score",
+        schedule="0 19 * * *",  # Run once daily at 19:00 UTC; gate enforces one long video per calendar day
+        start_date=datetime(2025, 11, 14),
+        catchup=False,
+        tags=["congress", "youtube", "chapters"],
+        params={
+            "max_chapters": 1,
+            "min_relevance_score": 2,
+            "isTesting": False,
+            "dry_run": False,  # Set to True to run the full pipeline without triggering the YouTube upload
+        },
+    ) as dag
+):
     # Step 0: Ensure data directory exists
     t0 = PythonOperator(
-        task_id='ensure_data_directory',
+        task_id="ensure_data_directory",
         python_callable=lambda ti: xcom_task(
             ti,
-            lambda: ensure_project_data_directory('congress_videos'),
-            'data_directory_path'
+            lambda: ensure_project_data_directory("congress_videos"),
+            "data_directory_path",
         ),
     )
 
@@ -327,44 +352,46 @@ with DAG(
     # Queries DB for uploads today and pending queue size.
     # Returns {queue_size, uploads_today}.
     t1_quota = PostgreSQLOperator(
-        task_id='check_upload_quota',
-        operation='check_upload_quota',
-        output_xcom_key='upload_quota',
+        task_id="check_upload_quota",
+        operation="check_upload_quota",
+        output_xcom_key="upload_quota",
     )
 
     # Step 1b: Short-circuit based on queue_size vs time-of-day threshold
     t1_skip = ShortCircuitOperator(
-        task_id='skip_if_quota_reached',
+        task_id="skip_if_quota_reached",
         python_callable=should_upload,
     )
 
     # Step 2: Get uploadable chapters (limit=1 per run)
     # Ordered by: session_date DESC, relevance_score DESC, created_at DESC
     t1_db = PostgreSQLOperator(
-        task_id='get_uploadable_chapters',
-        operation='get_uploadable_chapters',
-        output_xcom_key='uploadable_chapters'
+        task_id="get_uploadable_chapters",
+        operation="get_uploadable_chapters",
+        output_xcom_key="uploadable_chapters",
     )
 
     def _generate_youtube_metadata(ti):
         from congress_videos.modules.youtube import youtube_ai
+
         return xcom_task(
             ti,
             lambda: youtube_ai.generate_youtube_metadata_for_selected_videos(
-                ti.xcom_pull(key='uploadable_chapters')
+                ti.xcom_pull(key="uploadable_chapters")
             ),
-            'youtube_metadata_results'
+            "youtube_metadata_results",
         )
 
     def _run_prepare_thumbnail_config(ti):
         """Resolve speaker name and build thumbnail config struct for the chapter."""
         from congress_videos.modules.database import CongressionalVideoDB
-        chapters = ti.xcom_pull(key='uploadable_chapters') or []
+
+        chapters = ti.xcom_pull(key="uploadable_chapters") or []
         # Uploader processes exactly 1 chapter per run
         chapter = chapters[0] if chapters else {}
         db = CongressionalVideoDB()
         result = _prepare_thumbnail_config(chapter, db)
-        ti.xcom_push(key='thumbnail_config', value=result)
+        ti.xcom_push(key="thumbnail_config", value=result)
 
     def _run_generate_thumbnail(ti):
         """Trigger the generic thumbnail DAG and retain its completed result."""
@@ -372,26 +399,28 @@ with DAG(
 
     def _extract_chapter_videos(ti):
         from congress_videos.modules import video_splitter
+
         return xcom_task(
             ti,
             lambda: video_splitter.extract_chapters_from_video(
-                ti.xcom_pull(key='uploadable_chapters'),
-                ti.xcom_pull(key='data_directory_path')
+                ti.xcom_pull(key="uploadable_chapters"),
+                ti.xcom_pull(key="data_directory_path"),
             ),
-            'chapter_extraction_results'
+            "chapter_extraction_results",
         )
 
     def _prepare_upload_config(ti, **context):
         from congress_videos.modules.youtube import prepare_chapter_upload_config
+
         return xcom_task(
             ti,
             lambda: prepare_chapter_upload_config(
-                ti.xcom_pull(key='chapter_extraction_results'),
-                ti.xcom_pull(key='youtube_metadata_results'),
-                thumbnail_result=ti.xcom_pull(key='thumbnail_result'),
-                is_testing=context["params"].get("isTesting", False)
+                ti.xcom_pull(key="chapter_extraction_results"),
+                ti.xcom_pull(key="youtube_metadata_results"),
+                thumbnail_result=ti.xcom_pull(key="thumbnail_result"),
+                is_testing=context["params"].get("isTesting", False),
             ),
-            'upload_config'
+            "upload_config",
         )
 
     def _run_backfill_thumbnail_video_id(ti):
@@ -400,31 +429,31 @@ with DAG(
 
     # Step 2: Generate YouTube metadata for chapters
     t2 = PythonOperator(
-        task_id='generate_youtube_metadata',
+        task_id="generate_youtube_metadata",
         python_callable=_generate_youtube_metadata,
     )
 
     # Step 3 (new): Prepare thumbnail config — resolve speaker, build config struct
     t3_prepare = PythonOperator(
-        task_id='prepare_thumbnail_config',
+        task_id="prepare_thumbnail_config",
         python_callable=_run_prepare_thumbnail_config,
     )
 
     # Step 4 (new): Generate thumbnail via the generic thumbnail DAG
     t4_generate = PythonOperator(
-        task_id='generate_thumbnail',
+        task_id="generate_thumbnail",
         python_callable=_run_generate_thumbnail,
     )
 
     # Step 5: Extract chapter videos from source YouTube videos using ffmpeg
     t5 = PythonOperator(
-        task_id='extract_chapter_videos',
+        task_id="extract_chapter_videos",
         python_callable=_extract_chapter_videos,
     )
 
     # Step 6: Prepare upload configuration for generic YouTube uploader DAG
     t6 = PythonOperator(
-        task_id='prepare_upload_config',
+        task_id="prepare_upload_config",
         python_callable=_prepare_upload_config,
     )
 
@@ -436,21 +465,23 @@ with DAG(
 
         if context.get("params", {}).get("dry_run", False):
             logging.info("dry_run=True — skipping YouTube upload")
-            ti.xcom_push(key='upload_results', value={'upload_details': []})
+            ti.xcom_push(key="upload_results", value={"upload_details": []})
             return None
 
         # Get config from XCom
-        config = ti.xcom_pull(key='upload_config')
+        config = ti.xcom_pull(key="upload_config")
 
         if not config:
             logging.warning("No upload config found, skipping upload")
-            ti.xcom_push(key='upload_results', value={'upload_details': []})
+            ti.xcom_push(key="upload_results", value={"upload_details": []})
             return None
 
         # Trigger the DAG
-        logging.info(f"Triggering generic_youtube_uploader with {len(config.get('videos', []))} videos")
+        logging.info(
+            f"Triggering generic_youtube_uploader with {len(config.get('videos', []))} videos"
+        )
         dag_run = trigger_dag_api(
-            dag_id='generic_youtube_uploader',
+            dag_id="generic_youtube_uploader",
             conf=config,
             run_id=f"chapter_upload_{context['run_id']}",
         )
@@ -463,53 +494,60 @@ with DAG(
             time.sleep(10)
             dag_run.refresh_from_db()
 
-            if dag_run.state in ['success', 'failed']:
+            if dag_run.state in ["success", "failed"]:
                 logging.info(f"Upload DAG completed with state: {dag_run.state}")
 
                 # Pull upload results from the triggered DAG
                 upload_results = XCom.get_many(
                     execution_date=dag_run.execution_date,
-                    dag_ids=['generic_youtube_uploader'],
-                    task_ids=['upload_videos'],
-                    key='return_value',
-                    limit=1
+                    dag_ids=["generic_youtube_uploader"],
+                    task_ids=["upload_videos"],
+                    key="return_value",
+                    limit=1,
                 )
 
                 if upload_results:
                     results_data = upload_results[0].value
                     logging.info(f"Retrieved upload results: {results_data}")
-                    ti.xcom_push(key='upload_results', value=results_data)
+                    ti.xcom_push(key="upload_results", value=results_data)
                 else:
                     logging.warning("No upload results found from triggered DAG")
                     # Create results based on config and DAG state
                     upload_details = []
-                    for video_config in config.get('videos', []):
-                        upload_details.append({
-                            'chapter_id': video_config.get('chapter_id'),
-                            'video_id': video_config.get('video_id'),
-                            'video_file': video_config.get('video_file'),
-                            'success': dag_run.state == 'success',
-                            'youtube_video_id': None,
-                            'error': 'Upload failed - no results available' if dag_run.state == 'failed' else None
-                        })
-                    ti.xcom_push(key='upload_results', value={'upload_details': upload_details})
+                    for video_config in config.get("videos", []):
+                        upload_details.append(
+                            {
+                                "chapter_id": video_config.get("chapter_id"),
+                                "video_id": video_config.get("video_id"),
+                                "video_file": video_config.get("video_file"),
+                                "success": dag_run.state == "success",
+                                "youtube_video_id": None,
+                                "error": "Upload failed - no results available"
+                                if dag_run.state == "failed"
+                                else None,
+                            }
+                        )
+                    ti.xcom_push(
+                        key="upload_results", value={"upload_details": upload_details}
+                    )
 
                 return dag_run.run_id
 
     def _check_upload_failures(ti):
         """Raise after DB writes so failures are visible in the Airflow UI."""
-        updates = ti.xcom_pull(key='chapter_upload_updates')
+        updates = ti.xcom_pull(key="chapter_upload_updates")
         if updates is None:
             raise Exception(
                 "chapter_upload_updates XCom missing after mark_chapters_uploaded succeeded"
             )
 
-        recorded = updates.get('recorded_failures', 0)
-        failed = updates.get('failed_updates', 0)
+        recorded = updates.get("recorded_failures", 0)
+        failed = updates.get("failed_updates", 0)
         if recorded > 0 or failed > 0:
             bad = [
-                d for d in updates.get('details', [])
-                if d.get('status') in ('failure_recorded', 'failed')
+                d
+                for d in updates.get("details", [])
+                if d.get("status") in ("failure_recorded", "failed")
             ]
             raise Exception(
                 f"Chapter upload failures: {recorded} recorded, {failed} "
@@ -519,30 +557,44 @@ with DAG(
         logging.info("No chapter upload failures recorded")
 
     t7 = PythonOperator(
-        task_id='trigger_youtube_upload',
+        task_id="trigger_youtube_upload",
         python_callable=trigger_upload_with_config,
     )
 
     # Step 8: Update database to mark chapters as uploaded
     t8_db = PostgreSQLOperator(
-        task_id='mark_chapters_uploaded',
-        operation='mark_chapters_uploaded',
-        xcom_keys={'upload_results': 'upload_results'},
-        output_xcom_key='chapter_upload_updates'
+        task_id="mark_chapters_uploaded",
+        operation="mark_chapters_uploaded",
+        xcom_keys={"upload_results": "upload_results"},
+        output_xcom_key="chapter_upload_updates",
     )
 
     # Step 8b: Back-fill youtube_video_id in video_thumbnails
     t8_backfill = PythonOperator(
-        task_id='backfill_thumbnail_video_id',
+        task_id="backfill_thumbnail_video_id",
         python_callable=_run_backfill_thumbnail_video_id,
     )
 
     # Step 9: Alert when chapter upload failures were recorded (after DB write)
     t9 = PythonOperator(
-        task_id='check_upload_failures',
+        task_id="check_upload_failures",
         python_callable=_check_upload_failures,
     )
 
     # Task dependencies (13 tasks total)
     # t0 > t1_quota > t1_skip > t1_db > t2 > t3_prepare > t4_generate > t5 > t6 > t7 > t8_db > t8_backfill > t9
-    t0 >> t1_quota >> t1_skip >> t1_db >> t2 >> t3_prepare >> t4_generate >> t5 >> t6 >> t7 >> t8_db >> t8_backfill >> t9
+    (
+        t0
+        >> t1_quota
+        >> t1_skip
+        >> t1_db
+        >> t2
+        >> t3_prepare
+        >> t4_generate
+        >> t5
+        >> t6
+        >> t7
+        >> t8_db
+        >> t8_backfill
+        >> t9
+    )

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -30,6 +30,7 @@ import pytest
 # Helpers / shared fixtures
 # ---------------------------------------------------------------------------
 
+
 def _make_cfg(
     *,
     party_logo_map=None,
@@ -38,12 +39,15 @@ def _make_cfg(
 ) -> dict:
     """Build a minimal domain-config dict for testing."""
     if lookup_raises:
+
         def _lookup(name: str):
             raise RuntimeError("unexpected call to lookup")
     elif lookup_return is not None:
+
         def _lookup(name: str):
             return lookup_return
     else:
+
         def _lookup(name: str):
             return None
 
@@ -62,14 +66,20 @@ def _make_cfg(
 # T-01: resolve_participant_photo
 # ---------------------------------------------------------------------------
 
+
 class TestResolveParticipantPhoto:
     """resolve_participant_photo(name, cfg) contracts."""
 
     def test_photo_url_present_returns_base64_dict(self, monkeypatch):
         """When participant has photo_url, HTTP GET is performed and bytes returned."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+        )
 
-        participant = {"normalized_name": "garcia_maria", "photo_url": "https://example.com/garcia.jpg"}
+        participant = {
+            "normalized_name": "garcia_maria",
+            "photo_url": "https://example.com/garcia.jpg",
+        }
         cfg = _make_cfg(lookup_return=participant)
 
         fake_bytes = b"\x89PNG\r\n\x1a\n" + b"\x00" * 24
@@ -92,7 +102,9 @@ class TestResolveParticipantPhoto:
 
     def test_photo_url_none_with_logo_returns_logo_bytes(self, tmp_path):
         """When photo_url is NULL but party logo exists, logo bytes returned, no HTTP."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+        )
 
         logo_file = tmp_path / "logo.png"
         logo_bytes = b"\x89PNG\r\n\x1a\n" + b"\xff" * 20
@@ -110,7 +122,10 @@ class TestResolveParticipantPhoto:
 
     def test_photo_url_none_no_logo_returns_empty_result(self):
         """When photo_url is NULL and no party logo, EMPTY_RESULT returned + WARNING logged."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         participant = {"normalized_name": "garcia_maria", "photo_url": None}
         cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
@@ -123,7 +138,10 @@ class TestResolveParticipantPhoto:
 
     def test_participant_not_found_returns_empty_result(self):
         """When lookup returns None (unknown slug), EMPTY_RESULT returned + WARNING logged."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         cfg = _make_cfg(lookup_return=None)
 
@@ -144,9 +162,14 @@ class TestSlugResolution:
 
     def test_slug_hit_returns_photo_source_and_non_empty_b64(self, monkeypatch):
         """Valid slug resolving to a participant with photo_url → source='photo' + non-empty b64."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+        )
 
-        participant = {"slug": "garcia-lopez-maria", "photo_url": "https://example.com/img.jpg"}
+        participant = {
+            "slug": "garcia-lopez-maria",
+            "photo_url": "https://example.com/img.jpg",
+        }
         cfg = _make_cfg(lookup_return=participant)
 
         fake_bytes = b"\x89PNG" + b"\x00" * 20
@@ -158,17 +181,23 @@ class TestSlugResolution:
             result = resolve_participant_photo("garcia-lopez-maria", cfg)
 
         import base64
+
         assert result["source"] == "photo"
         assert result["support_image_b64"] == base64.b64encode(fake_bytes).decode()
 
     def test_absent_slug_none_returns_empty_result_no_lookup(self, caplog):
         """slug=None → EMPTY_RESULT returned + WARNING logged, lookup never called."""
         import logging
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         cfg = _make_cfg(lookup_raises=True)  # lookup raises if called
 
-        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with caplog.at_level(
+            logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+        ):
             result = resolve_participant_photo(None, cfg)
 
         assert result == EMPTY_RESULT
@@ -177,11 +206,16 @@ class TestSlugResolution:
     def test_empty_string_slug_returns_empty_result_no_lookup(self, caplog):
         """slug='' → EMPTY_RESULT + WARNING, lookup never called."""
         import logging
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         cfg = _make_cfg(lookup_raises=True)
 
-        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with caplog.at_level(
+            logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+        ):
             result = resolve_participant_photo("", cfg)
 
         assert result == EMPTY_RESULT
@@ -190,39 +224,60 @@ class TestSlugResolution:
     def test_whitespace_slug_returns_empty_result_no_lookup(self, caplog):
         """slug='   ' → EMPTY_RESULT + WARNING, lookup never called."""
         import logging
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         cfg = _make_cfg(lookup_raises=True)
 
-        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with caplog.at_level(
+            logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+        ):
             result = resolve_participant_photo("   ", cfg)
 
         assert result == EMPTY_RESULT
         assert any(r.levelno >= logging.WARNING for r in caplog.records)
 
-    def test_unknown_slug_lookup_returns_none_gives_empty_result_with_warning(self, caplog):
+    def test_unknown_slug_lookup_returns_none_gives_empty_result_with_warning(
+        self, caplog
+    ):
         """Unknown slug (lookup returns None) → EMPTY_RESULT + WARNING, no raise."""
         import logging
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         cfg = _make_cfg(lookup_return=None)
 
-        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with caplog.at_level(
+            logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+        ):
             result = resolve_participant_photo("nonexistent-slug-xyz", cfg)
 
         assert result == EMPTY_RESULT
         assert any(r.levelno >= logging.WARNING for r in caplog.records)
 
-    def test_photo_url_none_party_logo_map_none_returns_empty_result_no_http(self, caplog):
+    def test_photo_url_none_party_logo_map_none_returns_empty_result_no_http(
+        self, caplog
+    ):
         """photo_url=None + party_logo_map=None → EMPTY_RESULT + WARNING, no HTTP call."""
         import logging
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
         participant = {"slug": "garcia-ana", "photo_url": None}
         cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
 
-        with patch("requests.get") as mock_get, \
-             caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with (
+            patch("requests.get") as mock_get,
+            caplog.at_level(
+                logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+            ),
+        ):
             result = resolve_participant_photo("garcia-ana", cfg)
 
         mock_get.assert_not_called()
@@ -232,16 +287,26 @@ class TestSlugResolution:
     def test_http_404_returns_empty_result_with_warning(self, caplog):
         """HTTP 404 for photo_url (no logo fallback) → EMPTY_RESULT + WARNING."""
         import logging
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
-        participant = {"slug": "garcia-ana", "photo_url": "https://example.com/broken.jpg"}
+        participant = {
+            "slug": "garcia-ana",
+            "photo_url": "https://example.com/broken.jpg",
+        }
         cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
 
         mock_resp = MagicMock()
         mock_resp.status_code = 404
 
-        with patch("requests.get", return_value=mock_resp), \
-             caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with (
+            patch("requests.get", return_value=mock_resp),
+            caplog.at_level(
+                logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+            ),
+        ):
             result = resolve_participant_photo("garcia-ana", cfg)
 
         assert result == EMPTY_RESULT
@@ -251,13 +316,23 @@ class TestSlugResolution:
         """requests.RequestException → EMPTY_RESULT + WARNING."""
         import logging
         import requests as req
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo, EMPTY_RESULT
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+            EMPTY_RESULT,
+        )
 
-        participant = {"slug": "garcia-ana", "photo_url": "https://example.com/broken.jpg"}
+        participant = {
+            "slug": "garcia-ana",
+            "photo_url": "https://example.com/broken.jpg",
+        }
         cfg = _make_cfg(lookup_return=participant, party_logo_map=None)
 
-        with patch("requests.get", side_effect=req.RequestException("timeout")), \
-             caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with (
+            patch("requests.get", side_effect=req.RequestException("timeout")),
+            caplog.at_level(
+                logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+            ),
+        ):
             result = resolve_participant_photo("garcia-ana", cfg)
 
         assert result == EMPTY_RESULT
@@ -268,6 +343,7 @@ class TestSlugResolution:
 # T-02: choose_best_option
 # ---------------------------------------------------------------------------
 
+
 class TestChooseBestOption:
     """choose_best_option(options) selects max score; tie → first option."""
 
@@ -276,8 +352,20 @@ class TestChooseBestOption:
         from congress_videos.modules.thumbnail_generation import choose_best_option
 
         options = [
-            {"label": "option_a", "main_score": 72.0, "output_url": "urlA", "local_path": "/a.png", "style": "s"},
-            {"label": "option_b", "main_score": 85.0, "output_url": "urlB", "local_path": "/b.png", "style": "s"},
+            {
+                "label": "option_a",
+                "main_score": 72.0,
+                "output_url": "urlA",
+                "local_path": "/a.png",
+                "style": "s",
+            },
+            {
+                "label": "option_b",
+                "main_score": 85.0,
+                "output_url": "urlB",
+                "local_path": "/b.png",
+                "style": "s",
+            },
         ]
         best = choose_best_option(options)
         assert best["label"] == "option_b"
@@ -287,8 +375,20 @@ class TestChooseBestOption:
         from congress_videos.modules.thumbnail_generation import choose_best_option
 
         options = [
-            {"label": "option_a", "main_score": 78.0, "output_url": "urlA", "local_path": "/a.png", "style": "s"},
-            {"label": "option_b", "main_score": 78.0, "output_url": "urlB", "local_path": "/b.png", "style": "s"},
+            {
+                "label": "option_a",
+                "main_score": 78.0,
+                "output_url": "urlA",
+                "local_path": "/a.png",
+                "style": "s",
+            },
+            {
+                "label": "option_b",
+                "main_score": 78.0,
+                "output_url": "urlB",
+                "local_path": "/b.png",
+                "style": "s",
+            },
         ]
         best = choose_best_option(options)
         assert best["label"] == "option_a"
@@ -298,8 +398,20 @@ class TestChooseBestOption:
         from congress_videos.modules.thumbnail_generation import choose_best_option
 
         options = [
-            {"label": "option_a", "main_score": 90.0, "output_url": "u", "local_path": "/a.png", "style": "s"},
-            {"label": "option_b", "main_score": 50.0, "output_url": "u", "local_path": "/b.png", "style": "s"},
+            {
+                "label": "option_a",
+                "main_score": 90.0,
+                "output_url": "u",
+                "local_path": "/a.png",
+                "style": "s",
+            },
+            {
+                "label": "option_b",
+                "main_score": 50.0,
+                "output_url": "u",
+                "local_path": "/b.png",
+                "style": "s",
+            },
         ]
         best = choose_best_option(options)
         assert best.get("is_chosen") is True
@@ -320,6 +432,7 @@ def test_art_direct_is_publicly_importable():
 # ---------------------------------------------------------------------------
 # T-04: generate_title
 # ---------------------------------------------------------------------------
+
 
 class TestGenerateTitle:
     """generate_title(summary, best, cfg) contracts."""
@@ -368,6 +481,7 @@ class TestGenerateTitle:
         mock_fn.assert_called_once()
         # Verify no openai direct call was made via module import
         import congress_videos.modules.thumbnail_generation as m
+
         assert not hasattr(m, "openai"), "Module must not import openai directly"
 
     def test_title_exceeding_90_chars_triggers_reprompt(self, mocker):
@@ -436,7 +550,10 @@ class TestGenerateTitle:
         assert isinstance(result, str)
         assert len(result) <= 90
         assert "\U0001f525" not in result
-        assert any("WARNING" in r.levelname or r.levelno >= logging.WARNING for r in caplog.records)
+        assert any(
+            "WARNING" in r.levelname or r.levelno >= logging.WARNING
+            for r in caplog.records
+        )
 
     def test_all_uppercase_title_triggers_reprompt(self, mocker):
         """First response entirely in UPPERCASE triggers a second OpenAI call."""
@@ -481,6 +598,7 @@ class TestGenerateTitle:
 # ---------------------------------------------------------------------------
 # T-04: persist_results
 # ---------------------------------------------------------------------------
+
 
 class TestPersistResults:
     """persist_results(chapter_id, youtube_video_id, title, options, best_label) contracts."""
@@ -539,7 +657,9 @@ class TestPersistResults:
         assert title in chosen_params
         assert True in chosen_params
 
-    def test_non_chosen_option_has_null_title_and_is_chosen_false(self, mock_psycopg2_connection):
+    def test_non_chosen_option_has_null_title_and_is_chosen_false(
+        self, mock_psycopg2_connection
+    ):
         """Non-chosen row has openai_title=None and is_chosen=False."""
         from congress_videos.modules.thumbnail_generation import persist_results
 
@@ -567,8 +687,7 @@ class TestPersistResults:
         persist_results(7, "vid123", "Título", options, "option_a")
 
         all_calls_flat = [
-            c[0][1] if len(c[0]) > 1 else ()
-            for c in mock_cursor.execute.call_args_list
+            c[0][1] if len(c[0]) > 1 else () for c in mock_cursor.execute.call_args_list
         ]
         all_params = [item for row in all_calls_flat for item in row]
         assert "/opt/airflow/data/thumbnails/vid/option_a.png" in all_params
@@ -579,18 +698,24 @@ class TestPersistResults:
 # T-05: TRIANGULATE edge cases
 # ---------------------------------------------------------------------------
 
+
 class TestTriangulateEdgeCases:
     """Edge-case triangulation for resolve_participant_photo and choose_best_option."""
 
     def test_resolve_photo_http_non_200_falls_back_to_logo(self, tmp_path):
         """When HTTP GET for photo returns non-200, fallback to party logo."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+        )
 
         logo_file = tmp_path / "logo.png"
         logo_bytes = b"\x89PNG" + b"\xaa" * 16
         logo_file.write_bytes(logo_bytes)
 
-        participant = {"normalized_name": "garcia_maria", "photo_url": "https://example.com/broken.jpg"}
+        participant = {
+            "normalized_name": "garcia_maria",
+            "photo_url": "https://example.com/broken.jpg",
+        }
         cfg = _make_cfg(lookup_return=participant, party_logo_map=str(logo_file))
 
         mock_resp = MagicMock()
@@ -617,17 +742,24 @@ class TestTriangulateEdgeCases:
 
     def test_resolve_photo_request_exception_falls_back_to_logo(self, tmp_path):
         """When requests.get raises RequestException, fallback to party logo."""
-        from congress_videos.modules.thumbnail_generation import resolve_participant_photo
+        from congress_videos.modules.thumbnail_generation import (
+            resolve_participant_photo,
+        )
         import requests as req
 
         logo_file = tmp_path / "logo.png"
         logo_bytes = b"\x89PNG" + b"\xbb" * 16
         logo_file.write_bytes(logo_bytes)
 
-        participant = {"normalized_name": "garcia_maria", "photo_url": "https://example.com/broken.jpg"}
+        participant = {
+            "normalized_name": "garcia_maria",
+            "photo_url": "https://example.com/broken.jpg",
+        }
         cfg = _make_cfg(lookup_return=participant, party_logo_map=str(logo_file))
 
-        with patch("requests.get", side_effect=req.RequestException("connection refused")):
+        with patch(
+            "requests.get", side_effect=req.RequestException("connection refused")
+        ):
             result = resolve_participant_photo("garcia_maria", cfg)
 
         assert result["source"] == "party_logo"
@@ -717,7 +849,10 @@ class TestArtDirect:
 
     def test_malformed_response_reprompts_once_then_default(self, mocker) -> None:
         """Malformed response (missing keys) → reprompt once → _DEFAULT_ART_BRIEF on second failure."""
-        from congress_videos.modules.thumbnail_generation import art_direct, _DEFAULT_ART_BRIEF
+        from congress_videos.modules.thumbnail_generation import (
+            art_direct,
+            _DEFAULT_ART_BRIEF,
+        )
 
         call_count = {"n": 0}
 
@@ -849,10 +984,118 @@ class TestArtDirect:
         )
         cfg = self._make_cfg()
 
-        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with caplog.at_level(
+            logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+        ):
             art_direct("summary", cfg)
 
         assert any(r.levelno >= logging.WARNING for r in caplog.records)
+
+
+# ---------------------------------------------------------------------------
+# Issue #54: Art-direction audience policy at the completion-provider seam
+# ---------------------------------------------------------------------------
+
+
+class TestArtDirectionAudiencePolicy:
+    """The model receives the manually maintained audience-selection policy."""
+
+    def _make_cfg(self) -> dict:
+        return {
+            "styles": [{"label": "option_a", "layout": "A"}],
+            "participants_lookup": lambda slug: None,
+            "party_logo_map": None,
+        }
+
+    @staticmethod
+    def _valid_brief_response() -> dict:
+        return {
+            "data": {
+                "text": "DEBATE CLAVE",
+                "background": "una calle española",
+                "person": "un ciudadano preocupado, ropa casual",
+                "mood": "urgencia",
+            },
+            "error": None,
+        }
+
+    def _system_prompt_for(self, mocker, debate_summary: str) -> str:
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        completion = mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            return_value=self._valid_brief_response(),
+        )
+        art_direct(debate_summary, self._make_cfg())
+        return completion.call_args.kwargs["system_prompt"]
+
+    def test_default_policy_uses_youtube_analytics_audience_distribution(
+        self, mocker
+    ) -> None:
+        """The provider sees the 80% male and 63% 65+ audience distribution."""
+        system_prompt = self._system_prompt_for(mocker, "Debate presupuestario general")
+
+        assert "80%" in system_prompt
+        assert "63%" in system_prompt
+        assert "65+" in system_prompt
+        assert "persona relatable" in system_prompt.lower()
+        assert "nunca el ponente ni la foto de un participante" in system_prompt.lower()
+
+    def test_policy_source_is_youtube_analytics_and_manually_maintained(
+        self, mocker
+    ) -> None:
+        """Audience figures are an explicit manually maintained YouTube Analytics configuration."""
+        system_prompt = self._system_prompt_for(mocker, "Debate general")
+
+        prompt_lower = system_prompt.lower()
+        assert "youtube analytics" in prompt_lower
+        assert "configuración manual" in prompt_lower
+
+    def test_policy_does_not_use_database_or_live_analytics(self, mocker) -> None:
+        """The provider is told not to query a database, API, or live analytics."""
+        system_prompt = self._system_prompt_for(mocker, "Debate general")
+
+        prompt_lower = system_prompt.lower()
+        assert "no consultes" in prompt_lower
+        assert "base de datos" in prompt_lower
+        assert "api" in prompt_lower
+        assert "analíticas en tiempo real" in prompt_lower
+
+    def test_maternity_topics_override_the_generic_fallback(self, mocker) -> None:
+        """Maternity, pregnancy, and conciliation select a woman of child-bearing age."""
+        system_prompt = self._system_prompt_for(
+            mocker, "Propuesta de conciliación y embarazo"
+        )
+
+        prompt_lower = system_prompt.lower()
+        assert "maternidad, embarazo o conciliación" in prompt_lower
+        assert "mujer en edad de tener hijos" in prompt_lower
+        assert "prevalece sobre la regla general" in prompt_lower
+
+    def test_pensions_topics_override_the_generic_fallback(self, mocker) -> None:
+        """Pensions, dependency, and geriatric healthcare select an older person."""
+        system_prompt = self._system_prompt_for(
+            mocker, "Debate sobre pensiones y dependencia"
+        )
+
+        prompt_lower = system_prompt.lower()
+        assert "pensiones, dependencia o atención sanitaria geriátrica" in prompt_lower
+        assert "persona mayor" in prompt_lower
+        assert "prevalece sobre la regla general" in prompt_lower
+
+    def test_general_or_ambiguous_topics_use_the_probabilistic_fallback(
+        self, mocker
+    ) -> None:
+        """General summaries favor older men while retaining women and younger adults."""
+        system_prompt = self._system_prompt_for(
+            mocker, "Debate general sin tema dominante"
+        )
+
+        prompt_lower = system_prompt.lower()
+        assert "resúmenes generales o ambiguos" in prompt_lower
+        assert "hombres mayores aproximadamente el 80%" in prompt_lower
+        assert "mujeres y adultos jóvenes" in prompt_lower
+        assert "repetición entre hermanos prevalecen" in prompt_lower
 
 
 # ---------------------------------------------------------------------------
@@ -925,7 +1168,9 @@ class TestArtDirectRetry:
             "congress_videos.modules.thumbnail_generation.generate_json_completion",
             side_effect=_capture,
         )
-        art_direct("Debate sobre pensiones", self._make_cfg(), previous_brief=previous_brief)
+        art_direct(
+            "Debate sobre pensiones", self._make_cfg(), previous_brief=previous_brief
+        )
 
         assert captured_prompts, "generate_json_completion must be called"
         assert "REINTENTO" in captured_prompts[0], (
@@ -1023,7 +1268,7 @@ class TestArtDirectionPromptDiversity:
         paren_start = after_mood.find("(")
         paren_end = after_mood.find(")")
         assert paren_start != -1, "mood field must have a parenthetical list"
-        mood_list_text = after_mood[paren_start + 1:paren_end]
+        mood_list_text = after_mood[paren_start + 1 : paren_end]
         first_mood = mood_list_text.split(",")[0].strip().lower()
         assert first_mood != "indignación", (
             f"Mood list MUST NOT start with 'indignación'; first entry is {first_mood!r}"
@@ -1035,12 +1280,16 @@ class TestArtDirectionPromptDiversity:
 
         prompt_lower = ART_DIRECTION_SYSTEM_PROMPT.lower()
         background_idx = prompt_lower.find("background:")
-        assert background_idx != -1, "ART_DIRECTION_SYSTEM_PROMPT must contain 'background:' field"
+        assert background_idx != -1, (
+            "ART_DIRECTION_SYSTEM_PROMPT must contain 'background:' field"
+        )
         after_background = ART_DIRECTION_SYSTEM_PROMPT[background_idx:]
         paren_start = after_background.find("(")
         paren_end = after_background.find(")")
-        assert paren_start != -1, "background field must have a parenthetical example list"
-        bg_list_text = after_background[paren_start + 1:paren_end]
+        assert paren_start != -1, (
+            "background field must have a parenthetical example list"
+        )
+        bg_list_text = after_background[paren_start + 1 : paren_end]
         first_bg = bg_list_text.split(",")[0].strip().lower()
         assert "protesta callejera" not in first_bg, (
             f"Background parenthetical MUST NOT start with 'protesta callejera'; first entry is {first_bg!r}"
@@ -1145,7 +1394,10 @@ class TestTemperatureTuning:
 
         def _capture(system_prompt, user_prompt, **kw):
             captured_kwargs.append(kw)
-            return {"data": {"title": "Un título válido de longitud normal"}, "error": None}
+            return {
+                "data": {"title": "Un título válido de longitud normal"},
+                "error": None,
+            }
 
         mocker.patch(
             "congress_videos.modules.thumbnail_generation.generate_json_completion",
@@ -1170,7 +1422,9 @@ class TestSummariseSiblingBrief:
 
     def test_summarise_sibling_brief_extracts_fields(self) -> None:
         """Should extract background/person/mood/text lines and cap to 200 chars."""
-        from congress_videos.modules.thumbnail_generation import _summarise_sibling_brief
+        from congress_videos.modules.thumbnail_generation import (
+            _summarise_sibling_brief,
+        )
 
         brief = (
             "background: mercado en crisis, gente desesperada\n"
@@ -1186,11 +1440,15 @@ class TestSummariseSiblingBrief:
 
     def test_summarise_sibling_brief_raw_truncates_when_no_match(self) -> None:
         """When no recognisable field prefixes, raw-truncate fallback to 200 chars."""
-        from congress_videos.modules.thumbnail_generation import _summarise_sibling_brief
+        from congress_videos.modules.thumbnail_generation import (
+            _summarise_sibling_brief,
+        )
 
         long_prompt = "x" * 500
         result = _summarise_sibling_brief(long_prompt)
-        assert len(result) <= 200, f"Fallback must truncate to 200 chars, got {len(result)}"
+        assert len(result) <= 200, (
+            f"Fallback must truncate to 200 chars, got {len(result)}"
+        )
         assert result == long_prompt[:200]
 
     def test_summarise_sibling_brief_extracts_from_real_pikzels_format(self) -> None:
@@ -1202,7 +1460,9 @@ class TestSummariseSiblingBrief:
         converging in production, so they must survive summarisation. The TEXT
         phrase must be extracted from its quotes without the styling boilerplate.
         """
-        from congress_videos.modules.thumbnail_generation import _summarise_sibling_brief
+        from congress_videos.modules.thumbnail_generation import (
+            _summarise_sibling_brief,
+        )
 
         brief = (
             "A thick gold (#C9A84C) border frames the entire image edge.\n\n"
@@ -1275,7 +1535,10 @@ class TestArtDirectSiblingInjection:
         art_direct(
             "debate summary",
             self._make_cfg(),
-            sibling_briefs=["brief A sobre plaza pública", "brief B con fábrica cerrada"],
+            sibling_briefs=[
+                "brief A sobre plaza pública",
+                "brief B con fábrica cerrada",
+            ],
         )
 
         assert captured_prompts, "generate_json_completion must be called"
@@ -1360,7 +1623,10 @@ class TestGenerateTitleSiblingInjection:
             "debate summary",
             best,
             self._make_cfg(),
-            sibling_titles=["Title A: La crisis sanitaria", "Title B: El colapso del sistema"],
+            sibling_titles=[
+                "Title A: La crisis sanitaria",
+                "Title B: El colapso del sistema",
+            ],
         )
 
         assert captured_prompts, "generate_json_completion must be called"
@@ -1392,7 +1658,9 @@ class TestGenerateTitleSiblingInjection:
             "sibling_titles block must NOT appear when sibling_titles=None"
         )
 
-    def test_generate_title_no_injection_when_sibling_titles_empty(self, mocker) -> None:
+    def test_generate_title_no_injection_when_sibling_titles_empty(
+        self, mocker
+    ) -> None:
         """When sibling_titles=[], no sibling block in user_prompt."""
         from congress_videos.modules.thumbnail_generation import generate_title
 
@@ -1440,12 +1708,23 @@ class TestFetchRecentThumbnailHistory:
 
     def test_fetch_recent_thumbnail_history_happy_path(self, mocker) -> None:
         """Happy path: 3 rows returned; briefs are summarised, None titles excluded."""
-        from congress_videos.modules.thumbnail_generation import fetch_recent_thumbnail_history
+        from congress_videos.modules.thumbnail_generation import (
+            fetch_recent_thumbnail_history,
+        )
 
         rows = [
-            ("background: mercado en crisis\nperson: ciudadano\nmood: amenaza\ntext: TODO CAE", "Título A"),
-            ("background: hospital lleno\nperson: enfermero\nmood: pérdida\ntext: COLAPSO", "Título B"),
-            ("background: fábrica cerrada\nperson: obrero\nmood: tristeza\ntext: SIN TRABAJO", None),
+            (
+                "background: mercado en crisis\nperson: ciudadano\nmood: amenaza\ntext: TODO CAE",
+                "Título A",
+            ),
+            (
+                "background: hospital lleno\nperson: enfermero\nmood: pérdida\ntext: COLAPSO",
+                "Título B",
+            ),
+            (
+                "background: fábrica cerrada\nperson: obrero\nmood: tristeza\ntext: SIN TRABAJO",
+                None,
+            ),
         ]
 
         cursor_mock = self._make_cursor_mock(rows)
@@ -1469,9 +1748,13 @@ class TestFetchRecentThumbnailHistory:
         for b in briefs:
             assert len(b) <= 200, f"Brief must be ≤ 200 chars, got {len(b)}"
 
-    def test_fetch_recent_thumbnail_history_empty_returns_empty_lists(self, mocker) -> None:
+    def test_fetch_recent_thumbnail_history_empty_returns_empty_lists(
+        self, mocker
+    ) -> None:
         """When cursor returns no rows, return ([], [])."""
-        from congress_videos.modules.thumbnail_generation import fetch_recent_thumbnail_history
+        from congress_videos.modules.thumbnail_generation import (
+            fetch_recent_thumbnail_history,
+        )
 
         cursor_mock = self._make_cursor_mock([])
         conn_mock = self._make_conn_mock(cursor_mock)
@@ -1489,17 +1772,23 @@ class TestFetchRecentThumbnailHistory:
         assert briefs == []
         assert titles == []
 
-    def test_fetch_recent_thumbnail_history_db_error_never_raises(self, mocker, caplog) -> None:
+    def test_fetch_recent_thumbnail_history_db_error_never_raises(
+        self, mocker, caplog
+    ) -> None:
         """When PostgresConnection raises, return ([], []) and log WARNING."""
         import logging
-        from congress_videos.modules.thumbnail_generation import fetch_recent_thumbnail_history
+        from congress_videos.modules.thumbnail_generation import (
+            fetch_recent_thumbnail_history,
+        )
 
         mocker.patch(
             "congress_videos.modules.thumbnail_generation.PostgresConnection",
             side_effect=Exception("DB connection failed"),
         )
 
-        with caplog.at_level(logging.WARNING, logger="congress_videos.modules.thumbnail_generation"):
+        with caplog.at_level(
+            logging.WARNING, logger="congress_videos.modules.thumbnail_generation"
+        ):
             briefs, titles = fetch_recent_thumbnail_history()
 
         assert briefs == []

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -11,25 +11,29 @@ import pytest
 # 7.7 — DAG 2 load test (reap_shorts_uploader)
 # ---------------------------------------------------------------------------
 
-class TestReapShortsUploaderDAGLoads:
 
+class TestReapShortsUploaderDAGLoads:
     def test_reap_shorts_uploader_dag_loads(self):
         from congress_videos.reap_shorts_uploader_dag import dag
+
         assert dag is not None
         assert dag.dag_id == "reap_shorts_uploader"
 
     def test_dag_has_correct_task_count(self):
         from congress_videos.reap_shorts_uploader_dag import dag
+
         # Tasks: get_pending_shorts, generate_metadata, trigger_youtube_upload,
         # mark_shorts_uploaded, check_short_upload_failures
         assert len(dag.tasks) == 5
 
     def test_dag_schedule(self):
         from congress_videos.reap_shorts_uploader_dag import dag
-        assert dag.schedule_interval == '0 8,10,13,15,18,20,22 * * *'
+
+        assert dag.schedule_interval == "0 8,10,13,15,22 * * *"
 
     def test_dag_correct_task_ids(self):
         from congress_videos.reap_shorts_uploader_dag import dag
+
         task_ids = {t.task_id for t in dag.tasks}
         assert "get_pending_shorts" in task_ids
         assert "generate_metadata" in task_ids
@@ -39,6 +43,7 @@ class TestReapShortsUploaderDAGLoads:
 
     def test_dag_correct_dependency_chain(self):
         from congress_videos.reap_shorts_uploader_dag import dag
+
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         t1 = tasks_by_id["get_pending_shorts"]
         t2 = tasks_by_id["generate_metadata"]
@@ -56,12 +61,14 @@ class TestReapShortsUploaderDAGLoads:
 # 7.7 — Title truncation logic (unit test without Airflow context)
 # ---------------------------------------------------------------------------
 
-class TestTriggerYoutubeUploadTitleTruncation:
 
-    def _build_title(self, raw_title: str, suffix: str = " #Shorts", max_len: int = 100) -> str:
+class TestTriggerYoutubeUploadTitleTruncation:
+    def _build_title(
+        self, raw_title: str, suffix: str = " #Shorts", max_len: int = 100
+    ) -> str:
         """Reproduce the exact truncation logic from _trigger_youtube_upload."""
         if len(raw_title) + len(suffix) > max_len:
-            raw_title = raw_title[:max_len - len(suffix)]
+            raw_title = raw_title[: max_len - len(suffix)]
         return raw_title + suffix
 
     def test_short_title_is_not_truncated(self):
@@ -101,6 +108,7 @@ class TestTriggerYoutubeUploadTitleTruncation:
 # 7.8 — DAG 2 task functions (_get_pending_shorts, _mark_shorts_uploaded)
 # ---------------------------------------------------------------------------
 
+
 def _make_ti(xcom_store: dict | None = None):
     from unittest.mock import MagicMock
 
@@ -122,16 +130,19 @@ def _make_ti(xcom_store: dict | None = None):
 
 
 class TestGetPendingShorts:
-
     def test_empty_result_logs_and_pushes_empty_list(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _get_pending_shorts
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
         mock_db.get_pending_shorts.return_value = []
 
         ti = _make_ti()
-        _get_pending_shorts(ti, params={"max_shorts_per_run": 2, "min_virality_score": 0.0})
+        _get_pending_shorts(
+            ti, params={"max_shorts_per_run": 2, "min_virality_score": 0.0}
+        )
 
         assert ti.xcom_store["pending_shorts"] == []
 
@@ -142,33 +153,44 @@ class TestGetPendingShorts:
             {"id": 1, "reap_clip_id": "c-001", "local_file_path": "/data/c1.mp4"},
             {"id": 2, "reap_clip_id": "c-002", "local_file_path": "/data/c2.mp4"},
         ]
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db_cls.return_value.get_pending_shorts.return_value = shorts
 
         ti = _make_ti()
-        _get_pending_shorts(ti, params={"max_shorts_per_run": 3, "min_virality_score": 0.5})
+        _get_pending_shorts(
+            ti, params={"max_shorts_per_run": 3, "min_virality_score": 0.5}
+        )
 
         assert ti.xcom_store["pending_shorts"] == shorts
 
     def test_passes_limit_and_virality_to_db(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _get_pending_shorts
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
         mock_db.get_pending_shorts.return_value = []
 
         ti = _make_ti()
-        _get_pending_shorts(ti, params={"max_shorts_per_run": 5, "min_virality_score": 0.7})
+        _get_pending_shorts(
+            ti, params={"max_shorts_per_run": 5, "min_virality_score": 0.7}
+        )
 
-        mock_db.get_pending_shorts.assert_called_once_with(limit=5, min_virality_score=0.7)
+        mock_db.get_pending_shorts.assert_called_once_with(
+            limit=5, min_virality_score=0.7
+        )
 
 
 class TestMarkShortsUploaded:
-
     def test_successful_upload_calls_mark_short_uploaded(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _mark_shorts_uploaded
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
 
         upload_results = {
@@ -189,7 +211,9 @@ class TestMarkShortsUploaded:
     def test_failed_upload_does_not_call_mark_short_uploaded(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _mark_shorts_uploaded
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
 
         upload_results = {
@@ -211,7 +235,9 @@ class TestMarkShortsUploaded:
     def test_empty_upload_details_no_db_call(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _mark_shorts_uploaded
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
 
         ti = _make_ti({"upload_results": {"upload_details": []}})
@@ -230,7 +256,9 @@ class TestMarkShortsUploaded:
     def test_failed_upload_calls_record_short_upload_failure(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _mark_shorts_uploaded
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
 
         upload_results = {
@@ -247,13 +275,17 @@ class TestMarkShortsUploaded:
         ti = _make_ti({"upload_results": upload_results})
         _mark_shorts_uploaded(ti, params={})
 
-        mock_db.record_short_upload_failure.assert_called_once_with("c-fail", "Upload failed")
+        mock_db.record_short_upload_failure.assert_called_once_with(
+            "c-fail", "Upload failed"
+        )
         mock_db.mark_short_uploaded.assert_not_called()
 
     def test_failed_upload_missing_reap_clip_id_warns_and_skips(self, mocker, caplog):
         from congress_videos.reap_shorts_uploader_dag import _mark_shorts_uploaded
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
 
         upload_results = {
@@ -281,35 +313,41 @@ class TestMarkShortsUploaded:
 # _resolve_speakers unit tests
 # ---------------------------------------------------------------------------
 
-class TestResolveSpeakers:
 
+class TestResolveSpeakers:
     def test_resolve_speakers_uses_key_speakers_first(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
         result = _resolve_speakers({"key_speakers": ["A", "B"], "speakers": ["C"]})
         assert result == ("A", "B")
 
     def test_resolve_speakers_falls_back_to_speakers(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
         result = _resolve_speakers({"speakers": ["X", "Y"]})
         assert result == ("X", "Y")
 
     def test_resolve_speakers_key_speakers_empty_list(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
         result = _resolve_speakers({"key_speakers": [], "speakers": ["Z"]})
         assert result == ("Z", "")
 
     def test_resolve_speakers_empty_both(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
         assert _resolve_speakers({}) == ("", "")
         assert _resolve_speakers({"key_speakers": [], "speakers": []}) == ("", "")
 
     def test_resolve_speakers_single_speaker(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
         result = _resolve_speakers({"key_speakers": ["Solo"]})
         assert result == ("Solo", "")
 
     def test_resolve_speakers_none_values(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
         result = _resolve_speakers({"key_speakers": None, "speakers": None})
         assert result == ("", "")
 
@@ -318,14 +356,18 @@ class TestResolveSpeakers:
 # Prompt template regression tests
 # ---------------------------------------------------------------------------
 
-class TestPromptTemplates:
 
+class TestPromptTemplates:
     def test_old_speakers_placeholder_not_in_template(self):
-        from congress_videos.config.ai_prompts import SHORTS_METADATA_USER_PROMPT_TEMPLATE
+        from congress_videos.config.ai_prompts import (
+            SHORTS_METADATA_USER_PROMPT_TEMPLATE,
+        )
+
         assert "{speakers}" not in SHORTS_METADATA_USER_PROMPT_TEMPLATE
 
     def test_system_prompt_contains_siempre_and_taxonomy_rule(self):
         from congress_videos.config.ai_prompts import SHORTS_METADATA_SYSTEM_PROMPT
+
         assert "SIEMPRE" in SHORTS_METADATA_SYSTEM_PROMPT
         assert "Nivel 1" in SHORTS_METADATA_SYSTEM_PROMPT
 
@@ -334,12 +376,14 @@ class TestPromptTemplates:
 # _generate_metadata integration: prompt contains primary speaker
 # ---------------------------------------------------------------------------
 
-class TestGenerateMetadataPrompt:
 
+class TestGenerateMetadataPrompt:
     def test_generate_metadata_prompt_includes_primary_speaker(self, mocker):
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
         mock_db = mock_db_cls.return_value
         mock_db.get_chapter_metadata.return_value = {
             "key_speakers": ["Pedro Sánchez"],
@@ -362,14 +406,21 @@ class TestGenerateMetadataPrompt:
 
         def fake_generate_json_completion(system_prompt, user_prompt, **kwargs):
             captured["user_prompt"] = user_prompt
-            return {"data": {"title": "Pedro Sánchez debate vivienda", "description": "Desc #Shorts"}}
+            return {
+                "data": {
+                    "title": "Pedro Sánchez debate vivienda",
+                    "description": "Desc #Shorts",
+                }
+            }
 
         mocker.patch(
             "congress_videos.reap_shorts_uploader_dag.generate_json_completion",
             side_effect=fake_generate_json_completion,
         )
 
-        pending_shorts = [{"id": 1, "chapter_id": 42, "local_file_path": "/fake/clip.mp4"}]
+        pending_shorts = [
+            {"id": 1, "chapter_id": 42, "local_file_path": "/fake/clip.mp4"}
+        ]
         ti = _make_ti({"pending_shorts": pending_shorts})
         _generate_metadata(ti)
 
@@ -378,12 +429,15 @@ class TestGenerateMetadataPrompt:
         assert "Pedro Sánchez" in user_prompt
         transcript_pos = user_prompt.find("TRANSCRIPCIÓN")
         speaker_pos = user_prompt.find("Pedro Sánchez")
-        assert speaker_pos < transcript_pos, "primary_speaker must appear before TRANSCRIPCIÓN block"
+        assert speaker_pos < transcript_pos, (
+            "primary_speaker must appear before TRANSCRIPCIÓN block"
+        )
 
 
 # ---------------------------------------------------------------------------
 # Shared factory for chapter metadata dicts used across footer/session tests
 # ---------------------------------------------------------------------------
+
 
 def _make_chapter_metadata(**overrides) -> dict:
     base = {
@@ -409,15 +463,17 @@ def _make_chapter_metadata(**overrides) -> dict:
 # _format_own_channel_footer — unit tests
 # ---------------------------------------------------------------------------
 
-class TestFormatOwnChannelFooter:
 
+class TestFormatOwnChannelFooter:
     def test_returns_own_channel_url_when_id_present(self):
         """Happy path: youtube_video_id set → footer with own-channel URL."""
         from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
 
-        result = _format_own_channel_footer('abc123')
+        result = _format_own_channel_footer("abc123")
 
-        assert result == '\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v=abc123'
+        assert (
+            result == "\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v=abc123"
+        )
 
     def test_returns_empty_string_when_id_is_none(self):
         """Null guard: youtube_video_id=None → no footer (hard contract)."""
@@ -425,82 +481,102 @@ class TestFormatOwnChannelFooter:
 
         result = _format_own_channel_footer(None)
 
-        assert result == ''
+        assert result == ""
 
     def test_returns_empty_string_when_id_is_empty_string(self):
         """Empty-string guard: youtube_video_id='' → no footer."""
         from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
 
-        result = _format_own_channel_footer('')
+        result = _format_own_channel_footer("")
 
-        assert result == ''
+        assert result == ""
 
     def test_source_url_never_appears_in_footer(self):
         """No fallback to source URL — only own-channel URL is used."""
         from congress_videos.reap_shorts_uploader_dag import _format_own_channel_footer
 
-        result = _format_own_channel_footer('yt-XYZ')
+        result = _format_own_channel_footer("yt-XYZ")
 
-        assert 'youtube.com/watch?v=yt-XYZ' in result
-        assert 'Extraído de:' not in result
+        assert "youtube.com/watch?v=yt-XYZ" in result
+        assert "Extraído de:" not in result
 
 
 # ---------------------------------------------------------------------------
 # _generate_metadata — own-channel footer integration tests
 # ---------------------------------------------------------------------------
 
-class TestGenerateMetadataFooter:
 
+class TestGenerateMetadataFooter:
     def test_generate_metadata_footer_appended_when_youtube_video_id_set(self, mocker):
         """AC#4 — description ends with own-channel footer when youtube_video_id is set."""
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
-        mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            youtube_video_id='yt-own-abc',
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
+        mock_db_cls.return_value.get_chapter_metadata.return_value = (
+            _make_chapter_metadata(
+                youtube_video_id="yt-own-abc",
+            )
         )
 
         mocker.patch("os.path.exists", return_value=False)
 
-        pending_shorts = [{"id": 1, "chapter_id": 10, "local_file_path": "/fake/clip.mp4"}]
+        pending_shorts = [
+            {"id": 1, "chapter_id": 10, "local_file_path": "/fake/clip.mp4"}
+        ]
         ti = _make_ti({"pending_shorts": pending_shorts})
         _generate_metadata(ti)
 
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
-        expected_suffix = '\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v=yt-own-abc'
-        assert description.endswith(expected_suffix), f"Description was: {description!r}"
+        expected_suffix = (
+            "\n\n📺 Vídeo completo:\nhttps://www.youtube.com/watch?v=yt-own-abc"
+        )
+        assert description.endswith(expected_suffix), (
+            f"Description was: {description!r}"
+        )
 
     def test_generate_metadata_no_footer_when_youtube_video_id_null(self, mocker):
         """AC#5 — description has NO footer and source URL does NOT appear when youtube_video_id is None."""
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
-        mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            youtube_video_id=None,
-            source_video_url="https://youtube.com/watch?v=source-should-not-appear",
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
+        mock_db_cls.return_value.get_chapter_metadata.return_value = (
+            _make_chapter_metadata(
+                youtube_video_id=None,
+                source_video_url="https://youtube.com/watch?v=source-should-not-appear",
+            )
         )
 
         mocker.patch("os.path.exists", return_value=False)
 
-        pending_shorts = [{"id": 2, "chapter_id": 20, "local_file_path": "/fake/clip.mp4"}]
+        pending_shorts = [
+            {"id": 2, "chapter_id": 20, "local_file_path": "/fake/clip.mp4"}
+        ]
         ti = _make_ti({"pending_shorts": pending_shorts})
         _generate_metadata(ti)
 
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
-        assert '📺 Vídeo completo:' not in description
-        assert 'source-should-not-appear' not in description
+        assert "📺 Vídeo completo:" not in description
+        assert "source-should-not-appear" not in description
 
     def test_generate_metadata_source_fields_not_in_ai_prompt(self, mocker):
         """AC#6 — source_video_title and source_video_url must NOT appear in the AI user prompt."""
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
-        mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            youtube_video_id='yt-prompt-test',
-            source_video_title="Sesión con fuente",
-            source_video_url="https://youtube.com/watch?v=xyz789",
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
+        mock_db_cls.return_value.get_chapter_metadata.return_value = (
+            _make_chapter_metadata(
+                youtube_video_id="yt-prompt-test",
+                source_video_title="Sesión con fuente",
+                source_video_url="https://youtube.com/watch?v=xyz789",
+            )
         )
 
         mocker.patch("os.path.exists", return_value=True)
@@ -516,14 +592,18 @@ class TestGenerateMetadataFooter:
 
         def fake_generate_json_completion(system_prompt, user_prompt, **kwargs):
             captured["user_prompt"] = user_prompt
-            return {"data": {"title": "Título generado", "description": "Descripción AI"}}
+            return {
+                "data": {"title": "Título generado", "description": "Descripción AI"}
+            }
 
         mocker.patch(
             "congress_videos.reap_shorts_uploader_dag.generate_json_completion",
             side_effect=fake_generate_json_completion,
         )
 
-        pending_shorts = [{"id": 3, "chapter_id": 30, "local_file_path": "/fake/clip.mp4"}]
+        pending_shorts = [
+            {"id": 3, "chapter_id": 30, "local_file_path": "/fake/clip.mp4"}
+        ]
         ti = _make_ti({"pending_shorts": pending_shorts})
         _generate_metadata(ti)
 
@@ -539,8 +619,8 @@ class TestGenerateMetadataFooter:
 # _format_session_line — unit tests for all 4 spec scenarios (task 4.1)
 # ---------------------------------------------------------------------------
 
-class TestFormatSessionLine:
 
+class TestFormatSessionLine:
     def test_both_present_returns_full_line(self):
         """Spec scenario: both session_number and session_date present."""
         from datetime import date
@@ -581,29 +661,45 @@ class TestFormatSessionLine:
         from congress_videos.reap_shorts_uploader_dag import _format_session_line
 
         expected_months = [
-            "enero", "febrero", "marzo", "abril", "mayo", "junio",
-            "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+            "enero",
+            "febrero",
+            "marzo",
+            "abril",
+            "mayo",
+            "junio",
+            "julio",
+            "agosto",
+            "septiembre",
+            "octubre",
+            "noviembre",
+            "diciembre",
         ]
         for month_idx, month_name in enumerate(expected_months, start=1):
             result = _format_session_line(None, date(2024, month_idx, 1))
-            assert month_name in result, f"Month {month_idx} expected '{month_name}' in '{result}'"
+            assert month_name in result, (
+                f"Month {month_idx} expected '{month_name}' in '{result}'"
+            )
 
 
 # ---------------------------------------------------------------------------
 # _generate_metadata — session line integration tests (tasks 4.3 and 4.4)
 # ---------------------------------------------------------------------------
 
-class TestGenerateMetadataSessionLine:
 
+class TestGenerateMetadataSessionLine:
     def test_description_ends_with_session_suffix_when_data_available(self, mocker):
         """Task 4.3 — AI success + session data: description ends with Spanish session line."""
         from datetime import date
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
-        mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            session_number=80,
-            session_date=date(2024, 6, 10),
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
+        mock_db_cls.return_value.get_chapter_metadata.return_value = (
+            _make_chapter_metadata(
+                session_number=80,
+                session_date=date(2024, 6, 10),
+            )
         )
 
         mocker.patch("os.path.exists", return_value=True)
@@ -614,37 +710,51 @@ class TestGenerateMetadataSessionLine:
         )
         mocker.patch(
             "congress_videos.reap_shorts_uploader_dag.generate_json_completion",
-            return_value={"data": {"title": "Titulo AI", "description": "Descripcion AI generada"}},
+            return_value={
+                "data": {"title": "Titulo AI", "description": "Descripcion AI generada"}
+            },
         )
 
-        pending_shorts = [{"id": 1, "chapter_id": 10, "local_file_path": "/fake/clip.mp4"}]
+        pending_shorts = [
+            {"id": 1, "chapter_id": 10, "local_file_path": "/fake/clip.mp4"}
+        ]
         ti = _make_ti({"pending_shorts": pending_shorts})
         _generate_metadata(ti)
 
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
         expected_suffix = "\n\n🏛️ Sesión nº 80 del Congreso - 10 de junio de 2024"
-        assert description.endswith(expected_suffix), f"Description was: {description!r}"
+        assert description.endswith(expected_suffix), (
+            f"Description was: {description!r}"
+        )
 
     def test_description_unchanged_when_session_data_null(self, mocker):
         """Task 4.4 — session_number=None + session_date=None: no session suffix appended."""
         from congress_videos.reap_shorts_uploader_dag import _generate_metadata
 
-        mock_db_cls = mocker.patch("congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB")
-        mock_db_cls.return_value.get_chapter_metadata.return_value = _make_chapter_metadata(
-            session_number=None,
-            session_date=None,
+        mock_db_cls = mocker.patch(
+            "congress_videos.reap_shorts_uploader_dag.CongressionalVideoDB"
+        )
+        mock_db_cls.return_value.get_chapter_metadata.return_value = (
+            _make_chapter_metadata(
+                session_number=None,
+                session_date=None,
+            )
         )
 
         mocker.patch("os.path.exists", return_value=False)
 
-        pending_shorts = [{"id": 2, "chapter_id": 20, "local_file_path": "/fake/clip2.mp4"}]
+        pending_shorts = [
+            {"id": 2, "chapter_id": 20, "local_file_path": "/fake/clip2.mp4"}
+        ]
         ti = _make_ti({"pending_shorts": pending_shorts})
         _generate_metadata(ti)
 
         metadata = ti.xcom_store["shorts_metadata"]
         description = metadata[0]["description"]
-        assert "🏛️ Sesión" not in description, f"Unexpected session suffix in: {description!r}"
+        assert "🏛️ Sesión" not in description, (
+            f"Unexpected session suffix in: {description!r}"
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -653,14 +763,20 @@ class TestGenerateMetadataSessionLine:
 
 
 class TestCheckShortUploadFailures:
-
     def test_raises_on_failed_details(self):
-        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+        from congress_videos.reap_shorts_uploader_dag import (
+            _check_short_upload_failures,
+        )
 
         upload_results = {
             "upload_details": [
                 {"reap_clip_id": "c-ok", "youtube_video_id": "yt-ok", "success": True},
-                {"reap_clip_id": "c-fail", "youtube_video_id": None, "success": False, "error": "Upload failed"},
+                {
+                    "reap_clip_id": "c-fail",
+                    "youtube_video_id": None,
+                    "success": False,
+                    "error": "Upload failed",
+                },
             ]
         }
         ti = _make_ti({"upload_results": upload_results})
@@ -668,7 +784,9 @@ class TestCheckShortUploadFailures:
             _check_short_upload_failures(ti, params={})
 
     def test_raises_on_success_with_missing_youtube_id(self):
-        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+        from congress_videos.reap_shorts_uploader_dag import (
+            _check_short_upload_failures,
+        )
 
         upload_results = {
             "upload_details": [
@@ -680,7 +798,9 @@ class TestCheckShortUploadFailures:
             _check_short_upload_failures(ti, params={})
 
     def test_all_success_does_not_raise(self):
-        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+        from congress_videos.reap_shorts_uploader_dag import (
+            _check_short_upload_failures,
+        )
 
         upload_results = {
             "upload_details": [
@@ -692,13 +812,17 @@ class TestCheckShortUploadFailures:
         _check_short_upload_failures(ti, params={})
 
     def test_empty_details_noop(self):
-        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+        from congress_videos.reap_shorts_uploader_dag import (
+            _check_short_upload_failures,
+        )
 
         ti = _make_ti({"upload_results": {"upload_details": []}})
         _check_short_upload_failures(ti, params={})
 
     def test_missing_xcom_raises(self):
-        from congress_videos.reap_shorts_uploader_dag import _check_short_upload_failures
+        from congress_videos.reap_shorts_uploader_dag import (
+            _check_short_upload_failures,
+        )
 
         ti = _make_ti({})
         with pytest.raises(Exception, match="Upload results XCom missing"):

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -30,21 +30,24 @@ def _make_ti(xcom_store: dict | None = None):
 # DAG load + dependency chain
 # ---------------------------------------------------------------------------
 
-class TestYoutubeUploadDagLoads:
 
+class TestYoutubeUploadDagLoads:
     def test_dag_loads(self):
         from congress_videos.youtube_upload_dag import dag
+
         assert dag is not None
         assert dag.dag_id == "congress_youtube_chapter_uploader"
 
     def test_dag_has_thirteen_tasks(self):
         """DAG must have 13 tasks after replacing t3/t4 with 3 new tasks (net +1)."""
         from congress_videos.youtube_upload_dag import dag
+
         assert len(dag.tasks) == 13
 
     def test_expected_task_ids_present(self):
         """New task IDs present; legacy Pillow task IDs absent."""
         from congress_videos.youtube_upload_dag import dag
+
         task_ids = {t.task_id for t in dag.tasks}
         # Core tasks that must still exist
         assert "trigger_youtube_upload" in task_ids
@@ -61,6 +64,7 @@ class TestYoutubeUploadDagLoads:
     def test_chain_t7_t8_backfill_t9(self):
         """New chain: trigger -> mark_uploaded -> backfill -> check_failures."""
         from congress_videos.youtube_upload_dag import dag
+
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         t7 = tasks_by_id["trigger_youtube_upload"]
         t8 = tasks_by_id["mark_chapters_uploaded"]
@@ -74,6 +78,7 @@ class TestYoutubeUploadDagLoads:
     def test_prepare_precedes_generate(self):
         """prepare_thumbnail_config must be upstream of generate_thumbnail."""
         from congress_videos.youtube_upload_dag import dag
+
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         prepare = tasks_by_id["prepare_thumbnail_config"]
         generate = tasks_by_id["generate_thumbnail"]
@@ -84,6 +89,7 @@ class TestYoutubeUploadDagLoads:
     def test_generate_precedes_extract(self):
         """generate_thumbnail must be a direct upstream of extract_chapter_videos."""
         from congress_videos.youtube_upload_dag import dag
+
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         generate = tasks_by_id["generate_thumbnail"]
         extract = tasks_by_id["extract_chapter_videos"]
@@ -94,6 +100,7 @@ class TestYoutubeUploadDagLoads:
     def test_extract_precedes_upload_config(self):
         """extract_chapter_videos must be a direct upstream of prepare_upload_config."""
         from congress_videos.youtube_upload_dag import dag
+
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         extract = tasks_by_id["extract_chapter_videos"]
         upload_config = tasks_by_id["prepare_upload_config"]
@@ -104,6 +111,7 @@ class TestYoutubeUploadDagLoads:
     def test_backfill_after_mark_uploaded(self):
         """backfill_thumbnail_video_id must be downstream of mark_chapters_uploaded."""
         from congress_videos.youtube_upload_dag import dag
+
         tasks_by_id = {t.task_id: t for t in dag.tasks}
         mark = tasks_by_id["mark_chapters_uploaded"]
         backfill = tasks_by_id["backfill_thumbnail_video_id"]
@@ -116,19 +124,23 @@ class TestYoutubeUploadDagLoads:
 # _check_upload_failures
 # ---------------------------------------------------------------------------
 
-class TestCheckUploadFailures:
 
+class TestCheckUploadFailures:
     def test_raises_on_recorded_failures(self):
         from congress_videos.youtube_upload_dag import _check_upload_failures
 
-        ti = _make_ti({"chapter_upload_updates": {"recorded_failures": 1, "failed_updates": 0}})
+        ti = _make_ti(
+            {"chapter_upload_updates": {"recorded_failures": 1, "failed_updates": 0}}
+        )
         with pytest.raises(Exception, match="Chapter upload failures"):
             _check_upload_failures(ti)
 
     def test_raises_on_failed_updates(self):
         from congress_videos.youtube_upload_dag import _check_upload_failures
 
-        ti = _make_ti({"chapter_upload_updates": {"recorded_failures": 0, "failed_updates": 2}})
+        ti = _make_ti(
+            {"chapter_upload_updates": {"recorded_failures": 0, "failed_updates": 2}}
+        )
         with pytest.raises(Exception, match="Chapter upload failures"):
             _check_upload_failures(ti)
 
@@ -142,13 +154,23 @@ class TestCheckUploadFailures:
     def test_noop_on_zeros(self):
         from congress_videos.youtube_upload_dag import _check_upload_failures
 
-        ti = _make_ti({"chapter_upload_updates": {"recorded_failures": 0, "failed_updates": 0}})
+        ti = _make_ti(
+            {"chapter_upload_updates": {"recorded_failures": 0, "failed_updates": 0}}
+        )
         _check_upload_failures(ti)  # should not raise
 
     def test_noop_on_empty_payload_lacking_recorded_failures(self):
         from congress_videos.youtube_upload_dag import _check_upload_failures
 
-        ti = _make_ti({"chapter_upload_updates": {"updated_chapters": 0, "failed_updates": 0, "details": []}})
+        ti = _make_ti(
+            {
+                "chapter_upload_updates": {
+                    "updated_chapters": 0,
+                    "failed_updates": 0,
+                    "details": [],
+                }
+            }
+        )
         _check_upload_failures(ti)  # should not raise
 
 
@@ -156,12 +178,13 @@ class TestCheckUploadFailures:
 # trigger_upload_with_config (t7)
 # ---------------------------------------------------------------------------
 
-class TestTriggerUploadWithConfig:
 
-    def test_schedule_is_three_times_daily(self):
-        """DAG schedule is '0 11,14,17 * * *' — three runs per day (REQ-SCHED-01)."""
+class TestTriggerUploadWithConfig:
+    def test_schedule_is_once_daily_at_19_utc(self):
+        """DAG schedule is '0 19 * * *' — one run daily at 19:00 UTC."""
         from congress_videos.youtube_upload_dag import dag
-        assert dag.schedule_interval == "0 11,14,17 * * *"
+
+        assert dag.schedule_interval == "0 19 * * *"
 
     def test_no_raise_on_child_failure_and_pushes_fallback(self, mocker):
         from congress_videos.youtube_upload_dag import trigger_upload_with_config
@@ -172,19 +195,31 @@ class TestTriggerUploadWithConfig:
         mock_run.execution_date = "2026-07-28T00:00:00+00:00"
         mock_run.refresh_from_db = MagicMock()
 
-        mocker.patch("congress_videos.youtube_upload_dag.trigger_dag_api", return_value=mock_run)
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api", return_value=mock_run
+        )
         mocker.patch("time.sleep")
         mock_xcom = mocker.patch("airflow.models.XCom")
         mock_xcom.get_many.return_value = []
 
-        ti = _make_ti({
-            "upload_config": {
-                "videos": [
-                    {"chapter_id": "c-1", "video_id": "v-1", "video_file": "/c1.mp4"},
-                    {"chapter_id": "c-2", "video_id": "v-2", "video_file": "/c2.mp4"},
-                ]
+        ti = _make_ti(
+            {
+                "upload_config": {
+                    "videos": [
+                        {
+                            "chapter_id": "c-1",
+                            "video_id": "v-1",
+                            "video_file": "/c1.mp4",
+                        },
+                        {
+                            "chapter_id": "c-2",
+                            "video_id": "v-2",
+                            "video_file": "/c2.mp4",
+                        },
+                    ]
+                }
             }
-        })
+        )
 
         result = trigger_upload_with_config(ti, run_id="test_run")
 
@@ -198,26 +233,30 @@ class TestTriggerUploadWithConfig:
 # THRESHOLD_BY_HOUR constant (REQ-THRESH-01/02/03)
 # ---------------------------------------------------------------------------
 
-class TestThresholdByHour:
 
+class TestThresholdByHour:
     def test_constant_exists(self):
         """THRESHOLD_BY_HOUR is importable from the DAG module."""
         from congress_videos.youtube_upload_dag import THRESHOLD_BY_HOUR
+
         assert THRESHOLD_BY_HOUR is not None
 
     def test_threshold_at_11(self):
         """11:00 threshold is 10 (REQ-THRESH-01)."""
         from congress_videos.youtube_upload_dag import THRESHOLD_BY_HOUR
+
         assert THRESHOLD_BY_HOUR[11] == 10
 
     def test_threshold_at_14(self):
         """14:00 threshold is 20 (REQ-THRESH-02)."""
         from congress_videos.youtube_upload_dag import THRESHOLD_BY_HOUR
+
         assert THRESHOLD_BY_HOUR[14] == 20
 
     def test_threshold_at_17(self):
         """17:00 threshold is 0 (REQ-THRESH-03)."""
         from congress_videos.youtube_upload_dag import THRESHOLD_BY_HOUR
+
         assert THRESHOLD_BY_HOUR[17] == 0
 
 
@@ -225,7 +264,10 @@ class TestThresholdByHour:
 # should_upload function (REQ-GATE-01, REQ-THRESH-01/02/03)
 # ---------------------------------------------------------------------------
 
-def _make_context_for_should_upload(queue_size: int, hour: int) -> dict:
+
+def _make_context_for_should_upload(
+    queue_size: int, hour: int, uploads_today: int = 0
+) -> dict:
     """Build a minimal Airflow context for should_upload tests."""
     from datetime import datetime, timezone
     from unittest.mock import MagicMock
@@ -233,29 +275,34 @@ def _make_context_for_should_upload(queue_size: int, hour: int) -> dict:
     logical_date = datetime(2026, 7, 31, hour, 0, 0, tzinfo=timezone.utc)
 
     ti = MagicMock(name="TaskInstance")
-    ti.xcom_pull.return_value = {"queue_size": queue_size, "uploads_today": 0}
+    ti.xcom_pull.return_value = {
+        "queue_size": queue_size,
+        "uploads_today": uploads_today,
+    }
 
     return {"ti": ti, "logical_date": logical_date}
 
 
 class TestShouldUpload:
-
     # 11:00 — threshold 10
     def test_11_queue_10_is_false(self):
         """11:00, queue=10 → False (exactly at threshold, not above) (REQ-THRESH-01)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=10, hour=11)
         assert should_upload(**ctx) is False
 
     def test_11_queue_11_is_true(self):
         """11:00, queue=11 → True (above threshold) (REQ-THRESH-01)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=11, hour=11)
         assert should_upload(**ctx) is True
 
     def test_11_queue_5_is_false(self):
         """11:00, queue=5 → False (below threshold) (REQ-THRESH-01)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=5, hour=11)
         assert should_upload(**ctx) is False
 
@@ -263,12 +310,14 @@ class TestShouldUpload:
     def test_14_queue_20_is_false(self):
         """14:00, queue=20 → False (boundary — exactly at threshold) (REQ-THRESH-02)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=20, hour=14)
         assert should_upload(**ctx) is False
 
     def test_14_queue_21_is_true(self):
         """14:00, queue=21 → True (above threshold) (REQ-THRESH-02)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=21, hour=14)
         assert should_upload(**ctx) is True
 
@@ -276,25 +325,52 @@ class TestShouldUpload:
     def test_17_queue_0_is_false(self):
         """17:00, queue=0 → False (threshold 0, not strictly above) (REQ-THRESH-03)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=0, hour=17)
         assert should_upload(**ctx) is False
 
     def test_17_queue_1_is_true(self):
         """17:00, queue=1 → True (above threshold 0) (REQ-THRESH-03)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=1, hour=17)
         assert should_upload(**ctx) is True
+
+    def test_19_queue_1_is_true(self):
+        """Scheduled 19:00 UTC run uploads when the long-video queue is non-empty."""
+        from congress_videos.youtube_upload_dag import should_upload
+
+        ctx = _make_context_for_should_upload(queue_size=1, hour=19)
+        assert should_upload(**ctx) is True
+
+    def test_19_queue_1_is_false_after_daily_long_upload(self):
+        """A scheduled run cannot upload a second long-form chapter that day."""
+        from congress_videos.youtube_upload_dag import should_upload
+
+        ctx = _make_context_for_should_upload(queue_size=1, hour=19, uploads_today=1)
+
+        assert should_upload(**ctx) is False
+
+    def test_daily_limit_wins_over_manual_hour_threshold(self):
+        """Manual logical dates retain thresholds, but never bypass the daily cap."""
+        from congress_videos.youtube_upload_dag import should_upload
+
+        ctx = _make_context_for_should_upload(queue_size=11, hour=11, uploads_today=1)
+
+        assert should_upload(**ctx) is False
 
     # Unknown hour — defaults to threshold 0
     def test_unknown_hour_queue_0_is_false(self):
         """Unknown hour (e.g. 8), queue=0 → False (defaults to threshold 0)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=0, hour=8)
         assert should_upload(**ctx) is False
 
     def test_unknown_hour_queue_1_is_true(self):
         """Unknown hour (e.g. 8), queue=1 → True (above default threshold 0)."""
         from congress_videos.youtube_upload_dag import should_upload
+
         ctx = _make_context_for_should_upload(queue_size=1, hour=8)
         assert should_upload(**ctx) is True
 
@@ -333,7 +409,10 @@ class TestShouldUpload:
         """data_interval_end exactly 30 min in the past → True (guard uses strict >, not >=)."""
         from datetime import datetime, timedelta, timezone
         from unittest.mock import patch
-        from congress_videos.youtube_upload_dag import should_upload, STALE_RUN_TOLERANCE_MINUTES
+        from congress_videos.youtube_upload_dag import (
+            should_upload,
+            STALE_RUN_TOLERANCE_MINUTES,
+        )
 
         frozen_now = datetime(2026, 7, 31, 12, 0, 0, tzinfo=timezone.utc)
         # exactly at boundary: staleness == tolerance, NOT greater
@@ -353,14 +432,16 @@ class TestShouldUpload:
 # dry_run param
 # ---------------------------------------------------------------------------
 
-class TestDryRun:
 
+class TestDryRun:
     def test_dry_run_skips_upload_and_pushes_empty_results(self):
         """dry_run=True must return early without calling trigger_dag_api."""
         from congress_videos.youtube_upload_dag import trigger_upload_with_config
 
         ti = _make_ti({"upload_config": {"videos": [{"chapter_id": "c-1"}]}})
-        result = trigger_upload_with_config(ti, params={"dry_run": True}, run_id="test_dry")
+        result = trigger_upload_with_config(
+            ti, params={"dry_run": True}, run_id="test_dry"
+        )
 
         assert result is None
         assert ti.xcom_store.get("upload_results") == {"upload_details": []}
@@ -375,7 +456,9 @@ class TestDryRun:
         mock_run.execution_date = "2026-07-31T17:00:00+00:00"
         mock_run.refresh_from_db = MagicMock()
 
-        trigger_mock = mocker.patch("congress_videos.youtube_upload_dag.trigger_dag_api", return_value=mock_run)
+        trigger_mock = mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api", return_value=mock_run
+        )
         mocker.patch("time.sleep")
         mock_xcom = mocker.patch("airflow.models.XCom")
         mock_xcom.get_many.return_value = []
@@ -389,6 +472,7 @@ class TestDryRun:
 # ---------------------------------------------------------------------------
 # Helper: build a minimal chapter dict for thumbnail config tests
 # ---------------------------------------------------------------------------
+
 
 def _make_chapter(
     chapter_id: int = 42,
@@ -405,7 +489,9 @@ def _make_chapter(
         "description": description,
         "session_number": session_number,
         "session_date": session_date,
-        "key_speakers": key_speakers if key_speakers is not None else [{"name": "Ana García"}],
+        "key_speakers": key_speakers
+        if key_speakers is not None
+        else [{"name": "Ana García"}],
         "speakers": speakers if speakers is not None else ["Ana García"],
     }
 
@@ -414,8 +500,8 @@ def _make_chapter(
 # _prepare_thumbnail_config
 # ---------------------------------------------------------------------------
 
-class TestPrepareThumbnailConfig:
 
+class TestPrepareThumbnailConfig:
     def test_resolved_speaker_returns_full_config(self):
         """Raw speaker is resolved once at the boundary and stored as a slug."""
         from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
@@ -481,7 +567,9 @@ class TestPrepareThumbnailConfig:
 
         chapter = _make_chapter(key_speakers=[], speakers=[])
 
-        with patch("congress_videos.youtube_upload_dag.lookup_participant_fuzzy") as lookup:
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy"
+        ) as lookup:
             result = _prepare_thumbnail_config(chapter, MagicMock())
 
         assert result["slug"] is None
@@ -491,6 +579,7 @@ class TestPrepareThumbnailConfig:
 # ---------------------------------------------------------------------------
 # trigger_thumbnail_generation
 # ---------------------------------------------------------------------------
+
 
 class TestTriggerThumbnailGeneration:
     THUMBNAIL_CONFIG = {
@@ -525,7 +614,9 @@ class TestTriggerThumbnailGeneration:
             },
         )
 
-        trigger_thumbnail_generation(_make_ti({"thumbnail_config": self.THUMBNAIL_CONFIG}), run_id="test_run")
+        trigger_thumbnail_generation(
+            _make_ti({"thumbnail_config": self.THUMBNAIL_CONFIG}), run_id="test_run"
+        )
 
         trigger.assert_called_once_with(
             dag_id="generic_thumbnail_generator",
@@ -563,11 +654,15 @@ class TestTriggerThumbnailGeneration:
             run_id="chapter_thumbnail_test_run",
         )
 
-    def test_retrieves_result_by_child_dag_and_exact_triggered_run_id(self, mocker) -> None:
+    def test_retrieves_result_by_child_dag_and_exact_triggered_run_id(
+        self, mocker
+    ) -> None:
         from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
 
         child_run = self._successful_child_run()
-        mocker.patch("congress_videos.youtube_upload_dag.trigger_dag_api", return_value=child_run)
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api", return_value=child_run
+        )
         mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
         get_one = mocker.patch(
             "congress_videos.youtube_upload_dag.XCom.get_one",
@@ -597,7 +692,9 @@ class TestTriggerThumbnailGeneration:
 
         child_run = self._successful_child_run()
         child_run.state = "failed"
-        mocker.patch("congress_videos.youtube_upload_dag.trigger_dag_api", return_value=child_run)
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api", return_value=child_run
+        )
         mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
         get_one = mocker.patch("congress_videos.youtube_upload_dag.XCom.get_one")
         ti = _make_ti({"thumbnail_config": self.THUMBNAIL_CONFIG})
@@ -616,9 +713,13 @@ class TestTriggerThumbnailGeneration:
         from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
 
         child_run = self._successful_child_run()
-        mocker.patch("congress_videos.youtube_upload_dag.trigger_dag_api", return_value=child_run)
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api", return_value=child_run
+        )
         mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
-        mocker.patch("congress_videos.youtube_upload_dag.XCom.get_one", return_value=None)
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.XCom.get_one", return_value=None
+        )
         ti = _make_ti({"thumbnail_config": self.THUMBNAIL_CONFIG})
 
         trigger_thumbnail_generation(ti, run_id="test_run")
@@ -635,16 +736,25 @@ class TestTriggerThumbnailGeneration:
 # _backfill_thumbnail_video_id
 # ---------------------------------------------------------------------------
 
-class TestBackfillThumbnailVideoId:
 
+class TestBackfillThumbnailVideoId:
     def test_calls_update_when_thumbnail_success_true(self):
         """When thumbnail_result.success=True, update_thumbnail_youtube_video_id is called."""
         from congress_videos.youtube_upload_dag import _backfill_thumbnail_video_id
 
-        ti = _make_ti({
-            "thumbnail_result": {"success": True, "chapter_id": 42, "output_path": "/tmp/x.png", "title": "T"},
-            "upload_results": {"upload_details": [{"chapter_id": 42, "youtube_video_id": "abc123"}]},
-        })
+        ti = _make_ti(
+            {
+                "thumbnail_result": {
+                    "success": True,
+                    "chapter_id": 42,
+                    "output_path": "/tmp/x.png",
+                    "title": "T",
+                },
+                "upload_results": {
+                    "upload_details": [{"chapter_id": 42, "youtube_video_id": "abc123"}]
+                },
+            }
+        )
         mock_db = MagicMock()
 
         _backfill_thumbnail_video_id(ti, mock_db)
@@ -657,10 +767,19 @@ class TestBackfillThumbnailVideoId:
         """When thumbnail_result.success=False, update is NOT called."""
         from congress_videos.youtube_upload_dag import _backfill_thumbnail_video_id
 
-        ti = _make_ti({
-            "thumbnail_result": {"success": False, "chapter_id": 42, "output_path": None, "title": None},
-            "upload_results": {"upload_details": [{"chapter_id": 42, "youtube_video_id": "abc123"}]},
-        })
+        ti = _make_ti(
+            {
+                "thumbnail_result": {
+                    "success": False,
+                    "chapter_id": 42,
+                    "output_path": None,
+                    "title": None,
+                },
+                "upload_results": {
+                    "upload_details": [{"chapter_id": 42, "youtube_video_id": "abc123"}]
+                },
+            }
+        )
         mock_db = MagicMock()
 
         _backfill_thumbnail_video_id(ti, mock_db)


### PR DESCRIPTION
## Summary

Two independent concerns, one commit each:

1. **`feat(thumbnail): topic-aware audience demographics`** (issue #54)
   Adds a static YouTube-Analytics-based audience policy to the art-direction prompt so the generated `person` reflects the real viewer profile (~80% male, ~63% aged 65+) instead of defaulting to a young woman in 22/22 briefs. Person imagery represents the viewer/citizen (never the politician), with topic-specific overrides, a general fallback, and anti-repetition priority.

2. **`feat(upload): enforce one daily long upload and de-conflict Shorts schedule`**
   Long-form uploader runs once daily at 19:00 UTC with a hard cap of one long chapter/day (manual/backfill runs can't publish a second). Shorts rescheduled to 08:00/10:00/13:00/15:00/22:00 UTC (dropping 18:00/20:00) to keep a three-hour buffer around the 19:00 long upload.

## Test plan

- [x] `uv run pytest` on the affected suites — **168 passed**
  - `tests/congress_videos/modules/test_thumbnail_generation.py`
  - `tests/congress_videos/test_reap_uploader_dag.py`
  - `tests/congress_videos/test_youtube_upload_dag.py`
- [ ] Docker e2e smoke (`bash scripts/test-airflow-e2e.sh`) before merge — touches `congress_videos/**`