### PR TITLE
feat(chapters): mejorar speaker attribution en video_chapters (#56)

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -363,6 +363,15 @@ Tu tarea es analizar UN CHUNK de sesión parlamentaria que dura MÁS de 45 minut
 - Máximo 120 minutos por capítulo (solo si es tema único coherente)
 - Si divides, hazlo en pausas naturales (4-5+ segundos de silencio)
 
+FORMATO DE HABLADORES:
+Cada entrada en "speakers" es un objeto con tres campos:
+- speaker_name: nombre completo del hablador (string) o null si no se puede identificar
+- speaker_role: cargo o rol parlamentario (string) o null si no se conoce
+- speaker_confidence: confianza en la identificación (número 0.0-1.0) o null
+
+REGLA CRÍTICA: Usa null para speaker_name cuando el hablador no sea identificable por nombre.
+No uses texto genérico en speaker_name — los valores desconocidos siempre son null.
+
 IMPORTANTE:
 - Prioriza mantener temas completos juntos
 - Solo divide por tiempo si supera 2 horas
@@ -428,7 +437,13 @@ FORMATO DE RESPUESTA:
       "start_time": "HH:MM:SS,mmm",
       "end_time": "HH:MM:SS,mmm",
       "duration_minutes": <número>,
-      "speakers": ["Lista de habladores"],
+      "speakers": [
+        {{
+          "speaker_name": "Nombre completo o null si desconocido",
+          "speaker_role": "Cargo o rol o null",
+          "speaker_confidence": 0.9
+        }}
+      ],
       "topics": ["Lista de temas"]
     }}
   ]
@@ -445,7 +460,12 @@ Output: 1 capítulo completo (≤ 120 min, OK)
       "start_time": "00:00:00,000",
       "end_time": "01:30:00,000",
       "duration_minutes": 90.0,
-      "speakers": ["Portavoz PP", "Presidente Sánchez", "Portavoz Sumar", "Ministra"],
+      "speakers": [
+        {{"speaker_name": "Pedro Sánchez", "speaker_role": "Presidente del Gobierno", "speaker_confidence": 0.95}},
+        {{"speaker_name": "Alberto Núñez Feijóo", "speaker_role": "Líder del PP", "speaker_confidence": 0.95}},
+        {{"speaker_name": null, "speaker_role": "Portavoz Sumar", "speaker_confidence": null}},
+        {{"speaker_name": null, "speaker_role": "Ministra", "speaker_confidence": null}}
+      ],
       "topics": ["Víctimas Dana", "Responsabilidad gobierno", "Ayudas", "Prevención"]
     }}
   ]
@@ -462,7 +482,9 @@ Output: 2 capítulos divididos en pausas naturales
       "start_time": "00:00:00,000",
       "end_time": "01:25:00,000",
       "duration_minutes": 85.0,
-      "speakers": ["..."],
+      "speakers": [
+        {{"speaker_name": null, "speaker_role": "Portavoz PP", "speaker_confidence": null}}
+      ],
       "topics": ["Energía", "Precios luz", "Renovables"]
     }},
     {{
@@ -471,7 +493,9 @@ Output: 2 capítulos divididos en pausas naturales
       "start_time": "01:25:00,000",
       "end_time": "02:45:00,000",
       "duration_minutes": 80.0,
-      "speakers": ["..."],
+      "speakers": [
+        {{"speaker_name": null, "speaker_role": "Portavoz PSOE", "speaker_confidence": null}}
+      ],
       "topics": ["Energía", "Dependencia energética", "Transición"]
     }}
   ]
@@ -487,6 +511,7 @@ Output: 2 capítulos (uno por tema)
 - Solo divide por tiempo si el chunk > 120 minutos
 - Divide en pausas naturales (4-5+ segundos)
 - NUNCA lista vacía - mínimo 1 capítulo
+- speaker_name DEBE ser null (nunca texto genérico) cuando el hablador sea desconocido
 
 Devuelve SOLO el JSON."""
 

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1319,6 +1319,7 @@ class CongressionalVideoDB:
         speakers: list,
         key_speakers: list,
         timeline: list,
+        resolved_participant_slug: str | None = None,
     ) -> None:
         """Overwrite the speakers, key_speakers and timeline JSONB for a chapter.
 
@@ -1330,26 +1331,46 @@ class CongressionalVideoDB:
             speakers: Updated list of speaker display names.
             key_speakers: Updated list of key speaker display names.
             timeline: Updated list of timeline dicts (each has 'speaker' field).
+            resolved_participant_slug: When provided, also writes the FK column
+                ``resolved_participant_slug`` linking this chapter to a verified
+                ``congress_participants`` row. Omit (or pass None) to leave the
+                column unchanged.
         """
         chapters_table = self.pg_conn.get_qualified_table("video_chapters")
 
         with self.pg_conn.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    f"""
-                    UPDATE {chapters_table}
-                    SET speakers = %s,
-                        key_speakers = %s,
-                        timeline = %s::jsonb,
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE chapter_id = %s
-                    """,
-                    (speakers, key_speakers, json.dumps(timeline), chapter_id),
-                )
+                if resolved_participant_slug is not None:
+                    cur.execute(
+                        f"""
+                        UPDATE {chapters_table}
+                        SET speakers = %s,
+                            key_speakers = %s,
+                            timeline = %s::jsonb,
+                            resolved_participant_slug = %s,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE chapter_id = %s
+                        """,
+                        (speakers, key_speakers, json.dumps(timeline),
+                         resolved_participant_slug, chapter_id),
+                    )
+                else:
+                    cur.execute(
+                        f"""
+                        UPDATE {chapters_table}
+                        SET speakers = %s,
+                            key_speakers = %s,
+                            timeline = %s::jsonb,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE chapter_id = %s
+                        """,
+                        (speakers, key_speakers, json.dumps(timeline), chapter_id),
+                    )
                 logger.info(
                     "update_chapter_speakers: updated chapter %d "
-                    "(%d speakers, %d key_speakers, %d timeline entries)",
+                    "(%d speakers, %d key_speakers, %d timeline entries%s)",
                     chapter_id, len(speakers), len(key_speakers), len(timeline),
+                    f", slug={resolved_participant_slug!r}" if resolved_participant_slug else "",
                 )
 
     def get_processed_video_ids(self, video_ids: list[str]) -> set[str]:

--- a/congress_videos/modules/speaker_helpers.py
+++ b/congress_videos/modules/speaker_helpers.py
@@ -7,6 +7,8 @@ specific to the congressional video processing workflow.
 
 from typing import Dict, List
 
+from congress_videos.modules.speaker_placeholders import is_placeholder
+
 
 def format_speaker_list(
     speakers_info: List[Dict[str, str]],
@@ -15,6 +17,8 @@ def format_speaker_list(
 ) -> str:
     """
     Format a list of speakers into a text representation.
+
+    Entries whose speaker_name is missing or is a known placeholder are skipped.
 
     Args:
         speakers_info: List of dicts with 'speaker_name' and 'role' keys
