### PR TITLE
feat(chapters): restructure CHAPTER_IDENTIFICATION prompt + flatten speakers (PR3/3, #56)

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -363,6 +363,15 @@ Tu tarea es analizar UN CHUNK de sesión parlamentaria que dura MÁS de 45 minut
 - Máximo 120 minutos por capítulo (solo si es tema único coherente)
 - Si divides, hazlo en pausas naturales (4-5+ segundos de silencio)
 
+FORMATO DE HABLADORES:
+Cada entrada en "speakers" es un objeto con tres campos:
+- speaker_name: nombre completo del hablador (string) o null si no se puede identificar
+- speaker_role: cargo o rol parlamentario (string) o null si no se conoce
+- speaker_confidence: confianza en la identificación (número 0.0-1.0) o null
+
+REGLA CRÍTICA: Usa null para speaker_name cuando el hablador no sea identificable por nombre.
+No uses texto genérico en speaker_name — los valores desconocidos siempre son null.
+
 IMPORTANTE:
 - Prioriza mantener temas completos juntos
 - Solo divide por tiempo si supera 2 horas
@@ -428,7 +437,13 @@ FORMATO DE RESPUESTA:
       "start_time": "HH:MM:SS,mmm",
       "end_time": "HH:MM:SS,mmm",
       "duration_minutes": <número>,
-      "speakers": ["Lista de habladores"],
+      "speakers": [
+        {{
+          "speaker_name": "Nombre completo o null si desconocido",
+          "speaker_role": "Cargo o rol o null",
+          "speaker_confidence": 0.9
+        }}
+      ],
       "topics": ["Lista de temas"]
     }}
   ]
@@ -445,7 +460,12 @@ Output: 1 capítulo completo (≤ 120 min, OK)
       "start_time": "00:00:00,000",
       "end_time": "01:30:00,000",
       "duration_minutes": 90.0,
-      "speakers": ["Portavoz PP", "Presidente Sánchez", "Portavoz Sumar", "Ministra"],
+      "speakers": [
+        {{"speaker_name": "Pedro Sánchez", "speaker_role": "Presidente del Gobierno", "speaker_confidence": 0.95}},
+        {{"speaker_name": "Alberto Núñez Feijóo", "speaker_role": "Líder del PP", "speaker_confidence": 0.95}},
+        {{"speaker_name": null, "speaker_role": "Portavoz Sumar", "speaker_confidence": null}},
+        {{"speaker_name": null, "speaker_role": "Ministra", "speaker_confidence": null}}
+      ],
       "topics": ["Víctimas Dana", "Responsabilidad gobierno", "Ayudas", "Prevención"]
     }}
   ]
@@ -462,7 +482,9 @@ Output: 2 capítulos divididos en pausas naturales
       "start_time": "00:00:00,000",
       "end_time": "01:25:00,000",
       "duration_minutes": 85.0,
-      "speakers": ["..."],
+      "speakers": [
+        {{"speaker_name": null, "speaker_role": "Portavoz PP", "speaker_confidence": null}}
+      ],
       "topics": ["Energía", "Precios luz", "Renovables"]
     }},
     {{
@@ -471,7 +493,9 @@ Output: 2 capítulos divididos en pausas naturales
       "start_time": "01:25:00,000",
       "end_time": "02:45:00,000",
       "duration_minutes": 80.0,
-      "speakers": ["..."],
+      "speakers": [
+        {{"speaker_name": null, "speaker_role": "Portavoz PSOE", "speaker_confidence": null}}
+      ],
       "topics": ["Energía", "Dependencia energética", "Transición"]
     }}
   ]
@@ -487,6 +511,7 @@ Output: 2 capítulos (uno por tema)
 - Solo divide por tiempo si el chunk > 120 minutos
 - Divide en pausas naturales (4-5+ segundos)
 - NUNCA lista vacía - mínimo 1 capítulo
