### PR TITLE
feat(chapters): resolved_participant_slug column + backfill + async fill (PR2/3, #56)

### DIFF
--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1319,6 +1319,7 @@ class CongressionalVideoDB:
         speakers: list,
         key_speakers: list,
         timeline: list,
+        resolved_participant_slug: str | None = None,
     ) -> None:
         """Overwrite the speakers, key_speakers and timeline JSONB for a chapter.
 
@@ -1330,26 +1331,46 @@ class CongressionalVideoDB:
             speakers: Updated list of speaker display names.
             key_speakers: Updated list of key speaker display names.
             timeline: Updated list of timeline dicts (each has 'speaker' field).
+            resolved_participant_slug: When provided, also writes the FK column
+                ``resolved_participant_slug`` linking this chapter to a verified
+                ``congress_participants`` row. Omit (or pass None) to leave the
+                column unchanged.
         """
         chapters_table = self.pg_conn.get_qualified_table("video_chapters")
 
         with self.pg_conn.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    f"""
-                    UPDATE {chapters_table}
-                    SET speakers = %s,
-                        key_speakers = %s,
-                        timeline = %s::jsonb,
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE chapter_id = %s
-                    """,
-                    (speakers, key_speakers, json.dumps(timeline), chapter_id),
-                )
+                if resolved_participant_slug is not None:
+                    cur.execute(
+                        f"""
+                        UPDATE {chapters_table}
+                        SET speakers = %s,
+                            key_speakers = %s,
+                            timeline = %s::jsonb,
+                            resolved_participant_slug = %s,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE chapter_id = %s
+                        """,
+                        (speakers, key_speakers, json.dumps(timeline),
+                         resolved_participant_slug, chapter_id),
+                    )
+                else:
+                    cur.execute(
+                        f"""
+                        UPDATE {chapters_table}
+                        SET speakers = %s,
+                            key_speakers = %s,
+                            timeline = %s::jsonb,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE chapter_id = %s
+                        """,
+                        (speakers, key_speakers, json.dumps(timeline), chapter_id),
+                    )
                 logger.info(
                     "update_chapter_speakers: updated chapter %d "
-                    "(%d speakers, %d key_speakers, %d timeline entries)",
+                    "(%d speakers, %d key_speakers, %d timeline entries%s)",
                     chapter_id, len(speakers), len(key_speakers), len(timeline),
+                    f", slug={resolved_participant_slug!r}" if resolved_participant_slug else "",
                 )
 
     def get_processed_video_ids(self, video_ids: list[str]) -> set[str]:

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -47,6 +47,10 @@ class NormalizationResult:
     updated: bool = False
     """True if video_chapters was written back (at least one match confirmed)."""
 