@@ -29,13 +33,18 @@ def format_speaker_list(
 
     speaker_lines = []
     for speaker in speakers_info[:max_speakers]:
-        name = speaker.get("speaker_name", "Desconocido")
+        name = speaker.get("speaker_name", "")
+        if is_placeholder(name):
+            continue
         role = speaker.get("role", "")
 
         if include_role and role:
             speaker_lines.append(f"- {name} ({role})")
         else:
             speaker_lines.append(f"- {name}")
+
+    if not speaker_lines:
+        return "No hay participantes especificados"
 
     result = "\n".join(speaker_lines)
 
@@ -53,6 +62,8 @@ def format_speaker_context(
     """
     Format speakers into a compact context string for prompts.
 
+    Entries whose speaker_name is missing or is a known placeholder are skipped.
+
     Args:
         speakers_info: List of dicts with 'speaker_name' and 'role' keys
         max_speakers: Maximum number of speakers to include
@@ -66,11 +77,16 @@ def format_speaker_context(
 
     speaker_names = []
     for speaker in speakers_info[:max_speakers]:
-        name = speaker.get("speaker_name", "Unknown")
+        name = speaker.get("speaker_name", "")
+        if is_placeholder(name):
+            continue
         role = speaker.get("role", "")
         if role:
             speaker_names.append(f"{name} ({role})")
         else:
             speaker_names.append(name)
+
+    if not speaker_names:
+        return ""
 
     return f"{prefix}: {', '.join(speaker_names)}"

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -47,6 +47,10 @@ class NormalizationResult:
     updated: bool = False
     """True if video_chapters was written back (at least one match confirmed)."""
 
+    resolved_participant_slug: str | None = None
+    """Slug of the first confirmed matched participant, derived LLM-free from
+    the candidate's normalized_name.  None when no match was confirmed."""
+
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -221,11 +225,12 @@ def normalize_chapter_speakers(
             # Map AI decision to cache status
             if decision == "match":
                 canonical = candidate["display_name"]
+                normalized_name = candidate.get("normalized_name") or ""
                 _upsert_cache_row(
                     cursor, chapter_id, dirty,
                     status="matched",
                     canonical_speaker=canonical,
-                    participant_normalized_name=candidate.get("normalized_name"),
+                    participant_normalized_name=normalized_name or None,
                     confidence_score=confidence,
                 )
                 result.cache_rows.append({
@@ -235,6 +240,11 @@ def normalize_chapter_speakers(
                     "confidence_score": confidence,
                 })
                 result.corrections[dirty] = canonical
+                # Derive slug LLM-free from the authoritative normalized_name.
+                # slug = REPLACE(normalized_name, ' ', '-') — same formula as migration 018.
+                # Record only the first matched speaker's slug for this chapter.
+                if result.resolved_participant_slug is None and normalized_name:
+                    result.resolved_participant_slug = normalized_name.replace(" ", "-")
                 logger.info(
                     "normalize_chapter_speakers: matched %r -> %r (chapter %d, confidence=%.2f)",
                     dirty, canonical, chapter_id, confidence or 0.0,
@@ -261,21 +271,38 @@ def normalize_chapter_speakers(
             new_key_speakers = _apply_corrections(key_speakers, result.corrections)
             new_timeline = _apply_corrections_to_timeline(timeline, result.corrections)
 
-            cursor.execute(
-                f"""
-                UPDATE {_CHAPTERS_TABLE}
-                SET speakers     = %s,
-                    key_speakers = %s,
-                    timeline     = %s::jsonb,
-                    updated_at   = CURRENT_TIMESTAMP
-                WHERE chapter_id = %s
-                """,
-                (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
-            )
+            if result.resolved_participant_slug is not None:
+                cursor.execute(
+                    f"""
+                    UPDATE {_CHAPTERS_TABLE}
+                    SET speakers     = %s,
+                        key_speakers = %s,
+                        timeline     = %s::jsonb,
+                        resolved_participant_slug = %s,
+                        updated_at   = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (new_speakers, new_key_speakers, json.dumps(new_timeline),
+                     result.resolved_participant_slug, chapter_id),
+                )
+            else:
+                cursor.execute(
+                    f"""
+                    UPDATE {_CHAPTERS_TABLE}
+                    SET speakers     = %s,
+                        key_speakers = %s,
+                        timeline     = %s::jsonb,
+                        updated_at   = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
+                )
             result.updated = True
             logger.info(
-                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d",
+                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d%s",
                 len(result.corrections), chapter_id,
+                f" (slug={result.resolved_participant_slug!r})"
+                if result.resolved_participant_slug else "",
             )
 
     return result

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -24,6 +24,7 @@ from congress_videos.config.ai_prompts import (
 )
 from congress_videos.modules.participants_db import lookup_participant_fuzzy
 from congress_videos.modules.participants_ingestion import normalize_member_name
+from congress_videos.modules.speaker_placeholders import is_placeholder
 from utils.llm_cache import cached_json_completion
 
 logger = logging.getLogger(__name__)
@@ -56,11 +57,20 @@ def _dedupe_dirty_speakers(
     key_speakers: list[str],
     timeline: list[dict],
 ) -> list[str]:
-    """Return a de-duplicated, ordered list of unique dirty speaker names."""
+    """Return a de-duplicated, ordered list of unique dirty speaker names.
+
+    Placeholder speaker strings (e.g. "Desconocido", "Unknown",
+    "(No especificado)", single-token role abbreviations) are filtered out
+    before deduplication so they are never sent to the normalization pipeline.
+    """
     seen: list[str] = []
     seen_set: set[str] = set()
-    for name in list(speakers) + list(key_speakers) + [e.get("speaker", "") for e in timeline]:
-        if name and name not in seen_set:
+    for name in (
+        list(speakers)
+        + list(key_speakers)
+        + [e.get("speaker", "") for e in timeline]
+    ):
+        if name and not is_placeholder(name) and name not in seen_set:
             seen.append(name)
             seen_set.add(name)
     return seen

--- a/congress_videos/modules/speaker_placeholders.py
+++ b/congress_videos/modules/speaker_placeholders.py
@@ -1,0 +1,117 @@
+"""Shared placeholder-speaker detection for congressional chapter attribution.
+
+Exports
+-------
+PLACEHOLDER_SPEAKERS : frozenset[str]
+    Casefolded canonical set of known placeholder speaker strings.
+is_placeholder(s: str) -> bool
+    Pure, stateless predicate. Returns True when ``s`` is a known placeholder
+    or matches a role-only heuristic. Fail-open: unrecognised shapes → False.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Canonical placeholder set (casefolded, exact)
+# ---------------------------------------------------------------------------
+
+PLACEHOLDER_SPEAKERS: frozenset[str] = frozenset({
+    "desconocido",
+    "unknown",
+    "interviniente no especificado",
+    "(no especificado)",
+    "no especificado",
+    "",
+})
+
+# ---------------------------------------------------------------------------
+# Role-keyword heuristic
+# ---------------------------------------------------------------------------
+# These are role/title tokens that appear in the congressional transcription
+# output when the LLM cannot identify a real name. The regex matches the
+# token as a complete word at the start of the string (case-insensitive).
+# Confirmed against real dirty-speaker samples from ai_prompts.py and the
+# speaker_normalization pipeline.
+
+_ROLE_KEYWORDS = (
+    r"portavoz",
+    r"diputad[oa]",
+    r"senadore?[oa]?",
+    r"president[ea]",
+    r"ministr[oa]",
+    r"secretari[oa]",
+    r"vicesecretari[oa]",
+    r"vicepresidente?",
+    r"viceministr[oa]",
+    r"vocal",
+    r"interventor[a]?",
+    r"interveniente",
+    r"interviniente",
+    r"ponente",
+    r"consejere?[oa]?",
+    r"delegad[oa]",
+    r"coordinadore?[oa]?",
+)
+
+# Compiled pattern: role-keyword covers the ENTIRE string with only
+# lowercase/article suffixes (role-only, no proper name following).
+_ROLE_ONLY_RE = re.compile(
+    r"^(?:" + r"|".join(_ROLE_KEYWORDS) + r")(?:\s+(?:del?\s+[a-záéíóúàèìòùüñ]\w*|los?\s+[a-záéíóúàèìòùüñ]\w*|las?\s+[a-záéíóúàèìòùüñ]\w*|[a-záéíóúàèìòùüñ]\w*))*$",
+    re.IGNORECASE,
+)
+
+# Proper-name suffix: at least one word starting with a Unicode uppercase letter
+# (genuine Titlecase, NOT re.IGNORECASE for the suffix), following a role keyword.
+# If present the string is treated as a real name (fail-open).
+# Note: role keyword itself is matched case-insensitively via a separate prefix group.
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?:" + r"|".join(_ROLE_KEYWORDS) + r")\s+",
+    re.IGNORECASE,
+)
+
+# Uppercase letter set for Titlecase detection (Spanish + Latin Extended).
+_UPPERCASE_CHARS = set("ABCDEFGHIJKLMNOPQRSTUVWXYZÁÉÍÓÚÀÈÌÒÙÜÑ")
+
+
+def is_placeholder(s: str) -> bool:
+    """Return True when ``s`` is a known placeholder or a role-only string.
+
+    Decision rules (in order):
+    1. Strip and casefold; if in PLACEHOLDER_SPEAKERS → True.
+    2. Single-token (no whitespace after strip) → True.
+    3. Matches _ROLE_WITH_NAME_RE (role + proper-name Titlecase suffix) → False
+       (fail-open: real name).
+    4. Matches _ROLE_ONLY_RE → True.
+    5. Everything else → False (fail-open: treat as real name).
+
+    The function is pure and stateless — no I/O, no LLM, no DB.
+    """
+    stripped = s.strip()
+    casefolded = stripped.casefold()
+
+    # Rule 1: exact match in canonical set
+    if casefolded in PLACEHOLDER_SPEAKERS:
+        return True
+
+    # Rule 2: single-token (no whitespace) — e.g. "Portavoz", "PP"
+    if " " not in stripped:
+        return True
+
+    # Rule 3: role keyword + proper-name suffix → fail-open (real name).
+    # Check whether the suffix after the role prefix starts with a Titlecase word
+    # (i.e. first char is uppercase). We test this without re.IGNORECASE on the
+    # suffix to avoid "del" (lowercase d) being mistaken for a proper name.
+    prefix_m = _ROLE_PREFIX_RE.match(stripped)
+    if prefix_m:
+        suffix = stripped[prefix_m.end():]
+        if suffix and suffix[0] in _UPPERCASE_CHARS:
+            return False
+
+    # Rule 4: role-keyword pattern covers the whole string (role-only phrase)
+    if _ROLE_ONLY_RE.match(stripped):
+        return True
+
+    # Rule 5: unrecognised shape → fail-open
+    return False

--- a/congress_videos/modules/youtube/download.py
+++ b/congress_videos/modules/youtube/download.py
@@ -1327,6 +1327,7 @@ def identify_interesting_chapters(chunk_summaries, chunked_srt_data, target_date
         - videos: List with video_id, chunks_with_chapters (interesting chapters found in each chunk)
     """
     from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+    from utils.ai_chapter_analyzer import _flatten_speakers
     import json
 
     if not chunk_summaries or not chunk_summaries.get('videos'):
@@ -1518,6 +1519,10 @@ def identify_interesting_chapters(chunk_summaries, chunked_srt_data, target_date
                                 chapter.get('start_time'),
                                 chapter.get('end_time'),
                             )
+                            # Flatten structured speaker objects to list[str] so
+                            # video_chapters.speakers TEXT[] stays byte-compatible.
+                            # Also tolerates legacy flat-string form (backward compat).
+                            chapter['speakers'] = _flatten_speakers(chapter.get('speakers', []))
                             valid_chapters.append(chapter)
                         else:
                             logging.warning(

--- a/congress_videos/reap_shorts_uploader_dag.py
+++ b/congress_videos/reap_shorts_uploader_dag.py
@@ -36,10 +36,27 @@ POSTGRES_SCHEMA = os.getenv("POSTGRES_SCHEMA", "development")
 
 
 def _resolve_speakers(ch: dict) -> tuple[str, str]:
-    speakers = ch.get("key_speakers") or ch.get("speakers") or []
-    if not speakers:
+    """Return (primary_speaker, rest_speakers) filtering placeholders.
+
+    Priority: key_speakers (placeholder-filtered) before speakers
+    (placeholder-filtered). Deduplicates order-preserving. Returns ("", "")
+    when the combined pool is empty after filtering.
+    """
+    from congress_videos.modules.speaker_placeholders import is_placeholder
+
+    key_speakers: list[str] = ch.get("key_speakers") or []
+    speakers: list[str] = ch.get("speakers") or []
+
+    seen: set[str] = set()
+    pool: list[str] = []
+    for name in list(key_speakers) + list(speakers):
+        if not is_placeholder(name) and name not in seen:
+            pool.append(name)
+            seen.add(name)
+
+    if not pool:
         return ("", "")
-    return (speakers[0].strip(), ", ".join(speakers[1:]))
+    return (pool[0].strip(), ", ".join(pool[1:]))
 
 
 _MONTHS = [

--- a/congress_videos/sql/migrations/020_add_resolved_participant_slug.sql
+++ b/congress_videos/sql/migrations/020_add_resolved_participant_slug.sql
@@ -1,0 +1,39 @@
+-- Migration 020: Add resolved_participant_slug column to video_chapters
+-- Created: 2026-08-11
+-- Depends on: 018_add_participant_slug.sql (congress_participants.slug must exist)
+--             017_create_speaker_normalization_cache.sql
+--
+-- Adds a nullable FK column linking a chapter to a verified congress_participants row.
+-- Fill is LLM-free and async: normalize_chapter_speakers writes the slug after
+-- confirming a 'matched' cache entry. NULL is the honest unresolved state.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- Runner sets search_path before executing, so table names are UNQUALIFIED.
+--
+-- One-time backfill: fills rows whose chapter_id appears in speaker_normalization_cache
+-- with status='matched' and whose resolved_participant_slug is currently NULL.
+-- The JOIN through congress_participants guarantees FK integrity: only slugs that
+-- exist in congress_participants are written; rows with no matching slug are skipped.
+--
+-- Rollback: DROP COLUMN IF EXISTS resolved_participant_slug (additive/nullable, safe).
+
+-- 1) Add nullable column (idempotent).
+ALTER TABLE video_chapters
+    ADD COLUMN IF NOT EXISTS resolved_participant_slug TEXT
+        REFERENCES congress_participants(slug);
+
+-- 2) Create an index for FK lookups / downstream JOINs (idempotent).
+CREATE INDEX IF NOT EXISTS idx_video_chapters_resolved_participant_slug
+    ON video_chapters (resolved_participant_slug);
+
+-- 3) One-time idempotent backfill: set slug for matched cache rows where not yet set.
+--    JOIN congress_participants guarantees only valid slugs are written (FK integrity).
+--    WHERE IS NULL makes this a no-op for already-filled rows.
+UPDATE video_chapters vc
+    SET resolved_participant_slug = cp.slug
+    FROM speaker_normalization_cache snc
+    JOIN congress_participants cp
+        ON cp.normalized_name = snc.participant_normalized_name
+    WHERE snc.chapter_id = vc.chapter_id
+      AND snc.status = 'matched'
+      AND vc.resolved_participant_slug IS NULL;

--- a/tests/congress_videos/modules/test_speaker_helpers.py
+++ b/tests/congress_videos/modules/test_speaker_helpers.py
@@ -34,22 +34,26 @@ class TestFormatSpeakerList:
         result = format_speaker_list(speakers)
         assert result == "- Ana García"
 
-    def test_single_speaker_missing_name_key_uses_desconocido(self):
+    def test_single_speaker_missing_name_key_omits_placeholder(self):
+        """Task 1.7 RED: format_speaker_list MUST NOT emit 'Desconocido' literal.
+
+        When speaker_name key is missing, the entry should be skipped rather than
+        emitting a hardcoded placeholder string.
+        """
         speakers = [{"role": "Diputado"}]
         result = format_speaker_list(speakers)
-        assert "Desconocido" in result
-        assert "Diputado" in result
+        assert "Desconocido" not in result
 
     def test_multiple_speakers_each_on_own_line(self):
         speakers = [
-            {"speaker_name": "Ana", "role": "Presidenta"},
-            {"speaker_name": "Juan", "role": "Diputado"},
+            {"speaker_name": "Ana García", "role": "Presidenta"},
+            {"speaker_name": "Juan Pérez", "role": "Diputado"},
         ]
         result = format_speaker_list(speakers)
         lines = result.split("\n")
         assert len(lines) == 2
-        assert "Ana" in lines[0]
-        assert "Juan" in lines[1]
+        assert "Ana García" in lines[0]
+        assert "Juan Pérez" in lines[1]
 
     def test_include_role_false_omits_roles(self):
         speakers = [{"speaker_name": "Ana García", "role": "Presidenta"}]
@@ -58,30 +62,30 @@ class TestFormatSpeakerList:
         assert "Ana García" in result
 
     def test_max_speakers_limits_output(self):
-        speakers = [{"speaker_name": f"Speaker{i}", "role": "Rol"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "Rol"} for i in range(5)]
         result = format_speaker_list(speakers, max_speakers=3)
         lines = [line for line in result.split("\n") if line.startswith("-")]
         assert len(lines) == 3
 
     def test_overflow_singular_one_more(self):
         # Exactly max_speakers + 1 → "1 participante más" (singular)
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(4)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(4)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "y 1 participante más" in result
 
     def test_overflow_plural_multiple_more(self):
         # max_speakers + 2 → "2 participantes más" (plural)
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "y 2 participantes más" in result
 
     def test_no_overflow_message_when_exactly_at_max(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(3)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(3)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "más" not in result
 
     def test_overflow_message_with_default_max_10(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(12)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(12)]
         result = format_speaker_list(speakers)
         assert "y 2 participantes más" in result
 
@@ -91,7 +95,7 @@ class TestFormatSpeakerList:
         (10, "participantes"),
     ])
     def test_overflow_singular_plural_parametrized(self, remaining: int, expected_word: str):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(3 + remaining)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(3 + remaining)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert expected_word in result
 
@@ -117,43 +121,48 @@ class TestFormatSpeakerContext:
         assert "Ana García" in result
         assert "()" not in result
 
-    def test_single_speaker_missing_name_key_uses_unknown(self):
+    def test_single_speaker_missing_name_key_omits_placeholder(self):
+        """Task 1.7 RED: format_speaker_context MUST NOT emit 'Unknown' literal.
+
+        When speaker_name key is missing, the entry should be skipped rather than
+        emitting a hardcoded placeholder string.
+        """
         speakers = [{"role": "Diputado"}]
         result = format_speaker_context(speakers)
-        assert "Unknown" in result
+        assert "Unknown" not in result
 
     def test_prefix_is_included(self):
-        speakers = [{"speaker_name": "Ana", "role": "R"}]
+        speakers = [{"speaker_name": "Ana García", "role": "R"}]
         result = format_speaker_context(speakers, prefix="Participan")
         assert result.startswith("Participan:")
 
     def test_custom_prefix(self):
-        speakers = [{"speaker_name": "Ana", "role": "R"}]
+        speakers = [{"speaker_name": "Ana García", "role": "R"}]
         result = format_speaker_context(speakers, prefix="Speakers")
         assert result.startswith("Speakers:")
 
     def test_max_speakers_limits_output(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_context(speakers, max_speakers=2)
-        assert "S2" not in result
-        assert "S3" not in result
+        assert "Orador Numero2" not in result
+        assert "Orador Numero3" not in result
 
     def test_multiple_speakers_joined_by_comma(self):
         speakers = [
-            {"speaker_name": "Ana", "role": "Presidenta"},
-            {"speaker_name": "Juan", "role": "Diputado"},
+            {"speaker_name": "Ana García", "role": "Presidenta"},
+            {"speaker_name": "Juan Pérez", "role": "Diputado"},
         ]
         result = format_speaker_context(speakers)
-        assert "Ana (Presidenta), Juan (Diputado)" in result
+        assert "Ana García (Presidenta), Juan Pérez (Diputado)" in result
 
     def test_default_max_speakers_is_3(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_context(speakers)
-        assert "S3" not in result
-        assert "S4" not in result
+        assert "Orador Numero3" not in result
+        assert "Orador Numero4" not in result
 
     def test_speaker_without_role_no_parentheses(self):
-        speakers = [{"speaker_name": "Ana"}, {"speaker_name": "Juan"}]
+        speakers = [{"speaker_name": "Ana García"}, {"speaker_name": "Juan Pérez"}]
         result = format_speaker_context(speakers)
         assert "()" not in result
-        assert "Ana, Juan" in result
+        assert "Ana García, Juan Pérez" in result

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -531,6 +531,168 @@ class TestDedupeDirtySpeakersPlaceholderFilter:
 
 
 # ---------------------------------------------------------------------------
+# T-09 (Task 2.3 RED): update_chapter_speakers — optional resolved_participant_slug param
+# ---------------------------------------------------------------------------
+
+class TestUpdateChapterSpeakersSlugParam:
+    """Task 2.3 RED — update_chapter_speakers must accept and write resolved_participant_slug.
+
+    Tests the Database.update_chapter_speakers method in database.py.
+    """
+
+    def test_slug_written_when_provided(self, mock_psycopg2_connection):
+        """When resolved_participant_slug is provided, it must be included in the UPDATE."""
+        _, mock_conn, mock_cursor = mock_psycopg2_connection
+
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        db.update_chapter_speakers(
+            chapter_id=42,
+            speakers=["Pedro Sánchez"],
+            key_speakers=["Pedro Sánchez"],
+            timeline=[],
+            resolved_participant_slug="pedro-sanchez",
+        )
+
+        # Find the UPDATE call and assert resolved_participant_slug appears in it
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" in sql, (
+            "resolved_participant_slug column must be in the UPDATE SQL"
+        )
+        # Verify the slug value is in the params
+        params = update_calls[0].args[1]
+        assert "pedro-sanchez" in params, (
+            "resolved_participant_slug value must be passed as a parameter"
+        )
+
+    def test_slug_not_written_when_none(self, mock_psycopg2_connection):
+        """When resolved_participant_slug is None (default), it must NOT appear in UPDATE SQL."""
+        _, mock_conn, mock_cursor = mock_psycopg2_connection
+
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        db.update_chapter_speakers(
+            chapter_id=99,
+            speakers=["Ana López"],
+            key_speakers=[],
+            timeline=[],
+        )
+
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" not in sql, (
+            "resolved_participant_slug must not be in the UPDATE SQL when not provided"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-10 (Task 2.5 RED): normalize_chapter_speakers — slug fill on matched entry
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChapterSpeakersSlugFill:
+    """Task 2.5 RED — normalize_chapter_speakers must write resolved_participant_slug on match.
+
+    After AI confirms 'match', the function derives the slug from the candidate's
+    normalized_name and writes it via update_chapter_speakers (or direct UPDATE).
+    No LLM call is triggered by the slug fill itself.
+    """
+
+    def test_matched_cache_entry_triggers_slug_write(self, mock_db_conn):
+        """A confirmed 'matched' cache entry must write resolved_participant_slug."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            normalize_chapter_speakers(
+                42, ["Pedro Sanchez"], ["Pedro Sanchez"], [],
+                mock_conn, _make_config()
+            )
+
+        # The bulk UPDATE on video_chapters must include resolved_participant_slug
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" in sql, (
+            "resolved_participant_slug must be set in the UPDATE after a matched entry"
+        )
+        params = update_calls[0].args[1]
+        # Slug derived from normalized_name "pedro sanchez" → "pedro-sanchez"
+        assert "pedro-sanchez" in params, (
+            "slug 'pedro-sanchez' must be passed as a parameter in the UPDATE"
+        )
+
+    def test_unresolved_chapter_slug_stays_null(self, mock_db_conn):
+        """When there is no match, resolved_participant_slug must not be written."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                99, ["Unknown Speaker"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # No UPDATE should have been issued (no match, no write)
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert not update_calls, (
+            "UPDATE video_chapters must NOT be called when there is no match"
+        )
+
+    def test_no_llm_call_on_slug_fill_path(self, mock_db_conn):
+        """Slug fill must not trigger any additional LLM calls beyond the match itself."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result) as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            normalize_chapter_speakers(
+                42, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # cached_json_completion called exactly once (for the match decision only)
+        assert mock_ai.call_count == 1, (
+            "cached_json_completion must be called exactly once — slug fill is LLM-free"
+        )
+
+
+# ---------------------------------------------------------------------------
 # T-07 (Bonus from task description): ENABLED=False → immediate return
 # ---------------------------------------------------------------------------
 

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -185,7 +185,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -201,7 +201,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -218,7 +218,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -250,7 +250,7 @@ class TestAINoMatch:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroSanchezVariant"], [], [],
+                1, ["Pedro Sanchez Variant"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -273,7 +273,7 @@ class TestAINoMatch:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroSanchezVariant"], [], [],
+                1, ["Pedro Sanchez Variant"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -302,7 +302,7 @@ class TestAINeedsManual:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroAmbiguous"], [], [],
+                1, ["Pedro Ambiguo Real"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -322,7 +322,7 @@ class TestAINeedsManual:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroAmbiguous"], [], [],
+                1, ["Pedro Ambiguo Real"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -341,8 +341,8 @@ class TestMultipleSpeakers:
         mock_conn, mock_cursor = mock_db_conn
 
         participant_map = {
-            "Speaker One": _make_participant("Speaker One", "speaker one"),
-            "Speaker Two": _make_participant("Speaker Two", "speaker two"),
+            "Ana Ruiz Pérez": _make_participant("Ana Ruiz Pérez", "ana ruiz perez"),
+            "Juan García López": _make_participant("Juan García López", "juan garcia lopez"),
         }
 
         def fuzzy_side(name, threshold):
@@ -359,22 +359,22 @@ class TestMultipleSpeakers:
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
                 7,
-                ["Speaker One", "Speaker Two", "Unknown"],
+                ["Ana Ruiz Pérez", "Juan García López", "María Fernández Gil"],
                 [],
                 [],
                 mock_conn,
                 _make_config(),
             )
 
-        # One cache row per unique dirty speaker
+        # One cache row per unique dirty speaker (all three are real multi-word names)
         assert len(result.cache_rows) == 3
 
     def test_only_matched_speakers_corrected(self, mock_db_conn):
         mock_conn, mock_cursor = mock_db_conn
 
         def fuzzy_side(name, threshold):
-            if name == "Speaker One":
-                return _make_participant("Speaker One", "speaker one")
+            if name == "Ana Ruiz Pérez":
+                return _make_participant("Ana Ruiz Pérez", "ana ruiz perez")
             return None
 
         ai_result = _make_ai_result("match", confidence=0.90)
@@ -388,16 +388,16 @@ class TestMultipleSpeakers:
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
                 7,
-                ["Speaker One", "Speaker Two", "Unknown"],
+                ["Ana Ruiz Pérez", "Juan García López", "María Fernández Gil"],
                 [],
                 [],
                 mock_conn,
                 _make_config(),
             )
 
-        assert "Speaker One" in result.corrections
-        assert "Speaker Two" not in result.corrections
-        assert "Unknown" not in result.corrections
+        assert "Ana Ruiz Pérez" in result.corrections
+        assert "Juan García López" not in result.corrections
+        assert "María Fernández Gil" not in result.corrections
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +449,85 @@ class TestAICallError:
         assert result.updated is False
         calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
         assert not any("update" in s and "video_chapters" in s for s in calls_sql)
+
+
+# ---------------------------------------------------------------------------
+# T-08: _dedupe_dirty_speakers drops placeholder names (Task 1.7 RED)
+# ---------------------------------------------------------------------------
+
+class TestDedupeDirtySpeakersPlaceholderFilter:
+    """Task 1.7 RED — _dedupe_dirty_speakers must filter placeholders before dedup."""
+
+    def test_desconocido_dropped_from_speakers(self):
+        """'Desconocido' must not appear in the deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Desconocido", "Pedro Sánchez"],
+            [],
+            [],
+        )
+        assert "Desconocido" not in result
+        assert "Pedro Sánchez" in result
+
+    def test_unknown_dropped_from_speakers(self):
+        """'Unknown' must not appear in the deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Unknown", "María López"],
+            [],
+            [],
+        )
+        assert "Unknown" not in result
+        assert "María López" in result
+
+    def test_no_especificado_dropped_from_key_speakers(self):
+        """'(No especificado)' in key_speakers must be filtered."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            [],
+            ["(No especificado)", "Ana Martínez"],
+            [],
+        )
+        assert "(No especificado)" not in result
+        assert "Ana Martínez" in result
+
+    def test_placeholder_in_timeline_speaker_dropped(self):
+        """Placeholder in timeline[].speaker must be filtered."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            [],
+            [],
+            [{"speaker": "Desconocido", "content": "...", "time": "00:01:00"}],
+        )
+        assert "Desconocido" not in result
+
+    def test_all_real_speakers_preserved(self):
+        """Non-placeholder names must still appear in deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Ana Ruiz", "Pedro García"],
+            ["Laura Gómez"],
+            [],
+        )
+        assert "Ana Ruiz" in result
+        assert "Pedro García" in result
+        assert "Laura Gómez" in result
+
+    def test_mix_placeholders_and_real_names(self):
+        """Mixed list: only real names survive, order preserved."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Desconocido", "Ana Ruiz", "Unknown"],
+            ["Pedro García"],
+            [{"speaker": "No especificado", "content": "", "time": "00:00"}],
+        )
+        assert result == ["Ana Ruiz", "Pedro García"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/congress_videos/modules/test_speaker_placeholders.py
+++ b/tests/congress_videos/modules/test_speaker_placeholders.py
@@ -1,0 +1,166 @@
+"""Tests for congress_videos.modules.speaker_placeholders (Task 1.1 RED).
+
+Covers:
+- PLACEHOLDER_SPEAKERS frozenset membership (casefolded exact set)
+- is_placeholder: 5 spec scenarios (exact match, single-token, role-only,
+  role+propername fail-open, unrecognised fail-open)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestPlaceholderSpeakersSet:
+    """PLACEHOLDER_SPEAKERS is a frozenset of casefolded exact placeholder strings."""
+
+    def test_frozenset_is_importable(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert isinstance(PLACEHOLDER_SPEAKERS, frozenset)
+
+    def test_desconocido_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "desconocido" in PLACEHOLDER_SPEAKERS
+
+    def test_unknown_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "unknown" in PLACEHOLDER_SPEAKERS
+
+    def test_interviniente_no_especificado_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "interviniente no especificado" in PLACEHOLDER_SPEAKERS
+
+    def test_no_especificado_parenthesized_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "(no especificado)" in PLACEHOLDER_SPEAKERS
+
+    def test_no_especificado_plain_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "no especificado" in PLACEHOLDER_SPEAKERS
+
+    def test_empty_string_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "" in PLACEHOLDER_SPEAKERS
+
+    def test_real_name_not_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "pedro sánchez" not in PLACEHOLDER_SPEAKERS
+        assert "Ana Martínez" not in PLACEHOLDER_SPEAKERS
+
+
+class TestIsPlaceholderExactMatch:
+    """Scenario: Known placeholder exact match → is_placeholder returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Desconocido",
+        "desconocido",
+        "DESCONOCIDO",
+        "Unknown",
+        "unknown",
+        "UNKNOWN",
+        "Interviniente no especificado",
+        "INTERVINIENTE NO ESPECIFICADO",
+        "(No especificado)",
+        "(NO ESPECIFICADO)",
+        "No especificado",
+        "NO ESPECIFICADO",
+        "",
+    ])
+    def test_exact_placeholder_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderSingleToken:
+    """Scenario: Single-token string with no whitespace → is_placeholder returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Portavoz",
+        "PP",
+        "PSOE",
+        "Diputado",
+        "Diputada",
+        "Senador",
+        "Presidente",
+        "Presidenta",
+        "Ministro",
+        "Ministra",
+        "Secretario",
+        "Vocal",
+        "Interveniente",
+        "Interviniente",
+    ])
+    def test_single_token_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderRoleOnly:
+    """Scenario: Role-keyword prefix without a proper name → returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Presidenta",
+        "Ministro",
+        "Portavoz del grupo",
+        "Diputado del PP",
+    ])
+    def test_role_only_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderRoleWithProperName:
+    """Scenario: Role prefix followed by a proper name → fail-open, returns False."""
+
+    @pytest.mark.parametrize("name", [
+        "Presidente Sánchez",
+        "Ministra González",
+        "Portavoz López",
+        "Diputado Martínez García",
+    ])
+    def test_role_plus_propername_returns_false(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is False, f"Expected is_placeholder({name!r}) == False"
+
+
+class TestIsPlaceholderUnrecognisedFailOpen:
+    """Scenario: Unrecognised shape → fail-open, returns False (real name, not filtered)."""
+
+    @pytest.mark.parametrize("name", [
+        "Ana Martínez",
+        "Pedro López",
+        "Laura Gómez",
+        "María José Rodríguez",
+        "José Antonio Fernández",
+        "Xi Jinping",
+        "Joe Biden",
+        "Cualquier Nombre Real",
+    ])
+    def test_real_name_returns_false(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is False, f"Expected is_placeholder({name!r}) == False"
+
+    def test_whitespace_only_treated_as_placeholder(self):
+        """Whitespace-only strings collapse to empty string → placeholder."""
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder("   ") is True
+
+    def test_none_equivalent_empty_string_is_placeholder(self):
+        """Empty string is in PLACEHOLDER_SPEAKERS."""
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder("") is True

--- a/tests/congress_videos/modules/youtube/test_download.py
+++ b/tests/congress_videos/modules/youtube/test_download.py
@@ -1913,3 +1913,159 @@ class TestDownloadGuardForwarding:
         )
 
         assert spy.call_args.kwargs["guard_live_status"] is False
+
+
+# ---------------------------------------------------------------------------
+# PR3 — _flatten_speakers wired into identify_interesting_chapters (Task 3.7 RED)
+# ---------------------------------------------------------------------------
+
+class TestIdentifyInterestingChaptersFlattenSpeakers:
+    """Assert that identify_interesting_chapters flattens structured speaker
+    objects (new LLM prompt format) to list[str] before returning chapters.
+
+    The 'speakers' field in every interesting_chapter must be list[str]
+    regardless of whether the LLM returned the new object form or the legacy
+    flat-string form — backward compat is required in both paths.
+    """
+
+    def _make_summarized_chunk(self, number=1, duration_minutes=130):
+        return {
+            "chunk_number": number,
+            "start_time": "00:00:00",
+            "end_time": "02:10:00",
+            "duration_seconds": duration_minutes * 60,
+            "duration_minutes": duration_minutes,
+            "speakers": [{"name": "Diputado López", "role": "Diputado"}],
+            "topics": ["Presupuestos"],
+            "summary": "Debate largo sobre presupuestos"
+        }
+
+    def _make_srt_chunk(self, number=1, duration_minutes=130):
+        return {
+            "chunk_number": number,
+            "start_time": "00:00:00",
+            "end_time": "02:10:00",
+            "duration_minutes": duration_minutes,
+            "content": "1\n00:00:01,000 --> 00:00:05,000\nContenido de prueba"
+        }
+
+    def test_structured_speaker_objects_flattened_to_strings(self, mocker):
+        """LLM returns new object-form speakers → chapter['speakers'] is list[str]."""
+        # LLM returns structured speaker objects (new prompt format)
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate Presupuestos",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": [
+                    {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.95},
+                    {"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.3},
+                ],
+                "topics": ["Presupuestos"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        assert result["total_videos"] == 1
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        assert len(chapters) == 1
+        speakers = chapters[0]["speakers"]
+        # Must be flat list[str], not list[dict]
+        assert all(isinstance(s, str) for s in speakers), (
+            f"speakers must be list[str], got: {speakers!r}"
+        )
+        # Null speaker_name must be dropped; real name must be kept
+        assert "Ana López" in speakers
+        assert len(speakers) == 1, "null speaker_name entry must be dropped"
+
+    def test_legacy_flat_string_speakers_pass_through(self, mocker):
+        """LLM returns old flat-string speaker list → chapter['speakers'] unchanged."""
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": ["Ana López", "Pedro García"],
+                "topics": ["Política"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        speakers = chapters[0]["speakers"]
+        assert speakers == ["Ana López", "Pedro García"], (
+            f"flat-string speakers must pass through unchanged, got: {speakers!r}"
+        )
+
+    def test_all_null_speaker_names_yields_empty_list(self, mocker):
+        """LLM returns only null speaker_name objects → speakers list is empty."""
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": [
+                    {"speaker_name": None, "speaker_role": "Portavoz PP", "speaker_confidence": None},
+                    {"speaker_name": None, "speaker_role": "Portavoz PSOE", "speaker_confidence": None},
+                ],
+                "topics": ["Política"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        speakers = chapters[0]["speakers"]
+        assert speakers == [], (
+            f"all-null speaker_name objects must yield empty list, got: {speakers!r}"
+        )

--- a/tests/congress_videos/sql/test_migration_020.py
+++ b/tests/congress_videos/sql/test_migration_020.py
@@ -1,0 +1,110 @@
+"""[RED] Test: migration 020 — add resolved_participant_slug to video_chapters.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, column added idempotently, FK references congress_participants(slug),
+index created, backfill is idempotent (WHERE slug IS NULL), unqualified table names.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "020_add_resolved_participant_slug.sql"
+)
+
+
+class TestMigration020FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration020ColumnDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_adds_column_if_not_exists(self):
+        """Migration must use ADD COLUMN IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG" in sql
+
+    def test_column_is_text(self):
+        """resolved_participant_slug column must be TEXT type."""
+        sql = self._sql().upper()
+        # ADD COLUMN IF NOT EXISTS resolved_participant_slug TEXT
+        assert re.search(r"RESOLVED_PARTICIPANT_SLUG\s+TEXT", sql)
+
+    def test_column_references_congress_participants_slug(self):
+        """Column must have FK REFERENCES congress_participants(slug)."""
+        sql = self._sql()
+        assert "REFERENCES congress_participants(slug)" in sql
+
+    def test_creates_index_if_not_exists(self):
+        """Migration must create an index with CREATE INDEX IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "CREATE INDEX IF NOT EXISTS" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG" in sql
+
+
+class TestMigration020Backfill:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_backfill_updates_video_chapters(self):
+        """Backfill must UPDATE video_chapters."""
+        sql = self._sql().upper()
+        assert "UPDATE VIDEO_CHAPTERS" in sql
+
+    def test_backfill_joins_speaker_normalization_cache(self):
+        """Backfill must JOIN speaker_normalization_cache."""
+        sql = self._sql().upper()
+        assert "SPEAKER_NORMALIZATION_CACHE" in sql
+
+    def test_backfill_joins_congress_participants(self):
+        """Backfill must JOIN congress_participants to get authoritative slug."""
+        sql = self._sql().upper()
+        assert "CONGRESS_PARTICIPANTS" in sql
+
+    def test_backfill_filters_matched_status(self):
+        """Backfill must only apply to cache rows with status='matched'."""
+        sql = self._sql()
+        assert "'matched'" in sql or "= 'matched'" in sql
+
+    def test_backfill_is_idempotent_null_guard(self):
+        """Backfill WHERE clause must guard with IS NULL to avoid overwriting filled rows."""
+        sql = self._sql().upper()
+        assert "IS NULL" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG IS NULL" in sql
+
+    def test_backfill_sets_cp_slug(self):
+        """Backfill must set resolved_participant_slug to cp.slug (authoritative FK source)."""
+        sql = self._sql()
+        # Accepts either 'cp.slug' or aliased equivalent
+        assert "cp.slug" in sql or "congress_participants.slug" in sql
+
+
+class TestMigration020TableNames:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_no_schema_qualified_table_names(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        content = self._sql()
+        assert not re.search(r"\bpublic\.video_chapters\b", content)
+        assert not re.search(r"\bpublic\.congress_participants\b", content)
+        assert not re.search(r"\bpublic\.speaker_normalization_cache\b", content)

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -316,22 +316,27 @@ class TestMarkShortsUploaded:
 
 class TestResolveSpeakers:
     def test_resolve_speakers_uses_key_speakers_first(self):
+        """key_speakers take priority; speakers adds non-duplicate real names to the pool."""
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": ["A", "B"], "speakers": ["C"]})
-        assert result == ("A", "B")
+        result = _resolve_speakers({
+            "key_speakers": ["Ana García", "Pedro López"],
+            "speakers": ["María Ruiz"],
+        })
+        # Pool: [Ana García, Pedro López, María Ruiz] — key_speakers first, then new speakers
+        assert result == ("Ana García", "Pedro López, María Ruiz")
 
     def test_resolve_speakers_falls_back_to_speakers(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"speakers": ["X", "Y"]})
-        assert result == ("X", "Y")
+        result = _resolve_speakers({"speakers": ["Xose Fernández", "Yolanda Díaz"]})
+        assert result == ("Xose Fernández", "Yolanda Díaz")
 
     def test_resolve_speakers_key_speakers_empty_list(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": [], "speakers": ["Z"]})
-        assert result == ("Z", "")
+        result = _resolve_speakers({"key_speakers": [], "speakers": ["Zoila Martínez"]})
+        assert result == ("Zoila Martínez", "")
 
     def test_resolve_speakers_empty_both(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
@@ -342,14 +347,93 @@ class TestResolveSpeakers:
     def test_resolve_speakers_single_speaker(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": ["Solo"]})
-        assert result == ("Solo", "")
+        result = _resolve_speakers({"key_speakers": ["Pedro Sánchez"]})
+        assert result == ("Pedro Sánchez", "")
 
     def test_resolve_speakers_none_values(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
         result = _resolve_speakers({"key_speakers": None, "speakers": None})
         assert result == ("", "")
+
+    # -------------------------------------------------------------------------
+    # Placeholder-aware _resolve_speakers spec scenarios (Task 1.4 RED)
+    # -------------------------------------------------------------------------
+
+    def test_key_speakers_real_name_wins_over_speakers_placeholder(self):
+        """Spec scenario 1: key_speakers has a real name; speakers[0] is placeholder.
+
+        GIVEN key_speakers=["Ana Martínez"], speakers=["Desconocido", "Pedro López"]
+        THEN  primary="Ana Martínez", secondary="Pedro López"
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Ana Martínez"],
+            "speakers": ["Desconocido", "Pedro López"],
+        })
+        assert result == ("Ana Martínez", "Pedro López"), (
+            f"Expected ('Ana Martínez', 'Pedro López'), got {result!r}"
+        )
+
+    def test_placeholder_at_speakers_index_0_is_skipped(self):
+        """Spec scenario 2: key_speakers empty; speakers[1] is real, speakers[0] is placeholder.
+
+        GIVEN key_speakers=[], speakers=["Portavoz", "Pedro López"]
+        THEN  primary="Pedro López", secondary=""
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": [],
+            "speakers": ["Portavoz", "Pedro López"],
+        })
+        assert result == ("Pedro López", ""), (
+            f"Expected ('Pedro López', ''), got {result!r}"
+        )
+
+    def test_all_placeholders_returns_empty_sentinel(self):
+        """Spec scenario 3: All speakers are placeholders → ("", ""), no crash.
+
+        GIVEN key_speakers=["Desconocido"], speakers=["(No especificado)"]
+        THEN  returns ("", "")
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Desconocido"],
+            "speakers": ["(No especificado)"],
+        })
+        assert result == ("", ""), (
+            f"Expected ('', ''), got {result!r}"
+        )
+
+    def test_both_arrays_empty_returns_empty_sentinel(self):
+        """Spec scenario 4: Both arrays empty → ("", "").
+
+        GIVEN key_speakers=[], speakers=[]
+        THEN  returns ("", "")
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({"key_speakers": [], "speakers": []})
+        assert result == ("", "")
+
+    def test_only_key_speakers_real_speakers_empty(self):
+        """Spec scenario 5: Only key_speakers has a real name; speakers is empty.
+
+        GIVEN key_speakers=["Laura Gómez"], speakers=[]
+        THEN  primary="Laura Gómez", secondary=""
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Laura Gómez"],
+            "speakers": [],
+        })
+        assert result == ("Laura Gómez", ""), (
+            f"Expected ('Laura Gómez', ''), got {result!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/utils/test_ai_chapter_analyzer.py
+++ b/tests/utils/test_ai_chapter_analyzer.py
@@ -540,3 +540,143 @@ class TestDetectSilenceGapsAdaptive:
 
         assert len(result) == 1
         assert result[0]["gap_duration_seconds"] == pytest.approx(295, rel=1e-2)
+
+
+# --------------------------------------------------------------------------- #
+# _flatten_speakers (PR3 — Task 3.1 RED)
+# --------------------------------------------------------------------------- #
+
+class TestFlattenSpeakers:
+    """Tests for _flatten_speakers: object-form + plain-string tolerance.
+
+    Spec: https://github.com/alozur/airflow-dags/issues/56
+    """
+
+    def test_object_form_real_name_extracted(self):
+        """Object with non-null speaker_name → name extracted to list[str]."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.95}]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López"]
+
+    def test_object_form_null_speaker_name_dropped(self):
+        """Object with speaker_name=null → element dropped from output list."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.3}]
+        result = _flatten_speakers(raw)
+
+        assert result == []
+
+    def test_object_form_empty_string_speaker_name_dropped(self):
+        """Object with speaker_name='' → element dropped (empty is treated as unknown)."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": "", "speaker_role": "Ministro", "speaker_confidence": 0.5}]
+        result = _flatten_speakers(raw)
+
+        assert result == []
+
+    def test_old_flat_string_form_tolerated(self):
+        """Old flat-string list element → passed through unchanged (backward compat)."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = ["Ana López"]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López"]
+
+    def test_mixed_list_only_real_names_kept(self):
+        """Mixed list of objects and strings → only real names kept; nulls dropped."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [
+            {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.9},
+            {"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.2},
+            "Pedro García",  # old flat-string format
+            {"speaker_name": "", "speaker_role": "Presidente", "speaker_confidence": 0.1},
+        ]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López", "Pedro García"]
+
+    def test_empty_list_returns_empty(self):
+        """Empty input → empty output."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        assert _flatten_speakers([]) == []
+
+    def test_multiple_objects_all_real_names(self):
+        """Multiple object entries with real names → all extracted in order."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [
+            {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.9},
+            {"speaker_name": "Pedro García", "speaker_role": "Ministro", "speaker_confidence": 0.8},
+        ]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López", "Pedro García"]
+
+
+# --------------------------------------------------------------------------- #
+# CHAPTER_IDENTIFICATION prompt structure (PR3 — Task 3.4 RED)
+# --------------------------------------------------------------------------- #
+
+class TestChapterIdentificationPromptStructure:
+    """Golden/structural assertions on the CHAPTER_IDENTIFICATION prompts.
+
+    Verifies that the restructured prompt instructs the LLM to return
+    speaker objects with speaker_name/speaker_role/speaker_confidence fields
+    and does NOT use 'Desconocido' as a literal fallback value.
+    """
+
+    def test_system_prompt_contains_speaker_name_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_name' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_name" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_name field"
+        )
+
+    def test_system_prompt_contains_speaker_role_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_role' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_role" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_role field"
+        )
+
+    def test_system_prompt_contains_speaker_confidence_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_confidence' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_confidence" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_confidence field"
+        )
+
+    def test_system_prompt_does_not_use_desconocido_fallback(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must NOT use 'Desconocido' as fallback value."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "Desconocido" not in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must not use 'Desconocido' literal; use null instead"
+        )
+
+    def test_user_prompt_template_contains_speaker_name_field(self):
+        """CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE format section must reference speaker_name."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+
+        assert "speaker_name" in CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE, (
+            "CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must show speaker_name in response format"
+        )
+
+    def test_user_prompt_template_does_not_use_desconocido(self):
+        """CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must NOT use 'Desconocido' literal."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+
+        assert "Desconocido" not in CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE, (
+            "CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must not use 'Desconocido' literal"
+        )

