### PR TITLE
fix(e2e): mask untracked agent-tooling dirs in test stack

### DIFF
--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -48,6 +48,16 @@ x-airflow-common: &airflow-common
     # path inside the container hides the host's real .venv from Airflow without
     # touching the host filesystem or the shared root .airflowignore.
     - /opt/airflow/dags/.venv
+    # Same recursive-loop failure mode, different source: untracked agent-tooling
+    # dirs. `.claude/skills/*` and `.pi/skills/*` hold symlinks into `.agents/skills/*`,
+    # so the same real dir is reached via multiple paths and the followlinks walk
+    # raises "Detected recursive loop". Emptying `.agents` here leaves those symlinks
+    # dangling (targets gone), so os.walk skips them and the loop never forms.
+    - /opt/airflow/dags/.agents
+    # `downloads/` holds untracked one-off scripts (e.g. dated thumbnail generators)
+    # with imports absent from the lightweight test image (ModuleNotFoundError). None
+    # of these dirs are tracked, so they are absent from git-sync'd prod.
+    - /opt/airflow/dags/downloads
   # default bridge network only (no external networks)
 
 services:


### PR DESCRIPTION
## Problem

`scripts/test-airflow-e2e.sh` false-fails when untracked local agent-tooling dirs are present. The test compose bind-mounts the whole checkout (`./:/opt/airflow/dags:ro`), so Airflow's DagBag walk (with `followlinks=True`) traverses them:

- `.claude/skills/*` and `.pi/skills/*` hold **symlinks into `.agents/skills/*`**, so the same real dir is reached via multiple paths → `RuntimeError: Detected recursive loop when walking DAG directory`. This crashes `list-import-errors` entirely (the script maps the non-zero exit to an opaque "failed to run" internal error).
- `downloads/` holds untracked one-off scripts (e.g. dated thumbnail generators) importing modules absent from the lightweight test image → `ModuleNotFoundError`.

None of these dirs are tracked, so they never reach git-sync'd prod — this is purely a local-run e2e artifact.

## Fix

Mirror the existing `.venv` tmpfs treatment in `docker-compose.test.yml`: overlay empty tmpfs at `/opt/airflow/dags/.agents` and `/opt/airflow/dags/downloads`. Emptying `.agents` also leaves the `.claude`/`.pi` symlinks dangling, so `os.walk` skips them and the loop never forms. The shared root `.airflowignore` (which also affects prod) is left untouched.

## Test plan

- [x] `bash scripts/test-airflow-e2e.sh` with all cruft dirs (`.agents`, `.claude`, `.pi`, `downloads`) present on host → **`list-import-errors is empty. PASS.`** (exit 0)
- [x] Verified tracked DAGs themselves were always import-clean (parking the dirs manually also yielded `[]`).