+    resolved_participant_slug: str | None = None
+    """Slug of the first confirmed matched participant, derived LLM-free from
+    the candidate's normalized_name.  None when no match was confirmed."""
+
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -221,11 +225,12 @@ def normalize_chapter_speakers(
             # Map AI decision to cache status
             if decision == "match":
                 canonical = candidate["display_name"]
+                normalized_name = candidate.get("normalized_name") or ""
                 _upsert_cache_row(
                     cursor, chapter_id, dirty,
                     status="matched",
                     canonical_speaker=canonical,
-                    participant_normalized_name=candidate.get("normalized_name"),
+                    participant_normalized_name=normalized_name or None,
                     confidence_score=confidence,
                 )
                 result.cache_rows.append({
@@ -235,6 +240,11 @@ def normalize_chapter_speakers(
                     "confidence_score": confidence,
                 })
                 result.corrections[dirty] = canonical
+                # Derive slug LLM-free from the authoritative normalized_name.
+                # slug = REPLACE(normalized_name, ' ', '-') — same formula as migration 018.
+                # Record only the first matched speaker's slug for this chapter.
+                if result.resolved_participant_slug is None and normalized_name:
+                    result.resolved_participant_slug = normalized_name.replace(" ", "-")
                 logger.info(
                     "normalize_chapter_speakers: matched %r -> %r (chapter %d, confidence=%.2f)",
                     dirty, canonical, chapter_id, confidence or 0.0,
@@ -261,21 +271,38 @@ def normalize_chapter_speakers(
             new_key_speakers = _apply_corrections(key_speakers, result.corrections)
             new_timeline = _apply_corrections_to_timeline(timeline, result.corrections)
 
-            cursor.execute(
-                f"""
-                UPDATE {_CHAPTERS_TABLE}
-                SET speakers     = %s,
-                    key_speakers = %s,
-                    timeline     = %s::jsonb,
-                    updated_at   = CURRENT_TIMESTAMP
-                WHERE chapter_id = %s
-                """,
-                (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
-            )
+            if result.resolved_participant_slug is not None:
+                cursor.execute(
+                    f"""
+                    UPDATE {_CHAPTERS_TABLE}
+                    SET speakers     = %s,
+                        key_speakers = %s,
+                        timeline     = %s::jsonb,
+                        resolved_participant_slug = %s,
+                        updated_at   = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (new_speakers, new_key_speakers, json.dumps(new_timeline),
+                     result.resolved_participant_slug, chapter_id),
+                )
+            else:
+                cursor.execute(
+                    f"""
+                    UPDATE {_CHAPTERS_TABLE}
+                    SET speakers     = %s,
+                        key_speakers = %s,
+                        timeline     = %s::jsonb,
+                        updated_at   = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
+                )
             result.updated = True
             logger.info(
-                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d",
+                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d%s",
                 len(result.corrections), chapter_id,
+                f" (slug={result.resolved_participant_slug!r})"
+                if result.resolved_participant_slug else "",
             )
 
     return result

--- a/congress_videos/sql/migrations/020_add_resolved_participant_slug.sql
+++ b/congress_videos/sql/migrations/020_add_resolved_participant_slug.sql
@@ -1,0 +1,39 @@
+-- Migration 020: Add resolved_participant_slug column to video_chapters
+-- Created: 2026-08-11
+-- Depends on: 018_add_participant_slug.sql (congress_participants.slug must exist)
+--             017_create_speaker_normalization_cache.sql
+--
+-- Adds a nullable FK column linking a chapter to a verified congress_participants row.
+-- Fill is LLM-free and async: normalize_chapter_speakers writes the slug after
+-- confirming a 'matched' cache entry. NULL is the honest unresolved state.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- Runner sets search_path before executing, so table names are UNQUALIFIED.
+--
+-- One-time backfill: fills rows whose chapter_id appears in speaker_normalization_cache
+-- with status='matched' and whose resolved_participant_slug is currently NULL.
+-- The JOIN through congress_participants guarantees FK integrity: only slugs that
+-- exist in congress_participants are written; rows with no matching slug are skipped.
+--
+-- Rollback: DROP COLUMN IF EXISTS resolved_participant_slug (additive/nullable, safe).
+
+-- 1) Add nullable column (idempotent).
+ALTER TABLE video_chapters
+    ADD COLUMN IF NOT EXISTS resolved_participant_slug TEXT
+        REFERENCES congress_participants(slug);
+
+-- 2) Create an index for FK lookups / downstream JOINs (idempotent).
+CREATE INDEX IF NOT EXISTS idx_video_chapters_resolved_participant_slug
+    ON video_chapters (resolved_participant_slug);
+
+-- 3) One-time idempotent backfill: set slug for matched cache rows where not yet set.
+--    JOIN congress_participants guarantees only valid slugs are written (FK integrity).
+--    WHERE IS NULL makes this a no-op for already-filled rows.
+UPDATE video_chapters vc
+    SET resolved_participant_slug = cp.slug
+    FROM speaker_normalization_cache snc
+    JOIN congress_participants cp
+        ON cp.normalized_name = snc.participant_normalized_name
+    WHERE snc.chapter_id = vc.chapter_id
+      AND snc.status = 'matched'
+      AND vc.resolved_participant_slug IS NULL;

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -531,6 +531,168 @@ class TestDedupeDirtySpeakersPlaceholderFilter:
 
 
 # ---------------------------------------------------------------------------
+# T-09 (Task 2.3 RED): update_chapter_speakers — optional resolved_participant_slug param
+# ---------------------------------------------------------------------------
+
+class TestUpdateChapterSpeakersSlugParam:
+    """Task 2.3 RED — update_chapter_speakers must accept and write resolved_participant_slug.
+
+    Tests the Database.update_chapter_speakers method in database.py.
+    """
+
+    def test_slug_written_when_provided(self, mock_psycopg2_connection):
+        """When resolved_participant_slug is provided, it must be included in the UPDATE."""
+        _, mock_conn, mock_cursor = mock_psycopg2_connection
+
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        db.update_chapter_speakers(
+            chapter_id=42,
+            speakers=["Pedro Sánchez"],
+            key_speakers=["Pedro Sánchez"],
+            timeline=[],
+            resolved_participant_slug="pedro-sanchez",
+        )
+
+        # Find the UPDATE call and assert resolved_participant_slug appears in it
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" in sql, (
+            "resolved_participant_slug column must be in the UPDATE SQL"
+        )
+        # Verify the slug value is in the params
+        params = update_calls[0].args[1]
+        assert "pedro-sanchez" in params, (
+            "resolved_participant_slug value must be passed as a parameter"
+        )
+
+    def test_slug_not_written_when_none(self, mock_psycopg2_connection):
+        """When resolved_participant_slug is None (default), it must NOT appear in UPDATE SQL."""
+        _, mock_conn, mock_cursor = mock_psycopg2_connection
+
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        db.update_chapter_speakers(
+            chapter_id=99,
+            speakers=["Ana López"],
+            key_speakers=[],
+            timeline=[],
+        )
+
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" not in sql, (
+            "resolved_participant_slug must not be in the UPDATE SQL when not provided"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-10 (Task 2.5 RED): normalize_chapter_speakers — slug fill on matched entry
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChapterSpeakersSlugFill:
+    """Task 2.5 RED — normalize_chapter_speakers must write resolved_participant_slug on match.
+
+    After AI confirms 'match', the function derives the slug from the candidate's
+    normalized_name and writes it via update_chapter_speakers (or direct UPDATE).
+    No LLM call is triggered by the slug fill itself.
+    """
+
+    def test_matched_cache_entry_triggers_slug_write(self, mock_db_conn):
+        """A confirmed 'matched' cache entry must write resolved_participant_slug."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            normalize_chapter_speakers(
+                42, ["Pedro Sanchez"], ["Pedro Sanchez"], [],
+                mock_conn, _make_config()
+            )
+
+        # The bulk UPDATE on video_chapters must include resolved_participant_slug
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" in sql, (
+            "resolved_participant_slug must be set in the UPDATE after a matched entry"
+        )
+        params = update_calls[0].args[1]
+        # Slug derived from normalized_name "pedro sanchez" → "pedro-sanchez"
+        assert "pedro-sanchez" in params, (
+            "slug 'pedro-sanchez' must be passed as a parameter in the UPDATE"
+        )
+
+    def test_unresolved_chapter_slug_stays_null(self, mock_db_conn):
+        """When there is no match, resolved_participant_slug must not be written."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                99, ["Unknown Speaker"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # No UPDATE should have been issued (no match, no write)
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert not update_calls, (
+            "UPDATE video_chapters must NOT be called when there is no match"
+        )
+
+    def test_no_llm_call_on_slug_fill_path(self, mock_db_conn):
+        """Slug fill must not trigger any additional LLM calls beyond the match itself."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result) as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            normalize_chapter_speakers(
+                42, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # cached_json_completion called exactly once (for the match decision only)
+        assert mock_ai.call_count == 1, (
+            "cached_json_completion must be called exactly once — slug fill is LLM-free"
+        )
+
+
+# ---------------------------------------------------------------------------
 # T-07 (Bonus from task description): ENABLED=False → immediate return
 # ---------------------------------------------------------------------------
 

--- a/tests/congress_videos/sql/test_migration_020.py
+++ b/tests/congress_videos/sql/test_migration_020.py
@@ -1,0 +1,110 @@
+"""[RED] Test: migration 020 — add resolved_participant_slug to video_chapters.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, column added idempotently, FK references congress_participants(slug),
+index created, backfill is idempotent (WHERE slug IS NULL), unqualified table names.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "020_add_resolved_participant_slug.sql"
+)
+
+
+class TestMigration020FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration020ColumnDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_adds_column_if_not_exists(self):
+        """Migration must use ADD COLUMN IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG" in sql
+
+    def test_column_is_text(self):
+        """resolved_participant_slug column must be TEXT type."""
+        sql = self._sql().upper()
+        # ADD COLUMN IF NOT EXISTS resolved_participant_slug TEXT
+        assert re.search(r"RESOLVED_PARTICIPANT_SLUG\s+TEXT", sql)
+
+    def test_column_references_congress_participants_slug(self):
+        """Column must have FK REFERENCES congress_participants(slug)."""
+        sql = self._sql()
+        assert "REFERENCES congress_participants(slug)" in sql
+
+    def test_creates_index_if_not_exists(self):
+        """Migration must create an index with CREATE INDEX IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "CREATE INDEX IF NOT EXISTS" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG" in sql
+
+
+class TestMigration020Backfill:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_backfill_updates_video_chapters(self):
+        """Backfill must UPDATE video_chapters."""
+        sql = self._sql().upper()
+        assert "UPDATE VIDEO_CHAPTERS" in sql
+
+    def test_backfill_joins_speaker_normalization_cache(self):
+        """Backfill must JOIN speaker_normalization_cache."""
+        sql = self._sql().upper()
+        assert "SPEAKER_NORMALIZATION_CACHE" in sql
+
+    def test_backfill_joins_congress_participants(self):
+        """Backfill must JOIN congress_participants to get authoritative slug."""
+        sql = self._sql().upper()
+        assert "CONGRESS_PARTICIPANTS" in sql
+
+    def test_backfill_filters_matched_status(self):
+        """Backfill must only apply to cache rows with status='matched'."""
+        sql = self._sql()
+        assert "'matched'" in sql or "= 'matched'" in sql
+
+    def test_backfill_is_idempotent_null_guard(self):
+        """Backfill WHERE clause must guard with IS NULL to avoid overwriting filled rows."""
+        sql = self._sql().upper()
+        assert "IS NULL" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG IS NULL" in sql
+
+    def test_backfill_sets_cp_slug(self):
+        """Backfill must set resolved_participant_slug to cp.slug (authoritative FK source)."""
+        sql = self._sql()
+        # Accepts either 'cp.slug' or aliased equivalent
+        assert "cp.slug" in sql or "congress_participants.slug" in sql
+
+
+class TestMigration020TableNames:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_no_schema_qualified_table_names(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        content = self._sql()
+        assert not re.search(r"\bpublic\.video_chapters\b", content)
+        assert not re.search(r"\bpublic\.congress_participants\b", content)
+        assert not re.search(r"\bpublic\.speaker_normalization_cache\b", content)


### PR DESCRIPTION
PR **2 de 3** para #56 (reemplaza al #71, cerrado automáticamente al borrar la rama base de PR1 durante el merge de la cadena). Base ahora: rama tracker.

## Qué hace (PR2)
- **Migración 020**: `resolved_participant_slug TEXT REFERENCES congress_participants(slug)` + índice, idempotente. Backfill sin LLM vía JOIN a `speaker_normalization_cache` (status `matched`) → `congress_participants`, con guard `WHERE ... IS NULL`.
- **`update_chapter_speakers`**: parámetro opcional `resolved_participant_slug` (retrocompatible).
- **Fill async** en `normalize_chapter_speakers` tras match confirmado, fuera de cualquier path de LLM.

Strict TDD · suite 1915 passed · verify PASS. Rollback: `DROP COLUMN IF EXISTS resolved_participant_slug`. Parte de #56.