+- speaker_name DEBE ser null (nunca texto genérico) cuando el hablador sea desconocido
 
 Devuelve SOLO el JSON."""
 

--- a/congress_videos/modules/youtube/download.py
+++ b/congress_videos/modules/youtube/download.py
@@ -1327,6 +1327,7 @@ def identify_interesting_chapters(chunk_summaries, chunked_srt_data, target_date
         - videos: List with video_id, chunks_with_chapters (interesting chapters found in each chunk)
     """
     from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+    from utils.ai_chapter_analyzer import _flatten_speakers
     import json
 
     if not chunk_summaries or not chunk_summaries.get('videos'):
@@ -1518,6 +1519,10 @@ def identify_interesting_chapters(chunk_summaries, chunked_srt_data, target_date
                                 chapter.get('start_time'),
                                 chapter.get('end_time'),
                             )
+                            # Flatten structured speaker objects to list[str] so
+                            # video_chapters.speakers TEXT[] stays byte-compatible.
+                            # Also tolerates legacy flat-string form (backward compat).
+                            chapter['speakers'] = _flatten_speakers(chapter.get('speakers', []))
                             valid_chapters.append(chapter)
                         else:
                             logging.warning(

--- a/tests/congress_videos/modules/youtube/test_download.py
+++ b/tests/congress_videos/modules/youtube/test_download.py
@@ -1913,3 +1913,159 @@ class TestDownloadGuardForwarding:
         )
 
         assert spy.call_args.kwargs["guard_live_status"] is False
