### PR TITLE
feat(institutional-roles): drive thumbnails from resolved slug (PR3, #55)

### DIFF
--- a/congress_videos/sql/migrations/021_expose_resolved_participant_slug_in_uploadable_chapters.sql
+++ b/congress_videos/sql/migrations/021_expose_resolved_participant_slug_in_uploadable_chapters.sql
@@ -1,0 +1,54 @@
+-- Migration: Expose resolved_participant_slug in uploadable_chapters
+-- Created: 2026-08-12
+-- Depends on: 010_add_timeline_column.sql (uploadable_chapters view),
+--             020_add_resolved_participant_slug.sql (video_chapters.resolved_participant_slug)
+--
+-- Surfaces the authoritative participant slug written by speaker normalization
+-- (fuzzy match or institutional-role resolution) so the chapter uploader can
+-- build the thumbnail with the resolved person instead of re-fuzzy-matching the
+-- raw speaker string at thumbnail time.
+--
+-- Idempotent: CREATE OR REPLACE VIEW is safe to re-run. The new column is
+-- appended at the END of the select list, which CREATE OR REPLACE VIEW allows
+-- without a DROP (existing column names/order/types are unchanged).
+-- The migration runner runs `SET search_path TO {schema}, public` before
+-- executing, so table/view names are intentionally UNQUALIFIED.
+--
+-- Example (development): psql ... -c "SET search_path TO development, public;" -f 021_expose_resolved_participant_slug_in_uploadable_chapters.sql
+-- Example (production):  psql ... -c "SET search_path TO production, public;"  -f 021_expose_resolved_participant_slug_in_uploadable_chapters.sql
+
+CREATE OR REPLACE VIEW uploadable_chapters AS
+SELECT
+    vc.chapter_id,
+    vc.video_id,
+    ysv.video_title AS source_video_title,
+    ysv.session_number,
+    ysv.session_date,
+    vc.title AS chapter_title,
+    vc.description,
+    vc.duration_minutes,
+    vc.speakers,
+    vc.topics,
+    vc.timeline,
+    vc.start_time,
+    vc.end_time,
+    vc.relevance_score,
+    vc.speaker_relevance_points,
+    vc.topic_relevance_points,
+    vc.public_interest_points,
+    vc.scoring_reasoning,
+    vc.key_speakers,
+    vc.is_current_topic,
+    vc.is_uploaded_to_youtube,
+    vc.created_at,
+    CURRENT_DATE - DATE(vc.created_at) AS days_since_created,
+    vc.resolved_participant_slug
+FROM video_chapters vc
+JOIN youtube_source_videos ysv ON vc.video_id = ysv.video_id
+WHERE
+    vc.is_uploaded_to_youtube = FALSE
+    AND vc.relevance_score >= 2
+ORDER BY
+    ysv.session_date DESC NULLS LAST,
+    vc.relevance_score DESC,
+    vc.created_at DESC;

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -153,20 +153,24 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     else:
         session = str(session_date) if session_date else None
 
-    # Fuzzy matching is confined to this raw-speaker boundary. Downstream
-    # thumbnail code receives only the stable participant slug.
-    try:
-        raw_speaker = _resolve_speaker_name(chapter)
-        participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
-        slug = participant.get("slug") if participant else None
-    except Exception as exc:
-        logging.warning(
-            "_prepare_thumbnail_config: speaker resolution failed for "
-            "chapter_id=%s: %s — setting slug=None",
-            chapter_id,
-            exc,
-        )
-        slug = None
+    # Prefer the authoritative slug written by speaker normalization (fuzzy or
+    # institutional-role resolution). Fall back to a raw-speaker fuzzy match only
+    # when the chapter was never resolved. Fuzzy matching stays confined to this
+    # boundary; downstream thumbnail code receives only the stable slug.
+    slug = chapter.get("resolved_participant_slug") or None
+    if not slug:
+        try:
+            raw_speaker = _resolve_speaker_name(chapter)
+            participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
+            slug = participant.get("slug") if participant else None
+        except Exception as exc:
+            logging.warning(
+                "_prepare_thumbnail_config: speaker resolution failed for "
+                "chapter_id=%s: %s — setting slug=None",
+                chapter_id,
+                exc,
+            )
+            slug = None
 
     return {
         "chapter_id": chapter_id,

--- a/tests/congress_videos/sql/test_migration_021.py
+++ b/tests/congress_videos/sql/test_migration_021.py
@@ -1,0 +1,50 @@
+"""Test: migration 021 — expose resolved_participant_slug in uploadable_chapters.
+
+Reads the SQL file statically and asserts structural properties: file exists,
+recreates the view via CREATE OR REPLACE, appends resolved_participant_slug at
+the END of the select list (required for CREATE OR REPLACE VIEW), and uses
+unqualified names. No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "021_expose_resolved_participant_slug_in_uploadable_chapters.sql"
+)
+
+
+def _sql() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def test_migration_file_exists():
+    assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+def test_recreates_view_idempotently():
+    sql = _sql().upper()
+    assert "CREATE OR REPLACE VIEW UPLOADABLE_CHAPTERS" in sql
+
+
+def test_exposes_resolved_participant_slug():
+    assert "vc.resolved_participant_slug" in _sql()
+
+
+def test_new_column_appended_at_end():
+    """CREATE OR REPLACE VIEW can only append columns; the new column must come
+    after the previously-last column (days_since_created)."""
+    sql = _sql()
+    assert sql.index("days_since_created") < sql.index("vc.resolved_participant_slug")
+
+
+def test_no_schema_qualified_names():
+    content = _sql()
+    assert not re.search(r"\bpublic\.uploadable_chapters\b", content)
+    assert not re.search(r"\bpublic\.video_chapters\b", content)

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -482,6 +482,7 @@ def _make_chapter(
     session_date: str | None = "2025-06-10",
     key_speakers: list | None = None,
     speakers: list | None = None,
+    resolved_participant_slug: str | None = None,
 ) -> dict:
     return {
         "chapter_id": chapter_id,
@@ -493,6 +494,7 @@ def _make_chapter(
         if key_speakers is not None
         else [{"name": "Ana García"}],
         "speakers": speakers if speakers is not None else ["Ana García"],
+        "resolved_participant_slug": resolved_participant_slug,
     }
 
 
@@ -527,6 +529,42 @@ class TestPrepareThumbnailConfig:
         assert result["debate_summary"] != ""
         assert result["session"] is not None
         assert result["chapter_id"] == 42
+
+    def test_resolved_participant_slug_is_preferred_over_fuzzy(self):
+        """A chapter's resolved_participant_slug wins; no fuzzy lookup is spent."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(
+            chapter_id=7,
+            key_speakers=[{"name": "Ministra de Defensa"}],
+            resolved_participant_slug="margarita-robles-fernandez",
+        )
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+        ) as lookup:
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["slug"] == "margarita-robles-fernandez"
+        lookup.assert_not_called()
+
+    def test_falls_back_to_fuzzy_when_no_resolved_slug(self):
+        """Without a resolved slug the raw-speaker fuzzy path still applies."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(
+            key_speakers=[{"name": "Ana García"}],
+            resolved_participant_slug=None,
+        )
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value={"slug": "garcia-ana"},
+        ) as lookup:
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["slug"] == "garcia-ana"
+        lookup.assert_called_once_with("Ana García")
 
     def test_lookup_error_sets_slug_to_none(self):
         """A speaker lookup failure yields slug=None without raising."""


### PR DESCRIPTION
## Summary

PR3 (final) of `resolve-institutional-role-speakers` (issue #55). Closes the loop: an institutional-role speaker resolved to a sitting deputy now drives the **thumbnail photo**.

Chain: PR1 catalog ✅ → PR2 resolution + speaker integration ✅ → **PR3 thumbnail integration**.

## What's included

**Migration 021** — appends `resolved_participant_slug` to the `uploadable_chapters` view (idempotent `CREATE OR REPLACE VIEW`, column appended at the end so no `DROP`). The uploader reads the view with `SELECT *`, so the field flows through with no fetch-code change.

**Thumbnail config** (`youtube_upload_dag._prepare_thumbnail_config`)
- Prefers the chapter's authoritative `resolved_participant_slug` (written by speaker normalization — fuzzy match **or** institutional-role resolution).
- Falls back to the raw-speaker fuzzy lookup only when no resolved slug is present, so behaviour is unchanged for un-resolved chapters.

## Why this matters

Before, the thumbnail re-fuzzy-matched `key_speakers[0]` at thumbnail time. Now a chapter whose speaker was a role mention ("Ministra de Defensa" → the sitting minister, when a deputy) carries the exact slug end-to-end, so the correct person photo is used instead of a lossy re-match or a generic fallback.

## Ordering safety

If this code lands before migration 021 runs, `resolved_participant_slug` is simply absent and the fuzzy fallback applies — no breakage. The `run_migrations` DAG applies 021 idempotently on its next pass.

## Verification

- `uv run pytest` — **1949 passed**, 1 skipped, coverage 86.66%.
- Migration validated by static structural tests (`test_migration_021.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)