### PR TITLE
feat(chapters): shared placeholder set + placeholder-aware speaker selection (PR1/3, #56)

### DIFF
--- a/congress_videos/modules/speaker_helpers.py
+++ b/congress_videos/modules/speaker_helpers.py
@@ -7,6 +7,8 @@ specific to the congressional video processing workflow.
 
 from typing import Dict, List
 
+from congress_videos.modules.speaker_placeholders import is_placeholder
+
 
 def format_speaker_list(
     speakers_info: List[Dict[str, str]],
@@ -15,6 +17,8 @@ def format_speaker_list(
 ) -> str:
     """
     Format a list of speakers into a text representation.
+
+    Entries whose speaker_name is missing or is a known placeholder are skipped.
 
     Args:
         speakers_info: List of dicts with 'speaker_name' and 'role' keys
@@ -29,13 +33,18 @@ def format_speaker_list(
 
     speaker_lines = []
     for speaker in speakers_info[:max_speakers]:
-        name = speaker.get("speaker_name", "Desconocido")
+        name = speaker.get("speaker_name", "")
+        if is_placeholder(name):
+            continue
         role = speaker.get("role", "")
 
         if include_role and role:
             speaker_lines.append(f"- {name} ({role})")
         else:
             speaker_lines.append(f"- {name}")
+
+    if not speaker_lines:
+        return "No hay participantes especificados"
 
     result = "\n".join(speaker_lines)
 
@@ -53,6 +62,8 @@ def format_speaker_context(
     """
     Format speakers into a compact context string for prompts.
 
+    Entries whose speaker_name is missing or is a known placeholder are skipped.
+
     Args:
         speakers_info: List of dicts with 'speaker_name' and 'role' keys
         max_speakers: Maximum number of speakers to include
@@ -66,11 +77,16 @@ def format_speaker_context(
 
     speaker_names = []
     for speaker in speakers_info[:max_speakers]:
-        name = speaker.get("speaker_name", "Unknown")
+        name = speaker.get("speaker_name", "")
+        if is_placeholder(name):
+            continue
         role = speaker.get("role", "")
         if role:
             speaker_names.append(f"{name} ({role})")
         else:
             speaker_names.append(name)
+
+    if not speaker_names:
+        return ""
 
     return f"{prefix}: {', '.join(speaker_names)}"

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -24,6 +24,7 @@ from congress_videos.config.ai_prompts import (
 )
 from congress_videos.modules.participants_db import lookup_participant_fuzzy
 from congress_videos.modules.participants_ingestion import normalize_member_name
+from congress_videos.modules.speaker_placeholders import is_placeholder
 from utils.llm_cache import cached_json_completion
 
 logger = logging.getLogger(__name__)
@@ -56,11 +57,20 @@ def _dedupe_dirty_speakers(
     key_speakers: list[str],
     timeline: list[dict],
 ) -> list[str]:
-    """Return a de-duplicated, ordered list of unique dirty speaker names."""
+    """Return a de-duplicated, ordered list of unique dirty speaker names.
+
+    Placeholder speaker strings (e.g. "Desconocido", "Unknown",
+    "(No especificado)", single-token role abbreviations) are filtered out
+    before deduplication so they are never sent to the normalization pipeline.
+    """
     seen: list[str] = []
     seen_set: set[str] = set()
-    for name in list(speakers) + list(key_speakers) + [e.get("speaker", "") for e in timeline]:
-        if name and name not in seen_set:
+    for name in (
+        list(speakers)
+        + list(key_speakers)
+        + [e.get("speaker", "") for e in timeline]
+    ):
+        if name and not is_placeholder(name) and name not in seen_set:
             seen.append(name)
             seen_set.add(name)
     return seen

--- a/congress_videos/modules/speaker_placeholders.py
+++ b/congress_videos/modules/speaker_placeholders.py
@@ -1,0 +1,117 @@
+"""Shared placeholder-speaker detection for congressional chapter attribution.
+
+Exports
+-------
+PLACEHOLDER_SPEAKERS : frozenset[str]
+    Casefolded canonical set of known placeholder speaker strings.
+is_placeholder(s: str) -> bool
+    Pure, stateless predicate. Returns True when ``s`` is a known placeholder
+    or matches a role-only heuristic. Fail-open: unrecognised shapes → False.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Canonical placeholder set (casefolded, exact)
+# ---------------------------------------------------------------------------
+
+PLACEHOLDER_SPEAKERS: frozenset[str] = frozenset({
+    "desconocido",
+    "unknown",
+    "interviniente no especificado",
+    "(no especificado)",
+    "no especificado",
+    "",
+})
+
+# ---------------------------------------------------------------------------
+# Role-keyword heuristic
+# ---------------------------------------------------------------------------
+# These are role/title tokens that appear in the congressional transcription
+# output when the LLM cannot identify a real name. The regex matches the
+# token as a complete word at the start of the string (case-insensitive).
+# Confirmed against real dirty-speaker samples from ai_prompts.py and the
+# speaker_normalization pipeline.
+
+_ROLE_KEYWORDS = (
+    r"portavoz",
+    r"diputad[oa]",
+    r"senadore?[oa]?",
+    r"president[ea]",
+    r"ministr[oa]",
+    r"secretari[oa]",
+    r"vicesecretari[oa]",
+    r"vicepresidente?",
+    r"viceministr[oa]",
+    r"vocal",
+    r"interventor[a]?",
+    r"interveniente",
+    r"interviniente",
+    r"ponente",
+    r"consejere?[oa]?",
+    r"delegad[oa]",
+    r"coordinadore?[oa]?",
+)
+
+# Compiled pattern: role-keyword covers the ENTIRE string with only
+# lowercase/article suffixes (role-only, no proper name following).
+_ROLE_ONLY_RE = re.compile(
+    r"^(?:" + r"|".join(_ROLE_KEYWORDS) + r")(?:\s+(?:del?\s+[a-záéíóúàèìòùüñ]\w*|los?\s+[a-záéíóúàèìòùüñ]\w*|las?\s+[a-záéíóúàèìòùüñ]\w*|[a-záéíóúàèìòùüñ]\w*))*$",
+    re.IGNORECASE,
+)
+
+# Proper-name suffix: at least one word starting with a Unicode uppercase letter
+# (genuine Titlecase, NOT re.IGNORECASE for the suffix), following a role keyword.
+# If present the string is treated as a real name (fail-open).
+# Note: role keyword itself is matched case-insensitively via a separate prefix group.
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?:" + r"|".join(_ROLE_KEYWORDS) + r")\s+",
+    re.IGNORECASE,
+)
+
+# Uppercase letter set for Titlecase detection (Spanish + Latin Extended).
+_UPPERCASE_CHARS = set("ABCDEFGHIJKLMNOPQRSTUVWXYZÁÉÍÓÚÀÈÌÒÙÜÑ")
+
+
+def is_placeholder(s: str) -> bool:
+    """Return True when ``s`` is a known placeholder or a role-only string.
+
+    Decision rules (in order):
+    1. Strip and casefold; if in PLACEHOLDER_SPEAKERS → True.
+    2. Single-token (no whitespace after strip) → True.
+    3. Matches _ROLE_WITH_NAME_RE (role + proper-name Titlecase suffix) → False
+       (fail-open: real name).
+    4. Matches _ROLE_ONLY_RE → True.
+    5. Everything else → False (fail-open: treat as real name).
+
+    The function is pure and stateless — no I/O, no LLM, no DB.
+    """
+    stripped = s.strip()
+    casefolded = stripped.casefold()
+
+    # Rule 1: exact match in canonical set
+    if casefolded in PLACEHOLDER_SPEAKERS:
+        return True
+
+    # Rule 2: single-token (no whitespace) — e.g. "Portavoz", "PP"
+    if " " not in stripped:
+        return True
+
+    # Rule 3: role keyword + proper-name suffix → fail-open (real name).
+    # Check whether the suffix after the role prefix starts with a Titlecase word
+    # (i.e. first char is uppercase). We test this without re.IGNORECASE on the
+    # suffix to avoid "del" (lowercase d) being mistaken for a proper name.
+    prefix_m = _ROLE_PREFIX_RE.match(stripped)
+    if prefix_m:
+        suffix = stripped[prefix_m.end():]
+        if suffix and suffix[0] in _UPPERCASE_CHARS:
+            return False
+
+    # Rule 4: role-keyword pattern covers the whole string (role-only phrase)
+    if _ROLE_ONLY_RE.match(stripped):
+        return True
+
+    # Rule 5: unrecognised shape → fail-open
+    return False

--- a/congress_videos/reap_shorts_uploader_dag.py
+++ b/congress_videos/reap_shorts_uploader_dag.py
@@ -36,10 +36,27 @@ POSTGRES_SCHEMA = os.getenv("POSTGRES_SCHEMA", "development")
 
 
 def _resolve_speakers(ch: dict) -> tuple[str, str]:
-    speakers = ch.get("key_speakers") or ch.get("speakers") or []
-    if not speakers:
+    """Return (primary_speaker, rest_speakers) filtering placeholders.
+
+    Priority: key_speakers (placeholder-filtered) before speakers
+    (placeholder-filtered). Deduplicates order-preserving. Returns ("", "")
+    when the combined pool is empty after filtering.
+    """
+    from congress_videos.modules.speaker_placeholders import is_placeholder
+
+    key_speakers: list[str] = ch.get("key_speakers") or []
+    speakers: list[str] = ch.get("speakers") or []
+
+    seen: set[str] = set()
+    pool: list[str] = []
+    for name in list(key_speakers) + list(speakers):
+        if not is_placeholder(name) and name not in seen:
+            pool.append(name)
+            seen.add(name)
+
+    if not pool:
         return ("", "")
-    return (speakers[0].strip(), ", ".join(speakers[1:]))
+    return (pool[0].strip(), ", ".join(pool[1:]))
 
 
 _MONTHS = [

--- a/tests/congress_videos/modules/test_speaker_helpers.py
+++ b/tests/congress_videos/modules/test_speaker_helpers.py
@@ -34,22 +34,26 @@ class TestFormatSpeakerList:
         result = format_speaker_list(speakers)
         assert result == "- Ana García"
 
-    def test_single_speaker_missing_name_key_uses_desconocido(self):
+    def test_single_speaker_missing_name_key_omits_placeholder(self):
+        """Task 1.7 RED: format_speaker_list MUST NOT emit 'Desconocido' literal.
+
+        When speaker_name key is missing, the entry should be skipped rather than
+        emitting a hardcoded placeholder string.
+        """
         speakers = [{"role": "Diputado"}]
         result = format_speaker_list(speakers)
-        assert "Desconocido" in result
-        assert "Diputado" in result
+        assert "Desconocido" not in result
 
     def test_multiple_speakers_each_on_own_line(self):
         speakers = [
-            {"speaker_name": "Ana", "role": "Presidenta"},
-            {"speaker_name": "Juan", "role": "Diputado"},
+            {"speaker_name": "Ana García", "role": "Presidenta"},
+            {"speaker_name": "Juan Pérez", "role": "Diputado"},
         ]
         result = format_speaker_list(speakers)
         lines = result.split("\n")
         assert len(lines) == 2
-        assert "Ana" in lines[0]
-        assert "Juan" in lines[1]
+        assert "Ana García" in lines[0]
+        assert "Juan Pérez" in lines[1]
 
     def test_include_role_false_omits_roles(self):
         speakers = [{"speaker_name": "Ana García", "role": "Presidenta"}]
@@ -58,30 +62,30 @@ class TestFormatSpeakerList:
         assert "Ana García" in result
 
     def test_max_speakers_limits_output(self):
-        speakers = [{"speaker_name": f"Speaker{i}", "role": "Rol"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "Rol"} for i in range(5)]
         result = format_speaker_list(speakers, max_speakers=3)
         lines = [line for line in result.split("\n") if line.startswith("-")]
         assert len(lines) == 3
 
     def test_overflow_singular_one_more(self):
         # Exactly max_speakers + 1 → "1 participante más" (singular)
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(4)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(4)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "y 1 participante más" in result
 
     def test_overflow_plural_multiple_more(self):
         # max_speakers + 2 → "2 participantes más" (plural)
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "y 2 participantes más" in result
 
     def test_no_overflow_message_when_exactly_at_max(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(3)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(3)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "más" not in result
 
     def test_overflow_message_with_default_max_10(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(12)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(12)]
         result = format_speaker_list(speakers)
         assert "y 2 participantes más" in result
 
@@ -91,7 +95,7 @@ class TestFormatSpeakerList:
         (10, "participantes"),
     ])
     def test_overflow_singular_plural_parametrized(self, remaining: int, expected_word: str):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(3 + remaining)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(3 + remaining)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert expected_word in result
 
@@ -117,43 +121,48 @@ class TestFormatSpeakerContext:
         assert "Ana García" in result
         assert "()" not in result
 
-    def test_single_speaker_missing_name_key_uses_unknown(self):
+    def test_single_speaker_missing_name_key_omits_placeholder(self):
+        """Task 1.7 RED: format_speaker_context MUST NOT emit 'Unknown' literal.
+
+        When speaker_name key is missing, the entry should be skipped rather than
+        emitting a hardcoded placeholder string.
+        """
         speakers = [{"role": "Diputado"}]
         result = format_speaker_context(speakers)
-        assert "Unknown" in result
+        assert "Unknown" not in result
 
     def test_prefix_is_included(self):
-        speakers = [{"speaker_name": "Ana", "role": "R"}]
+        speakers = [{"speaker_name": "Ana García", "role": "R"}]
         result = format_speaker_context(speakers, prefix="Participan")
         assert result.startswith("Participan:")
 
     def test_custom_prefix(self):
-        speakers = [{"speaker_name": "Ana", "role": "R"}]
+        speakers = [{"speaker_name": "Ana García", "role": "R"}]
         result = format_speaker_context(speakers, prefix="Speakers")
         assert result.startswith("Speakers:")
 
     def test_max_speakers_limits_output(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_context(speakers, max_speakers=2)
-        assert "S2" not in result
-        assert "S3" not in result
+        assert "Orador Numero2" not in result
+        assert "Orador Numero3" not in result
 
     def test_multiple_speakers_joined_by_comma(self):
         speakers = [
-            {"speaker_name": "Ana", "role": "Presidenta"},
-            {"speaker_name": "Juan", "role": "Diputado"},
+            {"speaker_name": "Ana García", "role": "Presidenta"},
+            {"speaker_name": "Juan Pérez", "role": "Diputado"},
         ]
         result = format_speaker_context(speakers)
-        assert "Ana (Presidenta), Juan (Diputado)" in result
+        assert "Ana García (Presidenta), Juan Pérez (Diputado)" in result
 
     def test_default_max_speakers_is_3(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_context(speakers)
-        assert "S3" not in result
-        assert "S4" not in result
+        assert "Orador Numero3" not in result
+        assert "Orador Numero4" not in result
 
     def test_speaker_without_role_no_parentheses(self):
-        speakers = [{"speaker_name": "Ana"}, {"speaker_name": "Juan"}]
+        speakers = [{"speaker_name": "Ana García"}, {"speaker_name": "Juan Pérez"}]
         result = format_speaker_context(speakers)
         assert "()" not in result
-        assert "Ana, Juan" in result
+        assert "Ana García, Juan Pérez" in result

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -185,7 +185,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -201,7 +201,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -218,7 +218,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -250,7 +250,7 @@ class TestAINoMatch:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroSanchezVariant"], [], [],
+                1, ["Pedro Sanchez Variant"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -273,7 +273,7 @@ class TestAINoMatch:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroSanchezVariant"], [], [],
+                1, ["Pedro Sanchez Variant"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -302,7 +302,7 @@ class TestAINeedsManual:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroAmbiguous"], [], [],
+                1, ["Pedro Ambiguo Real"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -322,7 +322,7 @@ class TestAINeedsManual:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroAmbiguous"], [], [],
+                1, ["Pedro Ambiguo Real"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -341,8 +341,8 @@ class TestMultipleSpeakers:
         mock_conn, mock_cursor = mock_db_conn
 
         participant_map = {
-            "Speaker One": _make_participant("Speaker One", "speaker one"),
-            "Speaker Two": _make_participant("Speaker Two", "speaker two"),
+            "Ana Ruiz Pérez": _make_participant("Ana Ruiz Pérez", "ana ruiz perez"),
+            "Juan García López": _make_participant("Juan García López", "juan garcia lopez"),
         }
 
         def fuzzy_side(name, threshold):
@@ -359,22 +359,22 @@ class TestMultipleSpeakers:
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
                 7,
-                ["Speaker One", "Speaker Two", "Unknown"],
+                ["Ana Ruiz Pérez", "Juan García López", "María Fernández Gil"],
                 [],
                 [],
                 mock_conn,
                 _make_config(),
             )
 
-        # One cache row per unique dirty speaker
+        # One cache row per unique dirty speaker (all three are real multi-word names)
         assert len(result.cache_rows) == 3
 
     def test_only_matched_speakers_corrected(self, mock_db_conn):
         mock_conn, mock_cursor = mock_db_conn
 
         def fuzzy_side(name, threshold):
-            if name == "Speaker One":
-                return _make_participant("Speaker One", "speaker one")
+            if name == "Ana Ruiz Pérez":
+                return _make_participant("Ana Ruiz Pérez", "ana ruiz perez")
             return None
 
         ai_result = _make_ai_result("match", confidence=0.90)
@@ -388,16 +388,16 @@ class TestMultipleSpeakers:
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
                 7,
-                ["Speaker One", "Speaker Two", "Unknown"],
+                ["Ana Ruiz Pérez", "Juan García López", "María Fernández Gil"],
                 [],
                 [],
                 mock_conn,
                 _make_config(),
             )
 
-        assert "Speaker One" in result.corrections
-        assert "Speaker Two" not in result.corrections
-        assert "Unknown" not in result.corrections
+        assert "Ana Ruiz Pérez" in result.corrections
+        assert "Juan García López" not in result.corrections
+        assert "María Fernández Gil" not in result.corrections
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +449,85 @@ class TestAICallError:
         assert result.updated is False
         calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
         assert not any("update" in s and "video_chapters" in s for s in calls_sql)
+
+
+# ---------------------------------------------------------------------------
+# T-08: _dedupe_dirty_speakers drops placeholder names (Task 1.7 RED)
+# ---------------------------------------------------------------------------
+
+class TestDedupeDirtySpeakersPlaceholderFilter:
+    """Task 1.7 RED — _dedupe_dirty_speakers must filter placeholders before dedup."""
+
+    def test_desconocido_dropped_from_speakers(self):
+        """'Desconocido' must not appear in the deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Desconocido", "Pedro Sánchez"],
+            [],
+            [],
+        )
+        assert "Desconocido" not in result
+        assert "Pedro Sánchez" in result
+
+    def test_unknown_dropped_from_speakers(self):
+        """'Unknown' must not appear in the deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Unknown", "María López"],
+            [],
+            [],
+        )
+        assert "Unknown" not in result
+        assert "María López" in result
+
+    def test_no_especificado_dropped_from_key_speakers(self):
+        """'(No especificado)' in key_speakers must be filtered."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            [],
+            ["(No especificado)", "Ana Martínez"],
+            [],
+        )
+        assert "(No especificado)" not in result
+        assert "Ana Martínez" in result
+
+    def test_placeholder_in_timeline_speaker_dropped(self):
+        """Placeholder in timeline[].speaker must be filtered."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            [],
+            [],
+            [{"speaker": "Desconocido", "content": "...", "time": "00:01:00"}],
+        )
+        assert "Desconocido" not in result
+
+    def test_all_real_speakers_preserved(self):
+        """Non-placeholder names must still appear in deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Ana Ruiz", "Pedro García"],
+            ["Laura Gómez"],
+            [],
+        )
+        assert "Ana Ruiz" in result
+        assert "Pedro García" in result
+        assert "Laura Gómez" in result
+
+    def test_mix_placeholders_and_real_names(self):
+        """Mixed list: only real names survive, order preserved."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Desconocido", "Ana Ruiz", "Unknown"],
+            ["Pedro García"],
+            [{"speaker": "No especificado", "content": "", "time": "00:00"}],
+        )
+        assert result == ["Ana Ruiz", "Pedro García"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/congress_videos/modules/test_speaker_placeholders.py
+++ b/tests/congress_videos/modules/test_speaker_placeholders.py
@@ -1,0 +1,166 @@
+"""Tests for congress_videos.modules.speaker_placeholders (Task 1.1 RED).
+
+Covers:
+- PLACEHOLDER_SPEAKERS frozenset membership (casefolded exact set)
+- is_placeholder: 5 spec scenarios (exact match, single-token, role-only,
+  role+propername fail-open, unrecognised fail-open)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestPlaceholderSpeakersSet:
+    """PLACEHOLDER_SPEAKERS is a frozenset of casefolded exact placeholder strings."""
+
+    def test_frozenset_is_importable(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert isinstance(PLACEHOLDER_SPEAKERS, frozenset)
+
+    def test_desconocido_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "desconocido" in PLACEHOLDER_SPEAKERS
+
+    def test_unknown_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "unknown" in PLACEHOLDER_SPEAKERS
+
+    def test_interviniente_no_especificado_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "interviniente no especificado" in PLACEHOLDER_SPEAKERS
+
+    def test_no_especificado_parenthesized_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "(no especificado)" in PLACEHOLDER_SPEAKERS
+
+    def test_no_especificado_plain_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "no especificado" in PLACEHOLDER_SPEAKERS
+
+    def test_empty_string_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "" in PLACEHOLDER_SPEAKERS
+
+    def test_real_name_not_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "pedro sánchez" not in PLACEHOLDER_SPEAKERS
+        assert "Ana Martínez" not in PLACEHOLDER_SPEAKERS
+
+
+class TestIsPlaceholderExactMatch:
+    """Scenario: Known placeholder exact match → is_placeholder returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Desconocido",
+        "desconocido",
+        "DESCONOCIDO",
+        "Unknown",
+        "unknown",
+        "UNKNOWN",
+        "Interviniente no especificado",
+        "INTERVINIENTE NO ESPECIFICADO",
+        "(No especificado)",
+        "(NO ESPECIFICADO)",
+        "No especificado",
+        "NO ESPECIFICADO",
+        "",
+    ])
+    def test_exact_placeholder_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderSingleToken:
+    """Scenario: Single-token string with no whitespace → is_placeholder returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Portavoz",
+        "PP",
+        "PSOE",
+        "Diputado",
+        "Diputada",
+        "Senador",
+        "Presidente",
+        "Presidenta",
+        "Ministro",
+        "Ministra",
+        "Secretario",
+        "Vocal",
+        "Interveniente",
+        "Interviniente",
+    ])
+    def test_single_token_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderRoleOnly:
+    """Scenario: Role-keyword prefix without a proper name → returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Presidenta",
+        "Ministro",
+        "Portavoz del grupo",
+        "Diputado del PP",
+    ])
+    def test_role_only_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderRoleWithProperName:
+    """Scenario: Role prefix followed by a proper name → fail-open, returns False."""
+
+    @pytest.mark.parametrize("name", [
+        "Presidente Sánchez",
+        "Ministra González",
+        "Portavoz López",
+        "Diputado Martínez García",
+    ])
+    def test_role_plus_propername_returns_false(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is False, f"Expected is_placeholder({name!r}) == False"
+
+
+class TestIsPlaceholderUnrecognisedFailOpen:
+    """Scenario: Unrecognised shape → fail-open, returns False (real name, not filtered)."""
+
+    @pytest.mark.parametrize("name", [
+        "Ana Martínez",
+        "Pedro López",
+        "Laura Gómez",
+        "María José Rodríguez",
+        "José Antonio Fernández",
+        "Xi Jinping",
+        "Joe Biden",
+        "Cualquier Nombre Real",
+    ])
+    def test_real_name_returns_false(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is False, f"Expected is_placeholder({name!r}) == False"
+
+    def test_whitespace_only_treated_as_placeholder(self):
+        """Whitespace-only strings collapse to empty string → placeholder."""
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder("   ") is True
+
+    def test_none_equivalent_empty_string_is_placeholder(self):
+        """Empty string is in PLACEHOLDER_SPEAKERS."""
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder("") is True

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -316,22 +316,27 @@ class TestMarkShortsUploaded:
 
 class TestResolveSpeakers:
     def test_resolve_speakers_uses_key_speakers_first(self):
+        """key_speakers take priority; speakers adds non-duplicate real names to the pool."""
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": ["A", "B"], "speakers": ["C"]})
-        assert result == ("A", "B")
+        result = _resolve_speakers({
+            "key_speakers": ["Ana García", "Pedro López"],
+            "speakers": ["María Ruiz"],
+        })
+        # Pool: [Ana García, Pedro López, María Ruiz] — key_speakers first, then new speakers
+        assert result == ("Ana García", "Pedro López, María Ruiz")
 
     def test_resolve_speakers_falls_back_to_speakers(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"speakers": ["X", "Y"]})
-        assert result == ("X", "Y")
+        result = _resolve_speakers({"speakers": ["Xose Fernández", "Yolanda Díaz"]})
+        assert result == ("Xose Fernández", "Yolanda Díaz")
 
     def test_resolve_speakers_key_speakers_empty_list(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": [], "speakers": ["Z"]})
-        assert result == ("Z", "")
+        result = _resolve_speakers({"key_speakers": [], "speakers": ["Zoila Martínez"]})
+        assert result == ("Zoila Martínez", "")
 
     def test_resolve_speakers_empty_both(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
@@ -342,14 +347,93 @@ class TestResolveSpeakers:
     def test_resolve_speakers_single_speaker(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": ["Solo"]})
-        assert result == ("Solo", "")
+        result = _resolve_speakers({"key_speakers": ["Pedro Sánchez"]})
+        assert result == ("Pedro Sánchez", "")
 
     def test_resolve_speakers_none_values(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
         result = _resolve_speakers({"key_speakers": None, "speakers": None})
         assert result == ("", "")
+
+    # -------------------------------------------------------------------------
+    # Placeholder-aware _resolve_speakers spec scenarios (Task 1.4 RED)
+    # -------------------------------------------------------------------------
+
+    def test_key_speakers_real_name_wins_over_speakers_placeholder(self):
+        """Spec scenario 1: key_speakers has a real name; speakers[0] is placeholder.
+
+        GIVEN key_speakers=["Ana Martínez"], speakers=["Desconocido", "Pedro López"]
+        THEN  primary="Ana Martínez", secondary="Pedro López"
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Ana Martínez"],
+            "speakers": ["Desconocido", "Pedro López"],
+        })
+        assert result == ("Ana Martínez", "Pedro López"), (
+            f"Expected ('Ana Martínez', 'Pedro López'), got {result!r}"
+        )
+
+    def test_placeholder_at_speakers_index_0_is_skipped(self):
+        """Spec scenario 2: key_speakers empty; speakers[1] is real, speakers[0] is placeholder.
+
+        GIVEN key_speakers=[], speakers=["Portavoz", "Pedro López"]
+        THEN  primary="Pedro López", secondary=""
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": [],
+            "speakers": ["Portavoz", "Pedro López"],
+        })
+        assert result == ("Pedro López", ""), (
+            f"Expected ('Pedro López', ''), got {result!r}"
+        )
+
+    def test_all_placeholders_returns_empty_sentinel(self):
+        """Spec scenario 3: All speakers are placeholders → ("", ""), no crash.
+
+        GIVEN key_speakers=["Desconocido"], speakers=["(No especificado)"]
+        THEN  returns ("", "")
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Desconocido"],
+            "speakers": ["(No especificado)"],
+        })
+        assert result == ("", ""), (
+            f"Expected ('', ''), got {result!r}"
+        )
+
+    def test_both_arrays_empty_returns_empty_sentinel(self):
+        """Spec scenario 4: Both arrays empty → ("", "").
+
+        GIVEN key_speakers=[], speakers=[]
+        THEN  returns ("", "")
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({"key_speakers": [], "speakers": []})
+        assert result == ("", "")
+
+    def test_only_key_speakers_real_speakers_empty(self):
+        """Spec scenario 5: Only key_speakers has a real name; speakers is empty.
+
+        GIVEN key_speakers=["Laura Gómez"], speakers=[]
+        THEN  primary="Laura Gómez", secondary=""
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Laura Gómez"],
+            "speakers": [],
+        })
+        assert result == ("Laura Gómez", ""), (
+            f"Expected ('Laura Gómez', ''), got {result!r}"
+        )
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Contexto