--- a/utils/ai_chapter_analyzer.py
+++ b/utils/ai_chapter_analyzer.py
@@ -391,6 +391,36 @@ def format_seconds_to_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
 
+def _flatten_speakers(raw: list) -> list[str]:
+    """Flatten a speakers list that may contain object-form or plain-string elements.
+
+    Accepts the new structured form returned by the restructured
+    CHAPTER_IDENTIFICATION prompt (list of dicts with ``speaker_name``,
+    ``speaker_role``, ``speaker_confidence``) AND the legacy flat-string
+    form for backward compatibility.
+
+    Rules:
+    - dict with ``speaker_name`` key: include value only when non-null and non-empty.
+    - plain string: include as-is (backward compat with old prompt format).
+    - dict missing ``speaker_name``: skip.
+
+    Args:
+        raw: List of either dicts or strings from LLM speaker field.
+
+    Returns:
+        Flat ``list[str]`` of real speaker names; null/empty names are dropped.
+    """
+    result: list[str] = []
+    for element in raw:
+        if isinstance(element, dict):
+            name = element.get("speaker_name")
+            if name is not None and name != "":
+                result.append(name)
+        elif isinstance(element, str):
+            result.append(element)
+    return result
+
+
 def analyze_chapters_with_ai(
     srt_content: str,
     agenda_content: str,


### PR DESCRIPTION
Cierra #56. Entrega consolidada de la cadena SDD `improve-chapter-speaker-attribution` (PRs #70 + #73 + #72, ya mergeados al tracker).

## Resumen

Ataca la causa raíz del gap 195/427 capítulos usables: no existía set de placeholders compartido y el pipeline tomaba `speakers[0]` a ciegas.

- **Selección placeholder-aware** (ex-PR1): módulo `speaker_placeholders.py` (`is_placeholder`, fail-open multi-token) + `_resolve_speakers` reescrito + migración de fallbacks hardcodeados.
- **Columna resuelta** (ex-PR2): migración 020 `resolved_participant_slug` (FK a `congress_participants.slug`) + backfill idempotente sin LLM + fill async.
- **Prompt enriquecido** (ex-PR3): `CHAPTER_IDENTIFICATION` → `{speaker_name, speaker_role, speaker_confidence}` con `_flatten_speakers` antes de persistir; `video_chapters` schema byte-idéntico.

## Testing

Strict TDD en las 3 fases. Suite final: **1931 passed, 1 skipped, 0 failed**, cobertura 86.43%.

## Follow-ups (no bloquean)

- Skip-path `'Unknown'` en `download.py:1409` (pre-existente, ya mitigado por el set de placeholders) — merece issue aparte.
- Evaluación offline OE.1–OE.3: gold-set etiquetado para el criterio ≥70% (post-merge).