+
+
+# ---------------------------------------------------------------------------
+# PR3 — _flatten_speakers wired into identify_interesting_chapters (Task 3.7 RED)
+# ---------------------------------------------------------------------------
+
+class TestIdentifyInterestingChaptersFlattenSpeakers:
+    """Assert that identify_interesting_chapters flattens structured speaker
+    objects (new LLM prompt format) to list[str] before returning chapters.
+
+    The 'speakers' field in every interesting_chapter must be list[str]
+    regardless of whether the LLM returned the new object form or the legacy
+    flat-string form — backward compat is required in both paths.
+    """
+
+    def _make_summarized_chunk(self, number=1, duration_minutes=130):
+        return {
+            "chunk_number": number,
+            "start_time": "00:00:00",
+            "end_time": "02:10:00",
+            "duration_seconds": duration_minutes * 60,
+            "duration_minutes": duration_minutes,
+            "speakers": [{"name": "Diputado López", "role": "Diputado"}],
+            "topics": ["Presupuestos"],
+            "summary": "Debate largo sobre presupuestos"
+        }
+
+    def _make_srt_chunk(self, number=1, duration_minutes=130):
+        return {
+            "chunk_number": number,
+            "start_time": "00:00:00",
+            "end_time": "02:10:00",
+            "duration_minutes": duration_minutes,
+            "content": "1\n00:00:01,000 --> 00:00:05,000\nContenido de prueba"
+        }
+
+    def test_structured_speaker_objects_flattened_to_strings(self, mocker):
+        """LLM returns new object-form speakers → chapter['speakers'] is list[str]."""
+        # LLM returns structured speaker objects (new prompt format)
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate Presupuestos",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": [
+                    {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.95},
+                    {"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.3},
+                ],
+                "topics": ["Presupuestos"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        assert result["total_videos"] == 1
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        assert len(chapters) == 1
+        speakers = chapters[0]["speakers"]
+        # Must be flat list[str], not list[dict]
+        assert all(isinstance(s, str) for s in speakers), (
+            f"speakers must be list[str], got: {speakers!r}"
+        )
+        # Null speaker_name must be dropped; real name must be kept
+        assert "Ana López" in speakers
+        assert len(speakers) == 1, "null speaker_name entry must be dropped"
+
+    def test_legacy_flat_string_speakers_pass_through(self, mocker):
+        """LLM returns old flat-string speaker list → chapter['speakers'] unchanged."""
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": ["Ana López", "Pedro García"],
+                "topics": ["Política"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        speakers = chapters[0]["speakers"]
+        assert speakers == ["Ana López", "Pedro García"], (
+            f"flat-string speakers must pass through unchanged, got: {speakers!r}"
+        )
+
+    def test_all_null_speaker_names_yields_empty_list(self, mocker):
+        """LLM returns only null speaker_name objects → speakers list is empty."""
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": [
+                    {"speaker_name": None, "speaker_role": "Portavoz PP", "speaker_confidence": None},
+                    {"speaker_name": None, "speaker_role": "Portavoz PSOE", "speaker_confidence": None},
+                ],
+                "topics": ["Política"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        speakers = chapters[0]["speakers"]
+        assert speakers == [], (
+            f"all-null speaker_name objects must yield empty list, got: {speakers!r}"
+        )

--- a/tests/utils/test_ai_chapter_analyzer.py
+++ b/tests/utils/test_ai_chapter_analyzer.py
@@ -540,3 +540,143 @@ class TestDetectSilenceGapsAdaptive:
 
         assert len(result) == 1
         assert result[0]["gap_duration_seconds"] == pytest.approx(295, rel=1e-2)
+
+
+# --------------------------------------------------------------------------- #
+# _flatten_speakers (PR3 — Task 3.1 RED)
+# --------------------------------------------------------------------------- #
+
+class TestFlattenSpeakers:
+    """Tests for _flatten_speakers: object-form + plain-string tolerance.
+
+    Spec: https://github.com/alozur/airflow-dags/issues/56
+    """
+
+    def test_object_form_real_name_extracted(self):
+        """Object with non-null speaker_name → name extracted to list[str]."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.95}]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López"]
+
+    def test_object_form_null_speaker_name_dropped(self):
+        """Object with speaker_name=null → element dropped from output list."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.3}]
+        result = _flatten_speakers(raw)
+
+        assert result == []
+
+    def test_object_form_empty_string_speaker_name_dropped(self):
+        """Object with speaker_name='' → element dropped (empty is treated as unknown)."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": "", "speaker_role": "Ministro", "speaker_confidence": 0.5}]
+        result = _flatten_speakers(raw)
+
+        assert result == []
+
+    def test_old_flat_string_form_tolerated(self):
+        """Old flat-string list element → passed through unchanged (backward compat)."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = ["Ana López"]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López"]
+
+    def test_mixed_list_only_real_names_kept(self):
+        """Mixed list of objects and strings → only real names kept; nulls dropped."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [
+            {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.9},
+            {"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.2},
+            "Pedro García",  # old flat-string format
+            {"speaker_name": "", "speaker_role": "Presidente", "speaker_confidence": 0.1},
+        ]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López", "Pedro García"]
+
+    def test_empty_list_returns_empty(self):
+        """Empty input → empty output."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        assert _flatten_speakers([]) == []
+
+    def test_multiple_objects_all_real_names(self):
+        """Multiple object entries with real names → all extracted in order."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [
+            {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.9},
+            {"speaker_name": "Pedro García", "speaker_role": "Ministro", "speaker_confidence": 0.8},
+        ]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López", "Pedro García"]
+
+
+# --------------------------------------------------------------------------- #
+# CHAPTER_IDENTIFICATION prompt structure (PR3 — Task 3.4 RED)
+# --------------------------------------------------------------------------- #
+
+class TestChapterIdentificationPromptStructure:
+    """Golden/structural assertions on the CHAPTER_IDENTIFICATION prompts.
+
+    Verifies that the restructured prompt instructs the LLM to return
+    speaker objects with speaker_name/speaker_role/speaker_confidence fields
+    and does NOT use 'Desconocido' as a literal fallback value.
+    """
+
+    def test_system_prompt_contains_speaker_name_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_name' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_name" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_name field"
+        )
+
+    def test_system_prompt_contains_speaker_role_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_role' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_role" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_role field"
+        )
+
+    def test_system_prompt_contains_speaker_confidence_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_confidence' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_confidence" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_confidence field"
+        )
+
+    def test_system_prompt_does_not_use_desconocido_fallback(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must NOT use 'Desconocido' as fallback value."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "Desconocido" not in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must not use 'Desconocido' literal; use null instead"
+        )
+
+    def test_user_prompt_template_contains_speaker_name_field(self):
+        """CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE format section must reference speaker_name."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+
+        assert "speaker_name" in CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE, (
+            "CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must show speaker_name in response format"
+        )
+
+    def test_user_prompt_template_does_not_use_desconocido(self):
+        """CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must NOT use 'Desconocido' literal."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+
+        assert "Desconocido" not in CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE, (
+            "CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must not use 'Desconocido' literal"
+        )

--- a/utils/ai_chapter_analyzer.py
+++ b/utils/ai_chapter_analyzer.py
@@ -391,6 +391,36 @@ def format_seconds_to_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
 
+def _flatten_speakers(raw: list) -> list[str]:
+    """Flatten a speakers list that may contain object-form or plain-string elements.
+
+    Accepts the new structured form returned by the restructured
+    CHAPTER_IDENTIFICATION prompt (list of dicts with ``speaker_name``,
+    ``speaker_role``, ``speaker_confidence``) AND the legacy flat-string
+    form for backward compatibility.
+
+    Rules:
+    - dict with ``speaker_name`` key: include value only when non-null and non-empty.
+    - plain string: include as-is (backward compat with old prompt format).
+    - dict missing ``speaker_name``: skip.
+
+    Args:
+        raw: List of either dicts or strings from LLM speaker field.
+
+    Returns:
+        Flat ``list[str]`` of real speaker names; null/empty names are dropped.
+    """
+    result: list[str] = []
+    for element in raw:
+        if isinstance(element, dict):
+            name = element.get("speaker_name")
+            if name is not None and name != "":
+                result.append(name)
+        elif isinstance(element, str):
+            result.append(element)
+    return result
+
+
 def analyze_chapters_with_ai(
     srt_content: str,
     agenda_content: str,


### PR DESCRIPTION
## Contexto

PR **3 de 3** (final) encadenados para el issue #56. Cuelga de PR2 (#71) — feature-branch-chain. Base: `feat/issue-56-pr2-resolved-slug-column`.

> Nota: muestra los commits de PR1+PR2 hasta que mergeen. Revisar solo `5f796a4`, `12c3b57`, `32d4036`.

## Qué hace (PR3)

Mejora la fuente del dato: el LLM ahora separa nombre propio, cargo y confianza, sin romper el esquema persistido.

- **Prompt `CHAPTER_IDENTIFICATION` reestructurado**: el LLM devuelve `[{speaker_name, speaker_role, speaker_confidence}]` con `null` para nombre desconocido (en vez del fallback `"Desconocido"`).
- **`_flatten_speakers`** (`utils/ai_chapter_analyzer.py`): aplana la forma rica a `list[str]` **antes de persistir** — descarta objetos con `speaker_name` null/vacío y tolera la forma vieja de string plano (rollback-safe).
- **Wiring** en `identify_interesting_chapters` (`download.py`): el flatten se aplica en el ensamblado de `valid_chapters`, antes de la capa de persistencia.

## Compatibilidad

`video_chapters.speakers TEXT[]` queda **byte-idéntico** — la forma de objeto es puramente interna al pipeline Python. 13 schema tests + 128 migration tests verdes.

## Testing

Strict TDD. 16 tests nuevos. Suite completa: **1931 passed, 1 skipped, 0 failed**, cobertura 86.43%.

## Follow-up (fuera de scope)

⚠️ El *skip-path* (chunks ≤ 120 min) en `download.py:1409` usa fallback `'Unknown'` si un dict de speaker del `CHUNK_SUMMARY` no trae `name`. Es pre-existente (PR3 no lo toca) y ya queda mitigado porque PR1 sumó `"Unknown"` al set de placeholders → se filtra downstream. Vale un issue de follow-up para removerlo/gatearlo explícitamente.

## Evaluación offline pendiente

Las tareas OE.1–OE.3 (gold-set etiquetado a mano para medir el criterio ≥70%) son post-merge y no bloquean.

Cierra #56.