PR **1 de 3** encadenados para el issue #56 (mejorar calidad y enriquecimiento de speaker attribution en `video_chapters`). Estrategia: `feature-branch-chain` → este PR apunta a la rama tracker `feat/issue-56-chapter-speaker-attribution`; PR2 y PR3 colgarán en secuencia; solo el tracker mergea a `dev`.

## Qué hace (PR1)

Ataca la causa raíz del gap 195/427: no existía ningún set de placeholders compartido y el pipeline tomaba `speakers[0]` a ciegas.

- **Nuevo módulo `speaker_placeholders.py`**: `PLACEHOLDER_SPEAKERS` (frozenset casefold) + `is_placeholder(s)` puro/sin I/O, con regla *fail-open* (forma no reconocida multi-token → se trata como nombre real).
- **`_resolve_speakers` reescrito** (`reap_shorts_uploader_dag.py`): arma un pool deduplicado preservando orden — `key_speakers` no-placeholder primero, luego `speakers` no-placeholder — y devuelve `(primary, rest)`. Se acabó el `speakers[0]` ciego. Contrato de tupla intacto para los 7 callers internos.
- **Migración de fallbacks hardcodeados**: se eliminan los literales `"Desconocido"`/`"Unknown"` de `speaker_helpers.py` y se filtran placeholders en `_dedupe_dirty_speakers` antes del dedup (evita llamadas LLM inútiles).

## Testing

Strict TDD (RED → GREEN → REFACTOR). Suite completa: **1894 passed, 1 skipped, 0 failed**, cobertura 86.33%.

## Nota para reviewers

⚠️ La heurística de **token único = placeholder** clasifica siglas de partido sueltas ("PSOE", "PP", "VOX") como placeholder. Es **intencional y spec-consistent** (la spec lista "PP" como single-token → placeholder); la regla fail-open aplica solo a formas multi-token no reconocidas. Se validará el impacto real en el gold-set offline (tarea OE del plan).

## Alcance

No toca PR2 (migración 020 + columna `resolved_participant_slug`) ni PR3 (reestructurar prompt `CHAPTER_IDENTIFICATION` + `_flatten_speakers`).

Parte de #56.