### PR TITLE
release: promote dev to main (issues #55, #56, #25)

### DIFF
--- a/congress_videos/catalogs/institutional_roles.v1.json
+++ b/congress_videos/catalogs/institutional_roles.v1.json
@@ -12,9 +12,53 @@
       "aliases": ["ministro de la presidencia justicia y relaciones con las cortes"]
     },
     {
+      "key": "ministerio de transportes y movilidad sostenible",
+      "scope": "ministerial",
+      "aliases": ["ministro de transportes y movilidad sostenible", "ministro de transportes"]
+    },
+    {
+      "key": "ministerio de trabajo y economia social",
+      "scope": "ministerial",
+      "aliases": [
+        "ministra de trabajo y economia social",
+        "ministra de trabajo",
+        "vicepresidenta segunda del gobierno"
+      ]
+    },
+    {
       "key": "presidencia del congreso",
       "scope": "presidency_mesa",
       "aliases": ["presidenta del congreso"]
+    },
+    {
+      "key": "lider de la oposicion",
+      "scope": "parliamentary_group",
+      "aliases": ["presidente del partido popular", "lider del partido popular"]
+    },
+    {
+      "key": "presidencia de vox",
+      "scope": "parliamentary_group",
+      "aliases": ["presidente de vox", "lider de vox"]
+    },
+    {
+      "key": "portavoz de esquerra republicana",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz del grupo parlamentario republicano", "portavoz de erc"]
+    },
+    {
+      "key": "portavoz de junts per catalunya",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz de junts", "portavoz del grupo parlamentario junts per catalunya"]
+    },
+    {
+      "key": "portavoz de euskal herria bildu",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz de eh bildu", "portavoz de bildu"]
+    },
+    {
+      "key": "secretaria general de podemos",
+      "scope": "parliamentary_group",
+      "aliases": ["lider de podemos"]
     }
   ],
   "assignments": [
@@ -43,6 +87,30 @@
       }
     },
     {
+      "id": "ministry-transport-2023-oscar-puente",
+      "role": "ministerio de transportes y movilidad sostenible",
+      "participant_slug": "oscar-puente-santiago",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
+        "evidence_note": "Official government composition reviewed for the transport ministry assignment; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-labour-2023-yolanda-diaz",
+      "role": "ministerio de trabajo y economia social",
+      "participant_slug": "yolanda-diaz-perez",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
+        "evidence_note": "Official government composition reviewed for the labour ministry and second vice-presidency assignment; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
       "id": "mesa-presidency-2019-meritxell-batet",
       "role": "presidencia del congreso",
       "participant_slug": "meritxell-batet-lamana",
@@ -64,6 +132,78 @@
         "reference_url": "https://www.congreso.es/mesa",
         "evidence_note": "Official Mesa record reviewed for the XV Legislature presidency assignment.",
         "reviewed_on": "2023-08-17"
+      }
+    },
+    {
+      "id": "opposition-leader-2023-alberto-nunez-feijoo",
+      "role": "lider de la oposicion",
+      "participant_slug": "alberto-nunez-feijoo",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/busqueda-de-diputados",
+        "evidence_note": "XV Legislature Popular parliamentary group leadership reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "vox-presidency-2023-santiago-abascal",
+      "role": "presidencia de vox",
+      "participant_slug": "santiago-abascal-conde",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/busqueda-de-diputados",
+        "evidence_note": "XV Legislature VOX parliamentary group leadership reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "erc-spokesperson-2023-gabriel-rufian",
+      "role": "portavoz de esquerra republicana",
+      "participant_slug": "gabriel-rufian-romero",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "XV Legislature Republican parliamentary group spokesperson reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "junts-spokesperson-2023-miriam-nogueras",
+      "role": "portavoz de junts per catalunya",
+      "participant_slug": "miriam-nogueras-i-camero",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "XV Legislature Junts per Catalunya parliamentary group spokesperson reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "bildu-spokesperson-2023-mertxe-aizpurua",
+      "role": "portavoz de euskal herria bildu",
+      "participant_slug": "mertxe-aizpurua-arzallus",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "XV Legislature EH Bildu parliamentary group spokesperson reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "podemos-secretary-general-2023-ione-belarra",
+      "role": "secretaria general de podemos",
+      "participant_slug": "ione-belarra-urteaga",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/busqueda-de-diputados",
+        "evidence_note": "XV Legislature Podemos leadership reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
       }
     }
   ]

--- a/congress_videos/catalogs/institutional_roles.v1.json
+++ b/congress_videos/catalogs/institutional_roles.v1.json
@@ -1,0 +1,70 @@
+{
+  "catalog_version": 1,
+  "roles": [
+    {
+      "key": "presidencia del gobierno",
+      "scope": "ministerial",
+      "aliases": ["presidente del gobierno"]
+    },
+    {
+      "key": "ministerio de la presidencia justicia y relaciones con las cortes",
+      "scope": "ministerial",
+      "aliases": ["ministro de la presidencia justicia y relaciones con las cortes"]
+    },
+    {
+      "key": "presidencia del congreso",
+      "scope": "presidency_mesa",
+      "aliases": ["presidenta del congreso"]
+    }
+  ],
+  "assignments": [
+    {
+      "id": "government-presidency-2018-pedro-sanchez",
+      "role": "presidencia del gobierno",
+      "participant_slug": "pedro-sanchez-perez-castejon",
+      "validity": {"from": "2018-06-02", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
+        "evidence_note": "Official government composition reviewed for the continued presidency assignment.",
+        "reviewed_on": "2023-11-21"
+      }
+    },
+    {
+      "id": "ministry-presidency-justice-2023-felix-bolanos",
+      "role": "ministerio de la presidencia justicia y relaciones con las cortes",
+      "participant_slug": "felix-bolanos-garcia",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
+        "evidence_note": "Official government composition reviewed for the ministry assignment.",
+        "reviewed_on": "2023-11-21"
+      }
+    },
+    {
+      "id": "mesa-presidency-2019-meritxell-batet",
+      "role": "presidencia del congreso",
+      "participant_slug": "meritxell-batet-lamana",
+      "validity": {"from": "2019-12-03", "to": "2023-05-30"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/mesa",
+        "evidence_note": "Official Mesa record reviewed for the XIV Legislature presidency assignment.",
+        "reviewed_on": "2023-08-17"
+      }
+    },
+    {
+      "id": "mesa-presidency-2023-francina-armengol",
+      "role": "presidencia del congreso",
+      "participant_slug": "francina-armengol-socias",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/mesa",
+        "evidence_note": "Official Mesa record reviewed for the XV Legislature presidency assignment.",
+        "reviewed_on": "2023-08-17"
+      }
+    }
+  ]
+}

--- a/congress_videos/catalogs/institutional_roles.v1.json
+++ b/congress_videos/catalogs/institutional_roles.v1.json
@@ -4,7 +4,9 @@
     {
       "key": "presidencia del gobierno",
       "scope": "ministerial",
-      "aliases": ["presidente del gobierno"]
+      "aliases": [
+        "presidente del gobierno"
+      ]
     },
     {
       "key": "ministerio de economia comercio y empresa",
@@ -36,82 +38,123 @@
     {
       "key": "ministerio de asuntos exteriores union europea y cooperacion",
       "scope": "ministerial",
-      "aliases": ["ministro de asuntos exteriores", "ministro de exteriores"]
+      "aliases": [
+        "ministro de asuntos exteriores",
+        "ministro de exteriores"
+      ]
     },
     {
       "key": "ministerio de la presidencia justicia y relaciones con las cortes",
       "scope": "ministerial",
-      "aliases": ["ministro de la presidencia justicia y relaciones con las cortes"]
+      "aliases": [
+        "ministro de la presidencia justicia y relaciones con las cortes"
+      ]
     },
     {
       "key": "ministerio de defensa",
       "scope": "ministerial",
-      "aliases": ["ministra de defensa"]
+      "aliases": [
+        "ministra de defensa"
+      ]
     },
     {
       "key": "ministerio de hacienda",
       "scope": "ministerial",
-      "aliases": ["ministro de hacienda"]
+      "aliases": [
+        "ministro de hacienda"
+      ]
     },
     {
       "key": "ministerio del interior",
       "scope": "ministerial",
-      "aliases": ["ministro del interior"]
+      "aliases": [
+        "ministro del interior"
+      ]
     },
     {
       "key": "ministerio de transportes y movilidad sostenible",
       "scope": "ministerial",
-      "aliases": ["ministro de transportes y movilidad sostenible", "ministro de transportes"]
+      "aliases": [
+        "ministro de transportes y movilidad sostenible",
+        "ministro de transportes"
+      ]
     },
     {
       "key": "ministerio de educacion formacion profesional y deportes",
       "scope": "ministerial",
-      "aliases": ["ministra de educacion formacion profesional y deportes", "ministra de educacion"]
+      "aliases": [
+        "ministra de educacion formacion profesional y deportes",
+        "ministra de educacion"
+      ]
     },
     {
       "key": "ministerio de industria y turismo",
       "scope": "ministerial",
-      "aliases": ["ministro de industria y turismo", "ministro de industria"]
+      "aliases": [
+        "ministro de industria y turismo",
+        "ministro de industria"
+      ]
     },
     {
       "key": "ministerio de agricultura pesca y alimentacion",
       "scope": "ministerial",
-      "aliases": ["ministro de agricultura pesca y alimentacion", "ministro de agricultura"]
+      "aliases": [
+        "ministro de agricultura pesca y alimentacion",
+        "ministro de agricultura"
+      ]
     },
     {
       "key": "ministerio de politica territorial y memoria democratica",
       "scope": "ministerial",
-      "aliases": ["ministro de politica territorial y memoria democratica", "ministro de politica territorial"]
+      "aliases": [
+        "ministro de politica territorial y memoria democratica",
+        "ministro de politica territorial"
+      ]
     },
     {
       "key": "ministerio de vivienda y agenda urbana",
       "scope": "ministerial",
-      "aliases": ["ministra de vivienda y agenda urbana", "ministra de vivienda"]
+      "aliases": [
+        "ministra de vivienda y agenda urbana",
+        "ministra de vivienda"
+      ]
     },
     {
       "key": "ministerio de cultura",
       "scope": "ministerial",
-      "aliases": ["ministro de cultura"]
+      "aliases": [
+        "ministro de cultura"
+      ]
     },
     {
       "key": "ministerio de sanidad",
       "scope": "ministerial",
-      "aliases": ["ministra de sanidad"]
+      "aliases": [
+        "ministra de sanidad"
+      ]
     },
     {
       "key": "ministerio de derechos sociales consumo y agenda 2030",
       "scope": "ministerial",
-      "aliases": ["ministro de derechos sociales consumo y agenda 2030", "ministro de derechos sociales"]
+      "aliases": [
+        "ministro de derechos sociales consumo y agenda 2030",
+        "ministro de derechos sociales"
+      ]
     },
     {
       "key": "ministerio de ciencia innovacion y universidades",
       "scope": "ministerial",
-      "aliases": ["ministra de ciencia innovacion y universidades", "ministra de ciencia"]
+      "aliases": [
+        "ministra de ciencia innovacion y universidades",
+        "ministra de ciencia"
+      ]
     },
     {
       "key": "ministerio de igualdad",
       "scope": "ministerial",
-      "aliases": ["ministra de igualdad"]
+      "aliases": [
+        "ministra de igualdad"
+      ]
     },
     {
       "key": "ministerio de inclusion seguridad social y migraciones",
@@ -125,67 +168,102 @@
     {
       "key": "ministerio para la transformacion digital y de la funcion publica",
       "scope": "ministerial",
-      "aliases": ["ministro para la transformacion digital y de la funcion publica", "ministro de funcion publica"]
+      "aliases": [
+        "ministro para la transformacion digital y de la funcion publica",
+        "ministro de funcion publica"
+      ]
     },
     {
       "key": "ministerio de juventud e infancia",
       "scope": "ministerial",
-      "aliases": ["ministra de juventud e infancia", "ministra de juventud"]
+      "aliases": [
+        "ministra de juventud e infancia",
+        "ministra de juventud"
+      ]
     },
     {
       "key": "presidencia del congreso",
       "scope": "presidency_mesa",
-      "aliases": ["presidenta del congreso"]
+      "aliases": [
+        "presidenta del congreso"
+      ]
     },
     {
       "key": "lider de la oposicion",
       "scope": "parliamentary_group",
-      "aliases": ["presidente del partido popular", "lider del partido popular"]
+      "aliases": [
+        "presidente del partido popular",
+        "lider del partido popular"
+      ]
     },
     {
       "key": "presidencia de vox",
       "scope": "parliamentary_group",
-      "aliases": ["presidente de vox", "lider de vox"]
+      "aliases": [
+        "presidente de vox",
+        "lider de vox"
+      ]
     },
     {
       "key": "portavoz de esquerra republicana",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz del grupo parlamentario republicano", "portavoz de erc"]
+      "aliases": [
+        "portavoz del grupo parlamentario republicano",
+        "portavoz de erc"
+      ]
     },
     {
       "key": "portavoz de junts per catalunya",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz de junts", "portavoz del grupo parlamentario junts per catalunya"]
+      "aliases": [
+        "portavoz de junts",
+        "portavoz del grupo parlamentario junts per catalunya"
+      ]
     },
     {
       "key": "portavoz de euskal herria bildu",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz de eh bildu", "portavoz de bildu"]
+      "aliases": [
+        "portavoz de eh bildu",
+        "portavoz de bildu"
+      ]
     },
     {
       "key": "secretaria general de podemos",
       "scope": "parliamentary_group",
-      "aliases": ["lider de podemos"]
+      "aliases": [
+        "lider de podemos"
+      ]
     },
     {
       "key": "portavoz del grupo parlamentario socialista",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz del psoe", "portavoz socialista"]
+      "aliases": [
+        "portavoz del psoe",
+        "portavoz socialista"
+      ]
     },
     {
       "key": "portavoz del grupo parlamentario popular",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz del pp", "portavoz popular"]
+      "aliases": [
+        "portavoz del pp",
+        "portavoz popular"
+      ]
     },
     {
       "key": "portavoz del grupo parlamentario vox",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz de vox"]
+      "aliases": [
+        "portavoz de vox"
+      ]
     },
     {
       "key": "portavoz del grupo plurinacional sumar",
       "scope": "parliamentary_group",
-      "aliases": ["portavoz de sumar"]
+      "aliases": [
+        "portavoz de sumar"
+      ]
     }
   ],
   "assignments": [
@@ -193,7 +271,11 @@
       "id": "government-presidency-2018-pedro-sanchez",
       "role": "presidencia del gobierno",
       "participant_slug": "pedro-sanchez-perez-castejon",
-      "validity": {"from": "2018-06-02", "to": "open"},
+      "display_name": "Sánchez Pérez-Castejón, Pedro",
+      "validity": {
+        "from": "2018-06-02",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -205,7 +287,11 @@
       "id": "vp1-economy-2023-carlos-cuerpo",
       "role": "ministerio de economia comercio y empresa",
       "participant_slug": "carlos-cuerpo-caballero",
-      "validity": {"from": "2023-12-29", "to": "open"},
+      "display_name": "Cuerpo Caballero, Carlos",
+      "validity": {
+        "from": "2023-12-29",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -217,7 +303,11 @@
       "id": "vp2-labour-2023-yolanda-diaz",
       "role": "ministerio de trabajo y economia social",
       "participant_slug": "yolanda-diaz-perez",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Díaz Pérez, Yolanda",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -229,7 +319,11 @@
       "id": "vp3-ecological-transition-2024-sara-aagesen",
       "role": "ministerio para la transicion ecologica y el reto demografico",
       "participant_slug": "sara-aagesen-munoz",
-      "validity": {"from": "2024-11-25", "to": "open"},
+      "display_name": "Aagesen Muñoz, Sara",
+      "validity": {
+        "from": "2024-11-25",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -241,7 +335,11 @@
       "id": "ministry-foreign-affairs-2023-jose-manuel-albares",
       "role": "ministerio de asuntos exteriores union europea y cooperacion",
       "participant_slug": "jose-manuel-albares-bueno",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Albares Bueno, José Manuel",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -253,7 +351,11 @@
       "id": "ministry-presidency-justice-2023-felix-bolanos",
       "role": "ministerio de la presidencia justicia y relaciones con las cortes",
       "participant_slug": "felix-bolanos-garcia",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Bolaños García, Félix",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -265,7 +367,11 @@
       "id": "ministry-defence-2023-margarita-robles",
       "role": "ministerio de defensa",
       "participant_slug": "margarita-robles-fernandez",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Robles Fernández, Margarita",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -277,7 +383,11 @@
       "id": "ministry-treasury-2026-arcadi-espana",
       "role": "ministerio de hacienda",
       "participant_slug": "arcadi-espana-garcia",
-      "validity": {"from": "2026-03-27", "to": "open"},
+      "display_name": "España García, Arcadi",
+      "validity": {
+        "from": "2026-03-27",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -289,7 +399,11 @@
       "id": "ministry-interior-2023-fernando-grande-marlaska",
       "role": "ministerio del interior",
       "participant_slug": "fernando-grande-marlaska-gomez",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Grande-Marlaska Gómez, Fernando",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -301,7 +415,11 @@
       "id": "ministry-transport-2023-oscar-puente",
       "role": "ministerio de transportes y movilidad sostenible",
       "participant_slug": "oscar-puente-santiago",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Puente Santiago, Óscar",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -313,7 +431,11 @@
       "id": "ministry-education-2025-milagros-tolon",
       "role": "ministerio de educacion formacion profesional y deportes",
       "participant_slug": "milagros-tolon-jaime",
-      "validity": {"from": "2025-12-22", "to": "open"},
+      "display_name": "Tolón Jaime, Milagros",
+      "validity": {
+        "from": "2025-12-22",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -325,7 +447,11 @@
       "id": "ministry-industry-2023-jordi-hereu",
       "role": "ministerio de industria y turismo",
       "participant_slug": "jordi-hereu-boher",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Hereu Boher, Jordi",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -337,7 +463,11 @@
       "id": "ministry-agriculture-2023-luis-planas",
       "role": "ministerio de agricultura pesca y alimentacion",
       "participant_slug": "luis-planas-puchades",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Planas Puchades, Luis",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -349,7 +479,11 @@
       "id": "ministry-territorial-policy-2023-angel-victor-torres",
       "role": "ministerio de politica territorial y memoria democratica",
       "participant_slug": "angel-victor-torres-perez",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Torres Pérez, Ángel Víctor",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -361,7 +495,11 @@
       "id": "ministry-housing-2023-isabel-rodriguez",
       "role": "ministerio de vivienda y agenda urbana",
       "participant_slug": "isabel-rodriguez-garcia",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Rodríguez García, Isabel",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -373,7 +511,11 @@
       "id": "ministry-culture-2023-ernest-urtasun",
       "role": "ministerio de cultura",
       "participant_slug": "ernest-urtasun-domenech",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Urtasun Domènech, Ernest",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -385,7 +527,11 @@
       "id": "ministry-health-2023-monica-garcia",
       "role": "ministerio de sanidad",
       "participant_slug": "monica-garcia-gomez",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "García Gómez, Mónica",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -397,7 +543,11 @@
       "id": "ministry-social-rights-2023-pablo-bustinduy",
       "role": "ministerio de derechos sociales consumo y agenda 2030",
       "participant_slug": "pablo-bustinduy-amador",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Bustinduy Amador, Pablo",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -409,7 +559,11 @@
       "id": "ministry-science-2023-diana-morant",
       "role": "ministerio de ciencia innovacion y universidades",
       "participant_slug": "diana-morant-ripoll",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Morant Ripoll, Diana",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -421,7 +575,11 @@
       "id": "ministry-equality-2023-ana-redondo",
       "role": "ministerio de igualdad",
       "participant_slug": "ana-redondo-garcia",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Redondo García, Ana",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -433,7 +591,11 @@
       "id": "ministry-inclusion-2023-elma-saiz",
       "role": "ministerio de inclusion seguridad social y migraciones",
       "participant_slug": "elma-saiz-delgado",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Saiz Delgado, Elma",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -445,7 +607,11 @@
       "id": "ministry-digital-transformation-2024-oscar-lopez",
       "role": "ministerio para la transformacion digital y de la funcion publica",
       "participant_slug": "oscar-lopez-agueda",
-      "validity": {"from": "2024-09-06", "to": "open"},
+      "display_name": "López Águeda, Óscar",
+      "validity": {
+        "from": "2024-09-06",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -457,7 +623,11 @@
       "id": "ministry-youth-2023-sira-rego",
       "role": "ministerio de juventud e infancia",
       "participant_slug": "sira-rego",
-      "validity": {"from": "2023-11-21", "to": "open"},
+      "display_name": "Rego, Sira",
+      "validity": {
+        "from": "2023-11-21",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "La Moncloa",
         "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
@@ -469,7 +639,11 @@
       "id": "mesa-presidency-2019-meritxell-batet",
       "role": "presidencia del congreso",
       "participant_slug": "meritxell-batet-lamana",
-      "validity": {"from": "2019-12-03", "to": "2023-05-30"},
+      "display_name": "Batet Lamana, Meritxell",
+      "validity": {
+        "from": "2019-12-03",
+        "to": "2023-05-30"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/mesa",
@@ -481,7 +655,11 @@
       "id": "mesa-presidency-2023-francina-armengol",
       "role": "presidencia del congreso",
       "participant_slug": "francina-armengol-socias",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Armengol Socias, Francina",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/mesa",
@@ -493,7 +671,11 @@
       "id": "opposition-leader-2023-alberto-nunez-feijoo",
       "role": "lider de la oposicion",
       "participant_slug": "alberto-nunez-feijoo",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Núñez Feijóo, Alberto",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/busqueda-de-diputados",
@@ -505,7 +687,11 @@
       "id": "vox-presidency-2023-santiago-abascal",
       "role": "presidencia de vox",
       "participant_slug": "santiago-abascal-conde",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Abascal Conde, Santiago",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/busqueda-de-diputados",
@@ -517,7 +703,11 @@
       "id": "erc-spokesperson-2023-gabriel-rufian",
       "role": "portavoz de esquerra republicana",
       "participant_slug": "gabriel-rufian-romero",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Rufián Romero, Gabriel",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",
@@ -529,7 +719,11 @@
       "id": "junts-spokesperson-2023-miriam-nogueras",
       "role": "portavoz de junts per catalunya",
       "participant_slug": "miriam-nogueras-i-camero",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Nogueras i Camero, Míriam",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",
@@ -541,7 +735,11 @@
       "id": "bildu-spokesperson-2023-mertxe-aizpurua",
       "role": "portavoz de euskal herria bildu",
       "participant_slug": "mertxe-aizpurua-arzallus",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Aizpurua Arzallus, Mertxe",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",
@@ -553,7 +751,11 @@
       "id": "podemos-secretary-general-2023-ione-belarra",
       "role": "secretaria general de podemos",
       "participant_slug": "ione-belarra-urteaga",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Belarra Urteaga, Ione",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/busqueda-de-diputados",
@@ -565,7 +767,11 @@
       "id": "psoe-spokesperson-2023-patxi-lopez",
       "role": "portavoz del grupo parlamentario socialista",
       "participant_slug": "patxi-lopez-alvarez",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "López Álvarez, Patxi",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",
@@ -577,7 +783,11 @@
       "id": "pp-spokesperson-2023-miguel-tellado",
       "role": "portavoz del grupo parlamentario popular",
       "participant_slug": "miguel-tellado-filgueira",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Tellado Filgueira, Miguel",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",
@@ -589,7 +799,11 @@
       "id": "vox-spokesperson-2023-pepa-millan",
       "role": "portavoz del grupo parlamentario vox",
       "participant_slug": "maria-jose-rodriguez-de-millan-parro",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Rodríguez de Millán Parro, María José",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",
@@ -601,7 +815,11 @@
       "id": "sumar-spokesperson-2026-veronica-martinez-barbero",
       "role": "portavoz del grupo plurinacional sumar",
       "participant_slug": "veronica-martinez-barbero",
-      "validity": {"from": "2023-08-17", "to": "open"},
+      "display_name": "Martínez Barbero, Verónica",
+      "validity": {
+        "from": "2023-08-17",
+        "to": "open"
+      },
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/grupos",

--- a/congress_videos/catalogs/institutional_roles.v1.json
+++ b/congress_videos/catalogs/institutional_roles.v1.json
@@ -7,14 +7,14 @@
       "aliases": ["presidente del gobierno"]
     },
     {
-      "key": "ministerio de la presidencia justicia y relaciones con las cortes",
+      "key": "ministerio de economia comercio y empresa",
       "scope": "ministerial",
-      "aliases": ["ministro de la presidencia justicia y relaciones con las cortes"]
-    },
-    {
-      "key": "ministerio de transportes y movilidad sostenible",
-      "scope": "ministerial",
-      "aliases": ["ministro de transportes y movilidad sostenible", "ministro de transportes"]
+      "aliases": [
+        "ministro de economia comercio y empresa",
+        "ministro de economia",
+        "vicepresidente primero del gobierno",
+        "vicepresidencia primera del gobierno"
+      ]
     },
     {
       "key": "ministerio de trabajo y economia social",
@@ -24,6 +24,113 @@
         "ministra de trabajo",
         "vicepresidenta segunda del gobierno"
       ]
+    },
+    {
+      "key": "ministerio para la transicion ecologica y el reto demografico",
+      "scope": "ministerial",
+      "aliases": [
+        "ministra para la transicion ecologica",
+        "vicepresidenta tercera del gobierno"
+      ]
+    },
+    {
+      "key": "ministerio de asuntos exteriores union europea y cooperacion",
+      "scope": "ministerial",
+      "aliases": ["ministro de asuntos exteriores", "ministro de exteriores"]
+    },
+    {
+      "key": "ministerio de la presidencia justicia y relaciones con las cortes",
+      "scope": "ministerial",
+      "aliases": ["ministro de la presidencia justicia y relaciones con las cortes"]
+    },
+    {
+      "key": "ministerio de defensa",
+      "scope": "ministerial",
+      "aliases": ["ministra de defensa"]
+    },
+    {
+      "key": "ministerio de hacienda",
+      "scope": "ministerial",
+      "aliases": ["ministro de hacienda"]
+    },
+    {
+      "key": "ministerio del interior",
+      "scope": "ministerial",
+      "aliases": ["ministro del interior"]
+    },
+    {
+      "key": "ministerio de transportes y movilidad sostenible",
+      "scope": "ministerial",
+      "aliases": ["ministro de transportes y movilidad sostenible", "ministro de transportes"]
+    },
+    {
+      "key": "ministerio de educacion formacion profesional y deportes",
+      "scope": "ministerial",
+      "aliases": ["ministra de educacion formacion profesional y deportes", "ministra de educacion"]
+    },
+    {
+      "key": "ministerio de industria y turismo",
+      "scope": "ministerial",
+      "aliases": ["ministro de industria y turismo", "ministro de industria"]
+    },
+    {
+      "key": "ministerio de agricultura pesca y alimentacion",
+      "scope": "ministerial",
+      "aliases": ["ministro de agricultura pesca y alimentacion", "ministro de agricultura"]
+    },
+    {
+      "key": "ministerio de politica territorial y memoria democratica",
+      "scope": "ministerial",
+      "aliases": ["ministro de politica territorial y memoria democratica", "ministro de politica territorial"]
+    },
+    {
+      "key": "ministerio de vivienda y agenda urbana",
+      "scope": "ministerial",
+      "aliases": ["ministra de vivienda y agenda urbana", "ministra de vivienda"]
+    },
+    {
+      "key": "ministerio de cultura",
+      "scope": "ministerial",
+      "aliases": ["ministro de cultura"]
+    },
+    {
+      "key": "ministerio de sanidad",
+      "scope": "ministerial",
+      "aliases": ["ministra de sanidad"]
+    },
+    {
+      "key": "ministerio de derechos sociales consumo y agenda 2030",
+      "scope": "ministerial",
+      "aliases": ["ministro de derechos sociales consumo y agenda 2030", "ministro de derechos sociales"]
+    },
+    {
+      "key": "ministerio de ciencia innovacion y universidades",
+      "scope": "ministerial",
+      "aliases": ["ministra de ciencia innovacion y universidades", "ministra de ciencia"]
+    },
+    {
+      "key": "ministerio de igualdad",
+      "scope": "ministerial",
+      "aliases": ["ministra de igualdad"]
+    },
+    {
+      "key": "ministerio de inclusion seguridad social y migraciones",
+      "scope": "ministerial",
+      "aliases": [
+        "ministra de inclusion seguridad social y migraciones",
+        "ministra de inclusion",
+        "portavoz del gobierno"
+      ]
+    },
+    {
+      "key": "ministerio para la transformacion digital y de la funcion publica",
+      "scope": "ministerial",
+      "aliases": ["ministro para la transformacion digital y de la funcion publica", "ministro de funcion publica"]
+    },
+    {
+      "key": "ministerio de juventud e infancia",
+      "scope": "ministerial",
+      "aliases": ["ministra de juventud e infancia", "ministra de juventud"]
     },
     {
       "key": "presidencia del congreso",
@@ -59,6 +166,26 @@
       "key": "secretaria general de podemos",
       "scope": "parliamentary_group",
       "aliases": ["lider de podemos"]
+    },
+    {
+      "key": "portavoz del grupo parlamentario socialista",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz del psoe", "portavoz socialista"]
+    },
+    {
+      "key": "portavoz del grupo parlamentario popular",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz del pp", "portavoz popular"]
+    },
+    {
+      "key": "portavoz del grupo parlamentario vox",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz de vox"]
+    },
+    {
+      "key": "portavoz del grupo plurinacional sumar",
+      "scope": "parliamentary_group",
+      "aliases": ["portavoz de sumar"]
     }
   ],
   "assignments": [
@@ -69,9 +196,57 @@
       "validity": {"from": "2018-06-02", "to": "open"},
       "provenance": {
         "publisher": "La Moncloa",
-        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
-        "evidence_note": "Official government composition reviewed for the continued presidency assignment.",
-        "reviewed_on": "2023-11-21"
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "vp1-economy-2023-carlos-cuerpo",
+      "role": "ministerio de economia comercio y empresa",
+      "participant_slug": "carlos-cuerpo-caballero",
+      "validity": {"from": "2023-12-29", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "vp2-labour-2023-yolanda-diaz",
+      "role": "ministerio de trabajo y economia social",
+      "participant_slug": "yolanda-diaz-perez",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "vp3-ecological-transition-2024-sara-aagesen",
+      "role": "ministerio para la transicion ecologica y el reto demografico",
+      "participant_slug": "sara-aagesen-munoz",
+      "validity": {"from": "2024-11-25", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-foreign-affairs-2023-jose-manuel-albares",
+      "role": "ministerio de asuntos exteriores union europea y cooperacion",
+      "participant_slug": "jose-manuel-albares-bueno",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
       }
     },
     {
@@ -81,9 +256,45 @@
       "validity": {"from": "2023-11-21", "to": "open"},
       "provenance": {
         "publisher": "La Moncloa",
-        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
-        "evidence_note": "Official government composition reviewed for the ministry assignment.",
-        "reviewed_on": "2023-11-21"
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-defence-2023-margarita-robles",
+      "role": "ministerio de defensa",
+      "participant_slug": "margarita-robles-fernandez",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-treasury-2026-arcadi-espana",
+      "role": "ministerio de hacienda",
+      "participant_slug": "arcadi-espana-garcia",
+      "validity": {"from": "2026-03-27", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-interior-2023-fernando-grande-marlaska",
+      "role": "ministerio del interior",
+      "participant_slug": "fernando-grande-marlaska-gomez",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
       }
     },
     {
@@ -93,20 +304,164 @@
       "validity": {"from": "2023-11-21", "to": "open"},
       "provenance": {
         "publisher": "La Moncloa",
-        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
-        "evidence_note": "Official government composition reviewed for the transport ministry assignment; participant slug cross-checked against the active-deputies register.",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug cross-checked against the active-deputies register.",
         "reviewed_on": "2026-08-12"
       }
     },
     {
-      "id": "ministry-labour-2023-yolanda-diaz",
-      "role": "ministerio de trabajo y economia social",
-      "participant_slug": "yolanda-diaz-perez",
+      "id": "ministry-education-2025-milagros-tolon",
+      "role": "ministerio de educacion formacion profesional y deportes",
+      "participant_slug": "milagros-tolon-jaime",
+      "validity": {"from": "2025-12-22", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-industry-2023-jordi-hereu",
+      "role": "ministerio de industria y turismo",
+      "participant_slug": "jordi-hereu-boher",
       "validity": {"from": "2023-11-21", "to": "open"},
       "provenance": {
         "publisher": "La Moncloa",
-        "reference_url": "https://www.lamoncloa.gob.es/gobierno/Paginas/index.aspx",
-        "evidence_note": "Official government composition reviewed for the labour ministry and second vice-presidency assignment; participant slug cross-checked against the active-deputies register.",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-agriculture-2023-luis-planas",
+      "role": "ministerio de agricultura pesca y alimentacion",
+      "participant_slug": "luis-planas-puchades",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-territorial-policy-2023-angel-victor-torres",
+      "role": "ministerio de politica territorial y memoria democratica",
+      "participant_slug": "angel-victor-torres-perez",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-housing-2023-isabel-rodriguez",
+      "role": "ministerio de vivienda y agenda urbana",
+      "participant_slug": "isabel-rodriguez-garcia",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-culture-2023-ernest-urtasun",
+      "role": "ministerio de cultura",
+      "participant_slug": "ernest-urtasun-domenech",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-health-2023-monica-garcia",
+      "role": "ministerio de sanidad",
+      "participant_slug": "monica-garcia-gomez",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-social-rights-2023-pablo-bustinduy",
+      "role": "ministerio de derechos sociales consumo y agenda 2030",
+      "participant_slug": "pablo-bustinduy-amador",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-science-2023-diana-morant",
+      "role": "ministerio de ciencia innovacion y universidades",
+      "participant_slug": "diana-morant-ripoll",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-equality-2023-ana-redondo",
+      "role": "ministerio de igualdad",
+      "participant_slug": "ana-redondo-garcia",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-inclusion-2023-elma-saiz",
+      "role": "ministerio de inclusion seguridad social y migraciones",
+      "participant_slug": "elma-saiz-delgado",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; also government spokesperson since 2025-12-22; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-digital-transformation-2024-oscar-lopez",
+      "role": "ministerio para la transformacion digital y de la funcion publica",
+      "participant_slug": "oscar-lopez-agueda",
+      "validity": {"from": "2024-09-06", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "ministry-youth-2023-sira-rego",
+      "role": "ministerio de juventud e infancia",
+      "participant_slug": "sira-rego",
+      "validity": {"from": "2023-11-21", "to": "open"},
+      "provenance": {
+        "publisher": "La Moncloa",
+        "reference_url": "https://www.lamoncloa.gob.es/gobierno/composiciondelgobierno/paginas/index.aspx",
+        "evidence_note": "Official government composition; participant slug derived from the official name and not present in the active-deputies register.",
         "reviewed_on": "2026-08-12"
       }
     },
@@ -130,8 +485,8 @@
       "provenance": {
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/mesa",
-        "evidence_note": "Official Mesa record reviewed for the XV Legislature presidency assignment.",
-        "reviewed_on": "2023-08-17"
+        "evidence_note": "Official Mesa record reviewed for the XV Legislature presidency assignment; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
       }
     },
     {
@@ -203,6 +558,54 @@
         "publisher": "Congress of Deputies",
         "reference_url": "https://www.congreso.es/busqueda-de-diputados",
         "evidence_note": "XV Legislature Podemos leadership reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "psoe-spokesperson-2023-patxi-lopez",
+      "role": "portavoz del grupo parlamentario socialista",
+      "participant_slug": "patxi-lopez-alvarez",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "XV Legislature Socialist parliamentary group spokesperson reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "pp-spokesperson-2023-miguel-tellado",
+      "role": "portavoz del grupo parlamentario popular",
+      "participant_slug": "miguel-tellado-filgueira",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "XV Legislature Popular parliamentary group spokesperson reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "vox-spokesperson-2023-pepa-millan",
+      "role": "portavoz del grupo parlamentario vox",
+      "participant_slug": "maria-jose-rodriguez-de-millan-parro",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "XV Legislature VOX parliamentary group spokesperson reviewed against the official Congress register; participant slug cross-checked against the active-deputies register.",
+        "reviewed_on": "2026-08-12"
+      }
+    },
+    {
+      "id": "sumar-spokesperson-2026-veronica-martinez-barbero",
+      "role": "portavoz del grupo plurinacional sumar",
+      "participant_slug": "veronica-martinez-barbero",
+      "validity": {"from": "2023-08-17", "to": "open"},
+      "provenance": {
+        "publisher": "Congress of Deputies",
+        "reference_url": "https://www.congreso.es/grupos",
+        "evidence_note": "Plurinational SUMAR parliamentary group spokesperson reviewed against the official Congress register; group-spokesperson start date recorded as the legislature start as a best-effort bound; participant slug cross-checked against the active-deputies register.",
         "reviewed_on": "2026-08-12"
       }
     }

--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -363,6 +363,15 @@ Tu tarea es analizar UN CHUNK de sesión parlamentaria que dura MÁS de 45 minut
 - Máximo 120 minutos por capítulo (solo si es tema único coherente)
 - Si divides, hazlo en pausas naturales (4-5+ segundos de silencio)
 
+FORMATO DE HABLADORES:
+Cada entrada en "speakers" es un objeto con tres campos:
+- speaker_name: nombre completo del hablador (string) o null si no se puede identificar
+- speaker_role: cargo o rol parlamentario (string) o null si no se conoce
+- speaker_confidence: confianza en la identificación (número 0.0-1.0) o null
+
+REGLA CRÍTICA: Usa null para speaker_name cuando el hablador no sea identificable por nombre.
+No uses texto genérico en speaker_name — los valores desconocidos siempre son null.
+
 IMPORTANTE:
 - Prioriza mantener temas completos juntos
 - Solo divide por tiempo si supera 2 horas
@@ -428,7 +437,13 @@ FORMATO DE RESPUESTA:
       "start_time": "HH:MM:SS,mmm",
       "end_time": "HH:MM:SS,mmm",
       "duration_minutes": <número>,
-      "speakers": ["Lista de habladores"],
+      "speakers": [
+        {{
+          "speaker_name": "Nombre completo o null si desconocido",
+          "speaker_role": "Cargo o rol o null",
+          "speaker_confidence": 0.9
+        }}
+      ],
       "topics": ["Lista de temas"]
     }}
   ]
@@ -445,7 +460,12 @@ Output: 1 capítulo completo (≤ 120 min, OK)
       "start_time": "00:00:00,000",
       "end_time": "01:30:00,000",
       "duration_minutes": 90.0,
-      "speakers": ["Portavoz PP", "Presidente Sánchez", "Portavoz Sumar", "Ministra"],
+      "speakers": [
+        {{"speaker_name": "Pedro Sánchez", "speaker_role": "Presidente del Gobierno", "speaker_confidence": 0.95}},
+        {{"speaker_name": "Alberto Núñez Feijóo", "speaker_role": "Líder del PP", "speaker_confidence": 0.95}},
+        {{"speaker_name": null, "speaker_role": "Portavoz Sumar", "speaker_confidence": null}},
+        {{"speaker_name": null, "speaker_role": "Ministra", "speaker_confidence": null}}
+      ],
       "topics": ["Víctimas Dana", "Responsabilidad gobierno", "Ayudas", "Prevención"]
     }}
   ]
@@ -462,7 +482,9 @@ Output: 2 capítulos divididos en pausas naturales
       "start_time": "00:00:00,000",
       "end_time": "01:25:00,000",
       "duration_minutes": 85.0,
-      "speakers": ["..."],
+      "speakers": [
+        {{"speaker_name": null, "speaker_role": "Portavoz PP", "speaker_confidence": null}}
+      ],
       "topics": ["Energía", "Precios luz", "Renovables"]
     }},
     {{
@@ -471,7 +493,9 @@ Output: 2 capítulos divididos en pausas naturales
       "start_time": "01:25:00,000",
       "end_time": "02:45:00,000",
       "duration_minutes": 80.0,
-      "speakers": ["..."],
+      "speakers": [
+        {{"speaker_name": null, "speaker_role": "Portavoz PSOE", "speaker_confidence": null}}
+      ],
       "topics": ["Energía", "Dependencia energética", "Transición"]
     }}
   ]
@@ -487,6 +511,7 @@ Output: 2 capítulos (uno por tema)
 - Solo divide por tiempo si el chunk > 120 minutos
 - Divide en pausas naturales (4-5+ segundos)
 - NUNCA lista vacía - mínimo 1 capítulo
+- speaker_name DEBE ser null (nunca texto genérico) cuando el hablador sea desconocido
 
 Devuelve SOLO el JSON."""
 

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1319,6 +1319,7 @@ class CongressionalVideoDB:
         speakers: list,
         key_speakers: list,
         timeline: list,
+        resolved_participant_slug: str | None = None,
     ) -> None:
         """Overwrite the speakers, key_speakers and timeline JSONB for a chapter.
 
@@ -1330,26 +1331,46 @@ class CongressionalVideoDB:
             speakers: Updated list of speaker display names.
             key_speakers: Updated list of key speaker display names.
             timeline: Updated list of timeline dicts (each has 'speaker' field).
+            resolved_participant_slug: When provided, also writes the FK column
+                ``resolved_participant_slug`` linking this chapter to a verified
+                ``congress_participants`` row. Omit (or pass None) to leave the
+                column unchanged.
         """
         chapters_table = self.pg_conn.get_qualified_table("video_chapters")
 
         with self.pg_conn.get_connection() as conn:
             with conn.cursor() as cur:
-                cur.execute(
-                    f"""
-                    UPDATE {chapters_table}
-                    SET speakers = %s,
-                        key_speakers = %s,
-                        timeline = %s::jsonb,
-                        updated_at = CURRENT_TIMESTAMP
-                    WHERE chapter_id = %s
-                    """,
-                    (speakers, key_speakers, json.dumps(timeline), chapter_id),
-                )
+                if resolved_participant_slug is not None:
+                    cur.execute(
+                        f"""
+                        UPDATE {chapters_table}
+                        SET speakers = %s,
+                            key_speakers = %s,
+                            timeline = %s::jsonb,
+                            resolved_participant_slug = %s,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE chapter_id = %s
+                        """,
+                        (speakers, key_speakers, json.dumps(timeline),
+                         resolved_participant_slug, chapter_id),
+                    )
+                else:
+                    cur.execute(
+                        f"""
+                        UPDATE {chapters_table}
+                        SET speakers = %s,
+                            key_speakers = %s,
+                            timeline = %s::jsonb,
+                            updated_at = CURRENT_TIMESTAMP
+                        WHERE chapter_id = %s
+                        """,
+                        (speakers, key_speakers, json.dumps(timeline), chapter_id),
+                    )
                 logger.info(
                     "update_chapter_speakers: updated chapter %d "
-                    "(%d speakers, %d key_speakers, %d timeline entries)",
+                    "(%d speakers, %d key_speakers, %d timeline entries%s)",
                     chapter_id, len(speakers), len(key_speakers), len(timeline),
+                    f", slug={resolved_participant_slug!r}" if resolved_participant_slug else "",
                 )
 
     def get_processed_video_ids(self, video_ids: list[str]) -> set[str]:

--- a/congress_videos/modules/institutional_role_resolver.py
+++ b/congress_videos/modules/institutional_role_resolver.py
@@ -1,0 +1,191 @@
+"""Local validation for the bundled institutional-role catalog."""
+
+from __future__ import annotations
+
+from collections import Counter
+from dataclasses import dataclass
+from datetime import date
+import json
+from pathlib import Path
+import re
+import unicodedata
+from urllib.parse import urlparse
+
+
+class CatalogValidationError(ValueError):
+    """Raised when the V1 document shape cannot be safely loaded."""
+
+
+@dataclass(frozen=True)
+class Role:
+    key: str
+    scope: str
+    aliases: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class Assignment:
+    identifier: str
+    role: str | None
+    participant_slug: str | None
+    validity_from: date | None
+    validity_to: date | None
+    is_open_ended: bool
+    diagnostic: str | None
+
+    @property
+    def is_valid(self) -> bool:
+        return self.diagnostic is None
+
+
+@dataclass(frozen=True)
+class Catalog:
+    version: int
+    roles: tuple[Role, ...]
+    assignments: tuple[Assignment, ...]
+
+    @property
+    def valid_assignments(self) -> tuple[Assignment, ...]:
+        return tuple(assignment for assignment in self.assignments if assignment.is_valid)
+
+
+def normalize_role_label(label: str) -> str:
+    """Return the catalog's mechanical, accent-insensitive role key."""
+    decomposed = unicodedata.normalize("NFKD", label.strip())
+    without_accents = "".join(
+        character for character in decomposed if not unicodedata.combining(character)
+    )
+    return re.sub(r"\s+", " ", re.sub(r"[^a-z0-9]+", " ", without_accents.casefold())).strip()
+
+
+class CatalogLoader:
+    """Load and structurally validate one local UTF-8 V1 JSON catalog."""
+
+    def __init__(self, path: Path | str) -> None:
+        self.path = Path(path)
+
+    def load(self) -> Catalog:
+        try:
+            document = json.loads(self.path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError) as error:
+            raise CatalogValidationError("catalog_load_failed") from error
+
+        if not isinstance(document, dict):
+            raise CatalogValidationError("top_level")
+        if document.get("catalog_version") != 1:
+            raise CatalogValidationError("catalog_version")
+        roles = self._load_roles(document.get("roles"))
+        assignments = document.get("assignments")
+        if not isinstance(assignments, list):
+            raise CatalogValidationError("assignments")
+
+        parsed_assignments = tuple(
+            self._parse_assignment(item, {role.key for role in roles})
+            for item in assignments
+        )
+        return Catalog(1, roles, self._mark_duplicate_ids(parsed_assignments))
+
+    def _load_roles(self, raw_roles: object) -> tuple[Role, ...]:
+        if not isinstance(raw_roles, list):
+            raise CatalogValidationError("roles")
+
+        roles: list[Role] = []
+        claimed_labels: set[str] = set()
+        for raw_role in raw_roles:
+            if not isinstance(raw_role, dict):
+                raise CatalogValidationError("roles")
+            key = raw_role.get("key")
+            scope = raw_role.get("scope")
+            aliases = raw_role.get("aliases", [])
+            if not isinstance(key, str) or not key or key != normalize_role_label(key):
+                raise CatalogValidationError("normalized")
+            if scope not in {"ministerial", "presidency_mesa"}:
+                raise CatalogValidationError("scope")
+            if not isinstance(aliases, list) or any(
+                not isinstance(alias, str) or not alias or alias != normalize_role_label(alias)
+                for alias in aliases
+            ):
+                raise CatalogValidationError("aliases")
+            labels = [key, *aliases]
+            if len(set(labels)) != len(labels) or any(label in claimed_labels for label in labels):
+                raise CatalogValidationError("collides")
+            claimed_labels.update(labels)
+            roles.append(Role(key, scope, tuple(aliases)))
+        return tuple(roles)
+
+    def _parse_assignment(self, raw: object, role_keys: set[str]) -> Assignment:
+        if not isinstance(raw, dict):
+            return Assignment("", None, None, None, None, False, "invalid_assignment")
+        identifier = raw.get("id") if isinstance(raw.get("id"), str) else ""
+        role = raw.get("role") if isinstance(raw.get("role"), str) else None
+        slug = raw.get("participant_slug") if isinstance(raw.get("participant_slug"), str) else None
+        validity = raw.get("validity")
+        starts_on, ends_on, open_ended, interval_error = self._parse_interval(validity)
+
+        diagnostic = (
+            "missing_assignment_id" if not identifier else
+            "undeclared_role" if role not in role_keys else
+            "missing_participant_slug" if not slug else
+            interval_error or
+            self._provenance_error(raw.get("provenance"))
+        )
+        return Assignment(identifier, role, slug, starts_on, ends_on, open_ended, diagnostic)
+
+    @staticmethod
+    def _parse_interval(raw: object) -> tuple[date | None, date | None, bool, str | None]:
+        if not isinstance(raw, dict):
+            return None, None, False, "invalid_from"
+        starts_on = _parse_iso_date(raw.get("from"))
+        if starts_on is None:
+            return None, None, False, "invalid_from"
+        raw_end = raw.get("to")
+        if raw_end == "open":
+            return starts_on, None, True, None
+        ends_on = _parse_iso_date(raw_end)
+        if ends_on is None:
+            return starts_on, None, False, "invalid_to"
+        if ends_on < starts_on:
+            return starts_on, ends_on, False, "invalid_interval"
+        return starts_on, ends_on, False, None
+
+    @staticmethod
+    def _provenance_error(raw: object) -> str | None:
+        if not isinstance(raw, dict):
+            return "missing_provenance"
+        required = ("publisher", "reference_url", "evidence_note", "reviewed_on")
+        if any(not isinstance(raw.get(field), str) or not raw[field] for field in required):
+            return "invalid_provenance"
+        parsed_url = urlparse(raw["reference_url"])
+        if parsed_url.scheme not in {"http", "https"} or not parsed_url.netloc:
+            return "invalid_provenance"
+        return None if _parse_iso_date(raw["reviewed_on"]) else "invalid_provenance"
+
+    @staticmethod
+    def _mark_duplicate_ids(assignments: tuple[Assignment, ...]) -> tuple[Assignment, ...]:
+        identifier_counts = Counter(
+            assignment.identifier for assignment in assignments if assignment.identifier
+        )
+        duplicates = {identifier for identifier, count in identifier_counts.items() if count > 1}
+        return tuple(
+            Assignment(
+                assignment.identifier,
+                assignment.role,
+                assignment.participant_slug,
+                assignment.validity_from,
+                assignment.validity_to,
+                assignment.is_open_ended,
+                assignment.diagnostic or (
+                    "duplicate_assignment_id" if assignment.identifier in duplicates else None
+                ),
+            )
+            for assignment in assignments
+        )
+
+
+def _parse_iso_date(value: object) -> date | None:
+    if not isinstance(value, str) or len(value) != 10:
+        return None
+    try:
+        return date.fromisoformat(value)
+    except ValueError:
+        return None

--- a/congress_videos/modules/institutional_role_resolver.py
+++ b/congress_videos/modules/institutional_role_resolver.py
@@ -32,6 +32,7 @@ class Assignment:
     validity_to: date | None
     is_open_ended: bool
     diagnostic: str | None
+    display_name: str | None = None
 
     @property
     def is_valid(self) -> bool:
@@ -51,21 +52,31 @@ class Catalog:
     def resolve(self, mention: str, on: date) -> str | None:
         """Return the participant slug for the role *mention* in force on *on*.
 
+        Thin wrapper over :meth:`resolve_assignment` that returns just the slug.
+        """
+        assignment = self.resolve_assignment(mention, on)
+        return assignment.participant_slug if assignment is not None else None
+
+    def resolve_assignment(self, mention: str, on: date) -> Assignment | None:
+        """Return the assignment for the role *mention* in force on *on*.
+
         The mention is matched accent- and case-insensitively against every role
-        key and alias. Among the valid assignments for that role, the one whose
-        validity interval covers *on* wins. Returns ``None`` when the mention is
-        unknown, no assignment covers the date, or the coverage is ambiguous.
+        key and alias (tolerating a leading article). Among the valid assignments
+        for that role, the one whose validity interval covers *on* wins. Returns
+        ``None`` when the mention is unknown, no assignment covers the date, or
+        the coverage is ambiguous (more than one distinct participant).
         """
         role_key = self._label_index.get(_strip_leading_article(normalize_role_label(mention)))
         if role_key is None:
             return None
 
-        covering = {
-            assignment.participant_slug
+        covering = [
+            assignment
             for assignment in self.valid_assignments
             if assignment.role == role_key and _covers(assignment, on)
-        }
-        return next(iter(covering)) if len(covering) == 1 else None
+        ]
+        distinct_slugs = {assignment.participant_slug for assignment in covering}
+        return covering[0] if len(distinct_slugs) == 1 else None
 
     @property
     def _label_index(self) -> dict[str, str]:
@@ -149,6 +160,7 @@ class CatalogLoader:
         validity = raw.get("validity")
         starts_on, ends_on, open_ended, interval_error = self._parse_interval(validity)
 
+        display_name = raw.get("display_name") if isinstance(raw.get("display_name"), str) else None
         diagnostic = (
             "missing_assignment_id" if not identifier else
             "undeclared_role" if role not in role_keys else
@@ -156,7 +168,9 @@ class CatalogLoader:
             interval_error or
             self._provenance_error(raw.get("provenance"))
         )
-        return Assignment(identifier, role, slug, starts_on, ends_on, open_ended, diagnostic)
+        return Assignment(
+            identifier, role, slug, starts_on, ends_on, open_ended, diagnostic, display_name
+        )
 
     @staticmethod
     def _parse_interval(raw: object) -> tuple[date | None, date | None, bool, str | None]:
@@ -204,6 +218,7 @@ class CatalogLoader:
                 assignment.diagnostic or (
                     "duplicate_assignment_id" if assignment.identifier in duplicates else None
                 ),
+                assignment.display_name,
             )
             for assignment in assignments
         )

--- a/congress_videos/modules/institutional_role_resolver.py
+++ b/congress_videos/modules/institutional_role_resolver.py
@@ -99,7 +99,7 @@ class CatalogLoader:
             aliases = raw_role.get("aliases", [])
             if not isinstance(key, str) or not key or key != normalize_role_label(key):
                 raise CatalogValidationError("normalized")
-            if scope not in {"ministerial", "presidency_mesa"}:
+            if scope not in {"ministerial", "presidency_mesa", "parliamentary_group"}:
                 raise CatalogValidationError("scope")
             if not isinstance(aliases, list) or any(
                 not isinstance(alias, str) or not alias or alias != normalize_role_label(alias)

--- a/congress_videos/modules/institutional_role_resolver.py
+++ b/congress_videos/modules/institutional_role_resolver.py
@@ -48,6 +48,33 @@ class Catalog:
     def valid_assignments(self) -> tuple[Assignment, ...]:
         return tuple(assignment for assignment in self.assignments if assignment.is_valid)
 
+    def resolve(self, mention: str, on: date) -> str | None:
+        """Return the participant slug for the role *mention* in force on *on*.
+
+        The mention is matched accent- and case-insensitively against every role
+        key and alias. Among the valid assignments for that role, the one whose
+        validity interval covers *on* wins. Returns ``None`` when the mention is
+        unknown, no assignment covers the date, or the coverage is ambiguous.
+        """
+        role_key = self._label_index.get(_strip_leading_article(normalize_role_label(mention)))
+        if role_key is None:
+            return None
+
+        covering = {
+            assignment.participant_slug
+            for assignment in self.valid_assignments
+            if assignment.role == role_key and _covers(assignment, on)
+        }
+        return next(iter(covering)) if len(covering) == 1 else None
+
+    @property
+    def _label_index(self) -> dict[str, str]:
+        index: dict[str, str] = {}
+        for role in self.roles:
+            for label in (role.key, *role.aliases):
+                index[label] = role.key
+        return index
+
 
 def normalize_role_label(label: str) -> str:
     """Return the catalog's mechanical, accent-insensitive role key."""
@@ -180,6 +207,24 @@ class CatalogLoader:
             )
             for assignment in assignments
         )
+
+
+_LEADING_ARTICLES = {"el", "la", "los", "las"}
+
+
+def _strip_leading_article(label: str) -> str:
+    """Drop a single leading Spanish definite article from a normalized label."""
+    head, _, tail = label.partition(" ")
+    return tail if head in _LEADING_ARTICLES and tail else label
+
+
+def _covers(assignment: Assignment, on: date) -> bool:
+    """Return True when *on* falls within the assignment's validity interval."""
+    if assignment.validity_from is None or on < assignment.validity_from:
+        return False
+    if assignment.is_open_ended:
+        return True
+    return assignment.validity_to is not None and on <= assignment.validity_to
 
 
 def _parse_iso_date(value: object) -> date | None:

--- a/congress_videos/modules/speaker_helpers.py
+++ b/congress_videos/modules/speaker_helpers.py
@@ -7,6 +7,8 @@ specific to the congressional video processing workflow.
 
 from typing import Dict, List
 
+from congress_videos.modules.speaker_placeholders import is_placeholder
+
 
 def format_speaker_list(
     speakers_info: List[Dict[str, str]],
@@ -15,6 +17,8 @@ def format_speaker_list(
 ) -> str:
     """
     Format a list of speakers into a text representation.
+
+    Entries whose speaker_name is missing or is a known placeholder are skipped.
 
     Args:
         speakers_info: List of dicts with 'speaker_name' and 'role' keys
@@ -29,13 +33,18 @@ def format_speaker_list(
 
     speaker_lines = []
     for speaker in speakers_info[:max_speakers]:
-        name = speaker.get("speaker_name", "Desconocido")
+        name = speaker.get("speaker_name", "")
+        if is_placeholder(name):
+            continue
         role = speaker.get("role", "")
 
         if include_role and role:
             speaker_lines.append(f"- {name} ({role})")
         else:
             speaker_lines.append(f"- {name}")
+
+    if not speaker_lines:
+        return "No hay participantes especificados"
 
     result = "\n".join(speaker_lines)
 
@@ -53,6 +62,8 @@ def format_speaker_context(
     """
     Format speakers into a compact context string for prompts.
 
+    Entries whose speaker_name is missing or is a known placeholder are skipped.
+
     Args:
         speakers_info: List of dicts with 'speaker_name' and 'role' keys
         max_speakers: Maximum number of speakers to include
@@ -66,11 +77,16 @@ def format_speaker_context(
 
     speaker_names = []
     for speaker in speakers_info[:max_speakers]:
-        name = speaker.get("speaker_name", "Unknown")
+        name = speaker.get("speaker_name", "")
+        if is_placeholder(name):
+            continue
         role = speaker.get("role", "")
         if role:
             speaker_names.append(f"{name} ({role})")
         else:
             speaker_names.append(name)
+
+    if not speaker_names:
+        return ""
 
     return f"{prefix}: {', '.join(speaker_names)}"

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -17,12 +17,18 @@ import json
 import logging
 import os
 from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
 
 from congress_videos.config.ai_prompts import (
     SPEAKER_MATCH_SYSTEM_PROMPT,
     SPEAKER_MATCH_USER_PROMPT_TEMPLATE,
 )
-from congress_videos.modules.participants_db import lookup_participant_fuzzy
+from congress_videos.modules.institutional_role_resolver import CatalogLoader
+from congress_videos.modules.participants_db import (
+    lookup_participant_by_slug,
+    lookup_participant_fuzzy,
+)
 from congress_videos.modules.participants_ingestion import normalize_member_name
 from congress_videos.modules.speaker_placeholders import is_placeholder
 from utils.llm_cache import cached_json_completion
@@ -32,6 +38,38 @@ logger = logging.getLogger(__name__)
 # Table name — unqualified; callers supply a connected psycopg2 connection.
 _CACHE_TABLE = "speaker_normalization_cache"
 _CHAPTERS_TABLE = "video_chapters"
+
+# Bundled institutional-role catalog, loaded lazily and cached per process.
+_ROLE_CATALOG_PATH = Path(__file__).resolve().parents[1] / "catalogs" / "institutional_roles.v1.json"
+_role_catalog = None
+
+
+def _get_role_catalog():
+    """Load and cache the bundled institutional-role catalog."""
+    global _role_catalog
+    if _role_catalog is None:
+        _role_catalog = CatalogLoader(_ROLE_CATALOG_PATH).load()
+    return _role_catalog
+
+
+def _resolve_role(mention: str, on: date) -> tuple[str, str, bool] | None:
+    """Resolve *mention* on *on* to ``(participant_slug, display_name, is_participant)``.
+
+    The role resolves to a participant slug. When that slug matches a stored
+    participant, ``is_participant`` is True and the live ``display_name`` wins;
+    otherwise the catalog's curated ``display_name`` is used (e.g. ministers who
+    are not sitting deputies). Returns ``None`` when *mention* is not a known role
+    in force on that date, or no display name is available.
+    """
+    assignment = _get_role_catalog().resolve_assignment(mention, on)
+    if assignment is None:
+        return None
+    row = lookup_participant_by_slug(assignment.participant_slug)
+    if row and row.get("display_name"):
+        return assignment.participant_slug, row["display_name"], True
+    if assignment.display_name:
+        return assignment.participant_slug, assignment.display_name, False
+    return None
 
 
 @dataclass
@@ -55,6 +93,30 @@ class NormalizationResult:
 # ---------------------------------------------------------------------------
 # Private helpers
 # ---------------------------------------------------------------------------
+
+def _dedupe_raw_names(
+    speakers: list[str],
+    key_speakers: list[str],
+    timeline: list[dict],
+) -> list[str]:
+    """Ordered, de-duplicated non-empty raw speaker strings (no placeholder filter).
+
+    Used by institutional-role resolution, which must see role-only mentions
+    (e.g. "Ministra de Defensa") *before* :func:`_dedupe_dirty_speakers` drops
+    them as placeholders.
+    """
+    seen: list[str] = []
+    seen_set: set[str] = set()
+    for name in (
+        list(speakers)
+        + list(key_speakers)
+        + [e.get("speaker", "") for e in timeline]
+    ):
+        if name and name not in seen_set:
+            seen.append(name)
+            seen_set.add(name)
+    return seen
+
 
 def _dedupe_dirty_speakers(
     speakers: list[str],
@@ -150,6 +212,7 @@ def normalize_chapter_speakers(
     timeline: list[dict],
     db_conn,
     config,
+    session_date: date | None = None,
 ) -> NormalizationResult:
     """Normalize dirty speaker strings for a single chapter.
 
@@ -182,16 +245,48 @@ def normalize_chapter_speakers(
         logger.debug("normalize_chapter_speakers: ENABLED=False — skipping chapter %d", chapter_id)
         return result
 
-    dirty_names = _dedupe_dirty_speakers(speakers, key_speakers, timeline)
-    if not dirty_names:
-        return result
-
     _schema = os.getenv("POSTGRES_SCHEMA", "public")
 
     with db_conn.cursor() as cursor:
         cursor.execute(f"SET search_path TO {_schema}, public")
+
+        # Step 0: deterministic institutional-role resolution (point-in-time),
+        # run over the RAW speaker strings before placeholder filtering removes
+        # role-only mentions ("Ministra de Defensa"). Resolved mentions never
+        # reach the fuzzy/LLM pipeline because they are filtered as placeholders.
+        if session_date is not None:
+            for raw in _dedupe_raw_names(speakers, key_speakers, timeline):
+                resolved = _resolve_role(raw, session_date)
+                if resolved is None:
+                    continue
+                slug, role_name, is_participant = resolved
+                if role_name == raw:
+                    continue
+                _upsert_cache_row(
+                    cursor, chapter_id, raw,
+                    status="matched",
+                    canonical_speaker=role_name,
+                    participant_normalized_name=slug.replace("-", " ") if is_participant else None,
+                    confidence_score=1.0,
+                )
+                result.cache_rows.append({
+                    "dirty_speaker": raw,
+                    "status": "matched",
+                    "canonical_speaker": role_name,
+                    "confidence_score": 1.0,
+                })
+                result.corrections[raw] = role_name
+                if result.resolved_participant_slug is None and is_participant:
+                    result.resolved_participant_slug = slug
+                logger.info(
+                    "normalize_chapter_speakers: role-resolved %r -> %r (chapter %d)",
+                    raw, role_name, chapter_id,
+                )
+
+        # Step 1: fuzzy + LLM pipeline over the placeholder-filtered dirty names.
+        dirty_names = _dedupe_dirty_speakers(speakers, key_speakers, timeline)
         for dirty in dirty_names:
-            # Step 1: fuzzy lookup
+            # Step 1a: fuzzy lookup
             candidate = lookup_participant_fuzzy(dirty, threshold=config.FUZZY_THRESHOLD)
             if candidate is None:
                 logger.debug(

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -47,6 +47,10 @@ class NormalizationResult:
     updated: bool = False
     """True if video_chapters was written back (at least one match confirmed)."""
 
+    resolved_participant_slug: str | None = None
+    """Slug of the first confirmed matched participant, derived LLM-free from
+    the candidate's normalized_name.  None when no match was confirmed."""
+
 
 # ---------------------------------------------------------------------------
 # Private helpers
@@ -221,11 +225,12 @@ def normalize_chapter_speakers(
             # Map AI decision to cache status
             if decision == "match":
                 canonical = candidate["display_name"]
+                normalized_name = candidate.get("normalized_name") or ""
                 _upsert_cache_row(
                     cursor, chapter_id, dirty,
                     status="matched",
                     canonical_speaker=canonical,
-                    participant_normalized_name=candidate.get("normalized_name"),
+                    participant_normalized_name=normalized_name or None,
                     confidence_score=confidence,
                 )
                 result.cache_rows.append({
@@ -235,6 +240,11 @@ def normalize_chapter_speakers(
                     "confidence_score": confidence,
                 })
                 result.corrections[dirty] = canonical
+                # Derive slug LLM-free from the authoritative normalized_name.
+                # slug = REPLACE(normalized_name, ' ', '-') — same formula as migration 018.
+                # Record only the first matched speaker's slug for this chapter.
+                if result.resolved_participant_slug is None and normalized_name:
+                    result.resolved_participant_slug = normalized_name.replace(" ", "-")
                 logger.info(
                     "normalize_chapter_speakers: matched %r -> %r (chapter %d, confidence=%.2f)",
                     dirty, canonical, chapter_id, confidence or 0.0,
@@ -261,21 +271,38 @@ def normalize_chapter_speakers(
             new_key_speakers = _apply_corrections(key_speakers, result.corrections)
             new_timeline = _apply_corrections_to_timeline(timeline, result.corrections)
 
-            cursor.execute(
-                f"""
-                UPDATE {_CHAPTERS_TABLE}
-                SET speakers     = %s,
-                    key_speakers = %s,
-                    timeline     = %s::jsonb,
-                    updated_at   = CURRENT_TIMESTAMP
-                WHERE chapter_id = %s
-                """,
-                (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
-            )
+            if result.resolved_participant_slug is not None:
+                cursor.execute(
+                    f"""
+                    UPDATE {_CHAPTERS_TABLE}
+                    SET speakers     = %s,
+                        key_speakers = %s,
+                        timeline     = %s::jsonb,
+                        resolved_participant_slug = %s,
+                        updated_at   = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (new_speakers, new_key_speakers, json.dumps(new_timeline),
+                     result.resolved_participant_slug, chapter_id),
+                )
+            else:
+                cursor.execute(
+                    f"""
+                    UPDATE {_CHAPTERS_TABLE}
+                    SET speakers     = %s,
+                        key_speakers = %s,
+                        timeline     = %s::jsonb,
+                        updated_at   = CURRENT_TIMESTAMP
+                    WHERE chapter_id = %s
+                    """,
+                    (new_speakers, new_key_speakers, json.dumps(new_timeline), chapter_id),
+                )
             result.updated = True
             logger.info(
-                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d",
+                "normalize_chapter_speakers: updated %d speaker(s) in chapter %d%s",
                 len(result.corrections), chapter_id,
+                f" (slug={result.resolved_participant_slug!r})"
+                if result.resolved_participant_slug else "",
             )
 
     return result

--- a/congress_videos/modules/speaker_normalization.py
+++ b/congress_videos/modules/speaker_normalization.py
@@ -24,6 +24,7 @@ from congress_videos.config.ai_prompts import (
 )
 from congress_videos.modules.participants_db import lookup_participant_fuzzy
 from congress_videos.modules.participants_ingestion import normalize_member_name
+from congress_videos.modules.speaker_placeholders import is_placeholder
 from utils.llm_cache import cached_json_completion
 
 logger = logging.getLogger(__name__)
@@ -56,11 +57,20 @@ def _dedupe_dirty_speakers(
     key_speakers: list[str],
     timeline: list[dict],
 ) -> list[str]:
-    """Return a de-duplicated, ordered list of unique dirty speaker names."""
+    """Return a de-duplicated, ordered list of unique dirty speaker names.
+
+    Placeholder speaker strings (e.g. "Desconocido", "Unknown",
+    "(No especificado)", single-token role abbreviations) are filtered out
+    before deduplication so they are never sent to the normalization pipeline.
+    """
     seen: list[str] = []
     seen_set: set[str] = set()
-    for name in list(speakers) + list(key_speakers) + [e.get("speaker", "") for e in timeline]:
-        if name and name not in seen_set:
+    for name in (
+        list(speakers)
+        + list(key_speakers)
+        + [e.get("speaker", "") for e in timeline]
+    ):
+        if name and not is_placeholder(name) and name not in seen_set:
             seen.append(name)
             seen_set.add(name)
     return seen

--- a/congress_videos/modules/speaker_placeholders.py
+++ b/congress_videos/modules/speaker_placeholders.py
@@ -1,0 +1,117 @@
+"""Shared placeholder-speaker detection for congressional chapter attribution.
+
+Exports
+-------
+PLACEHOLDER_SPEAKERS : frozenset[str]
+    Casefolded canonical set of known placeholder speaker strings.
+is_placeholder(s: str) -> bool
+    Pure, stateless predicate. Returns True when ``s`` is a known placeholder
+    or matches a role-only heuristic. Fail-open: unrecognised shapes → False.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Canonical placeholder set (casefolded, exact)
+# ---------------------------------------------------------------------------
+
+PLACEHOLDER_SPEAKERS: frozenset[str] = frozenset({
+    "desconocido",
+    "unknown",
+    "interviniente no especificado",
+    "(no especificado)",
+    "no especificado",
+    "",
+})
+
+# ---------------------------------------------------------------------------
+# Role-keyword heuristic
+# ---------------------------------------------------------------------------
+# These are role/title tokens that appear in the congressional transcription
+# output when the LLM cannot identify a real name. The regex matches the
+# token as a complete word at the start of the string (case-insensitive).
+# Confirmed against real dirty-speaker samples from ai_prompts.py and the
+# speaker_normalization pipeline.
+
+_ROLE_KEYWORDS = (
+    r"portavoz",
+    r"diputad[oa]",
+    r"senadore?[oa]?",
+    r"president[ea]",
+    r"ministr[oa]",
+    r"secretari[oa]",
+    r"vicesecretari[oa]",
+    r"vicepresidente?",
+    r"viceministr[oa]",
+    r"vocal",
+    r"interventor[a]?",
+    r"interveniente",
+    r"interviniente",
+    r"ponente",
+    r"consejere?[oa]?",
+    r"delegad[oa]",
+    r"coordinadore?[oa]?",
+)
+
+# Compiled pattern: role-keyword covers the ENTIRE string with only
+# lowercase/article suffixes (role-only, no proper name following).
+_ROLE_ONLY_RE = re.compile(
+    r"^(?:" + r"|".join(_ROLE_KEYWORDS) + r")(?:\s+(?:del?\s+[a-záéíóúàèìòùüñ]\w*|los?\s+[a-záéíóúàèìòùüñ]\w*|las?\s+[a-záéíóúàèìòùüñ]\w*|[a-záéíóúàèìòùüñ]\w*))*$",
+    re.IGNORECASE,
+)
+
+# Proper-name suffix: at least one word starting with a Unicode uppercase letter
+# (genuine Titlecase, NOT re.IGNORECASE for the suffix), following a role keyword.
+# If present the string is treated as a real name (fail-open).
+# Note: role keyword itself is matched case-insensitively via a separate prefix group.
+_ROLE_PREFIX_RE = re.compile(
+    r"^(?:" + r"|".join(_ROLE_KEYWORDS) + r")\s+",
+    re.IGNORECASE,
+)
+
+# Uppercase letter set for Titlecase detection (Spanish + Latin Extended).
+_UPPERCASE_CHARS = set("ABCDEFGHIJKLMNOPQRSTUVWXYZÁÉÍÓÚÀÈÌÒÙÜÑ")
+
+
+def is_placeholder(s: str) -> bool:
+    """Return True when ``s`` is a known placeholder or a role-only string.
+
+    Decision rules (in order):
+    1. Strip and casefold; if in PLACEHOLDER_SPEAKERS → True.
+    2. Single-token (no whitespace after strip) → True.
+    3. Matches _ROLE_WITH_NAME_RE (role + proper-name Titlecase suffix) → False
+       (fail-open: real name).
+    4. Matches _ROLE_ONLY_RE → True.
+    5. Everything else → False (fail-open: treat as real name).
+
+    The function is pure and stateless — no I/O, no LLM, no DB.
+    """
+    stripped = s.strip()
+    casefolded = stripped.casefold()
+
+    # Rule 1: exact match in canonical set
+    if casefolded in PLACEHOLDER_SPEAKERS:
+        return True
+
+    # Rule 2: single-token (no whitespace) — e.g. "Portavoz", "PP"
+    if " " not in stripped:
+        return True
+
+    # Rule 3: role keyword + proper-name suffix → fail-open (real name).
+    # Check whether the suffix after the role prefix starts with a Titlecase word
+    # (i.e. first char is uppercase). We test this without re.IGNORECASE on the
+    # suffix to avoid "del" (lowercase d) being mistaken for a proper name.
+    prefix_m = _ROLE_PREFIX_RE.match(stripped)
+    if prefix_m:
+        suffix = stripped[prefix_m.end():]
+        if suffix and suffix[0] in _UPPERCASE_CHARS:
+            return False
+
+    # Rule 4: role-keyword pattern covers the whole string (role-only phrase)
+    if _ROLE_ONLY_RE.match(stripped):
+        return True
+
+    # Rule 5: unrecognised shape → fail-open
+    return False

--- a/congress_videos/modules/youtube/download.py
+++ b/congress_videos/modules/youtube/download.py
@@ -1327,6 +1327,7 @@ def identify_interesting_chapters(chunk_summaries, chunked_srt_data, target_date
         - videos: List with video_id, chunks_with_chapters (interesting chapters found in each chunk)
     """
     from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+    from utils.ai_chapter_analyzer import _flatten_speakers
     import json
 
     if not chunk_summaries or not chunk_summaries.get('videos'):
@@ -1518,6 +1519,10 @@ def identify_interesting_chapters(chunk_summaries, chunked_srt_data, target_date
                                 chapter.get('start_time'),
                                 chapter.get('end_time'),
                             )
+                            # Flatten structured speaker objects to list[str] so
+                            # video_chapters.speakers TEXT[] stays byte-compatible.
+                            # Also tolerates legacy flat-string form (backward compat).
+                            chapter['speakers'] = _flatten_speakers(chapter.get('speakers', []))
                             valid_chapters.append(chapter)
                         else:
                             logging.warning(

--- a/congress_videos/modules/youtube/youtube_channel.py
+++ b/congress_videos/modules/youtube/youtube_channel.py
@@ -39,7 +39,7 @@ def fetch_youtube_channel_videos(channel_id: str, max_results: int = 10):
         RuntimeError: If channel not found or API request fails
     """
     # Get YouTube API key from environment
-    youtube_api_key = os.getenv('YOUTUBE_API_KEY')
+    youtube_api_key = os.getenv("YOUTUBE_API_KEY")
 
     if not youtube_api_key:
         error_msg = "YOUTUBE_API_KEY environment variable not set"
@@ -50,37 +50,38 @@ def fetch_youtube_channel_videos(channel_id: str, max_results: int = 10):
 
     try:
         # Build YouTube service with API key (no OAuth needed for public data)
-        youtube = build('youtube', 'v3', developerKey=youtube_api_key)
+        youtube = build("youtube", "v3", developerKey=youtube_api_key)
 
         # Search for completed LIVE STREAMS only (not regular uploads)
         # This specifically queries the channel's "Streams" tab
         # eventType='completed' ensures we only get finished broadcasts
-        search_response = youtube.search().list(
-            part='snippet',
-            channelId=channel_id,
-            maxResults=max_results,
-            order='date',
-            type='video',
-            eventType='completed'  # Only completed broadcasts (finished streams)
-        ).execute()
+        search_response = (
+            youtube.search()
+            .list(
+                part="snippet",
+                channelId=channel_id,
+                maxResults=max_results,
+                order="date",
+                type="video",
+                eventType="completed",  # Only completed broadcasts (finished streams)
+            )
+            .execute()
+        )
 
         videos = []
-        for item in search_response.get('items', []):
+        for item in search_response.get("items", []):
             video_data = {
-                'video_id': item['id']['videoId'],
-                'title': item['snippet']['title'],
-                'description': item['snippet']['description'],
-                'published_at': item['snippet']['publishedAt'],
-                'thumbnail_url': item['snippet']['thumbnails']['high']['url'],
-                'channel_title': item['snippet']['channelTitle'],
+                "video_id": item["id"]["videoId"],
+                "title": item["snippet"]["title"],
+                "description": item["snippet"]["description"],
+                "published_at": item["snippet"]["publishedAt"],
+                "thumbnail_url": item["snippet"]["thumbnails"]["high"]["url"],
+                "channel_title": item["snippet"]["channelTitle"],
             }
             videos.append(video_data)
 
         logging.info(f"Found {len(videos)} videos from channel")
-        return {
-            'total_videos': len(videos),
-            'videos': videos
-        }
+        return {"total_videos": len(videos), "videos": videos}
 
     except (ValueError, RuntimeError):
         # Re-raise known errors
@@ -113,13 +114,9 @@ def filter_plenary_session_videos(
         - videos: List of matching video details
         - target_date: Target date used for filtering
     """
-    if not channel_videos or not channel_videos.get('videos'):
+    if not channel_videos or not channel_videos.get("videos"):
         logging.warning("No channel videos to filter")
-        return {
-            'total_matches': 0,
-            'videos': [],
-            'target_date': target_date
-        }
+        return {"total_matches": 0, "videos": [], "target_date": target_date}
 
     target_date_obj = datetime.strptime(target_date, "%Y-%m-%d").date()
     range_start = target_date_obj - timedelta(days=lookback_days)
@@ -129,11 +126,13 @@ def filter_plenary_session_videos(
     )
 
     matching_videos = []
-    for video in channel_videos['videos']:
+    for video in channel_videos["videos"]:
         # Check if title contains target string (case-insensitive)
-        if target_title.lower() in video['title'].lower():
+        if target_title.lower() in video["title"].lower():
             # Parse published date
-            published_at = datetime.fromisoformat(video['published_at'].replace('Z', '+00:00'))
+            published_at = datetime.fromisoformat(
+                video["published_at"].replace("Z", "+00:00")
+            )
             published_date = published_at.date()
 
             # Check if date falls within the inclusive lookback range
@@ -143,9 +142,9 @@ def filter_plenary_session_videos(
 
     logging.info(f"Found {len(matching_videos)} matching videos for {target_date}")
     return {
-        'total_matches': len(matching_videos),
-        'videos': matching_videos,
-        'target_date': target_date
+        "total_matches": len(matching_videos),
+        "videos": matching_videos,
+        "target_date": target_date,
     }
 
 
@@ -160,27 +159,30 @@ def filter_unprocessed_videos(plenary_videos: dict) -> dict:
     FAIL-CLOSED: on DB error this raises (does NOT treat all as unprocessed).
     PRODUCTION path only (test mode never reaches this task).
     """
-    if not plenary_videos or not plenary_videos.get('videos'):
-        return plenary_videos or {'total_matches': 0, 'videos': []}
+    if not plenary_videos or not plenary_videos.get("videos"):
+        return plenary_videos or {"total_matches": 0, "videos": []}
 
     from congress_videos.modules.database import CongressionalVideoDB
 
-    videos = plenary_videos['videos']
-    video_ids = [v['video_id'] for v in videos if v.get('video_id')]
+    videos = plenary_videos["videos"]
+    video_ids = [v["video_id"] for v in videos if v.get("video_id")]
 
     db = CongressionalVideoDB()
     already_processed = db.get_processed_video_ids(video_ids)
 
-    kept = [v for v in videos if v.get('video_id') not in already_processed]
+    kept = [v for v in videos if v.get("video_id") not in already_processed]
     skipped = len(videos) - len(kept)
     logging.info(
         "Idempotency filter: %d candidate(s), %d already processed, %d to process. Skipped ids: %s",
-        len(videos), skipped, len(kept), sorted(already_processed),
+        len(videos),
+        skipped,
+        len(kept),
+        sorted(already_processed),
     )
 
-    result = dict(plenary_videos)            # preserve target_date + any extra keys
-    result['videos'] = kept
-    result['total_matches'] = len(kept)
+    result = dict(plenary_videos)  # preserve target_date + any extra keys
+    result["videos"] = kept
+    result["total_matches"] = len(kept)
     return result
 
 
@@ -224,36 +226,39 @@ def filter_finished_streams(
         Dict with the same shape as the input, with not-ready candidates removed
         and 'total_matches' recomputed to the kept count.
     """
-    if not plenary_videos or not plenary_videos.get('videos'):
-        return plenary_videos or {'total_matches': 0, 'videos': []}
+    if not plenary_videos or not plenary_videos.get("videos"):
+        return plenary_videos or {"total_matches": 0, "videos": []}
 
     if not guard_enabled:
-        logging.info("Finished-stream guard disabled (guard_enabled=False); passthrough")
+        logging.info(
+            "Finished-stream guard disabled (guard_enabled=False); passthrough"
+        )
         return plenary_videos
 
-    youtube_api_key = os.getenv('YOUTUBE_API_KEY')
+    youtube_api_key = os.getenv("YOUTUBE_API_KEY")
 
     if not youtube_api_key:
         error_msg = "YOUTUBE_API_KEY environment variable not set"
         logging.error(error_msg)
         raise ValueError(error_msg)
 
-    youtube = build('youtube', 'v3', developerKey=youtube_api_key)
+    youtube = build("youtube", "v3", developerKey=youtube_api_key)
 
-    videos = plenary_videos['videos']
+    videos = plenary_videos["videos"]
 
     # Single batched Data API call for all candidate ids (no per-candidate call).
-    ids = [v['video_id'] for v in videos if v.get('video_id')]
-    resp = youtube.videos().list(
-        part='snippet,contentDetails,liveStreamingDetails',
-        id=','.join(ids)
-    ).execute()
-    by_id = {it['id']: it for it in resp.get('items', [])}
+    ids = [v["video_id"] for v in videos if v.get("video_id")]
+    resp = (
+        youtube.videos()
+        .list(part="snippet,contentDetails,liveStreamingDetails", id=",".join(ids))
+        .execute()
+    )
+    by_id = {it["id"]: it for it in resp.get("items", [])}
 
     kept = []
 
     for video in videos:
-        video_id = video.get('video_id')
+        video_id = video.get("video_id")
         try:
             if not video_id:
                 logging.info("Dropping candidate without video_id (fail-closed)")
@@ -266,25 +271,29 @@ def filter_finished_streams(
                 logging.info(f"Dropping {video_id}: not found via Data API")
                 continue
 
-            snippet = item.get('snippet', {})
-            live_details = item.get('liveStreamingDetails', {})
+            snippet = item.get("snippet", {})
+            live_details = item.get("liveStreamingDetails", {})
 
             # (a) Data API live-state pre-filter
-            broadcast = snippet.get('liveBroadcastContent')
-            if broadcast in ('live', 'upcoming'):
+            broadcast = snippet.get("liveBroadcastContent")
+            if broadcast in ("live", "upcoming"):
                 logging.info(f"Dropping {video_id}: liveBroadcastContent={broadcast!r}")
                 continue
 
-            if live_details.get('concurrentViewers') is not None:
-                logging.info(f"Dropping {video_id}: concurrentViewers present (broadcasting)")
+            if live_details.get("concurrentViewers") is not None:
+                logging.info(
+                    f"Dropping {video_id}: concurrentViewers present (broadcasting)"
+                )
                 continue
 
-            actual_end_time = live_details.get('actualEndTime')
+            actual_end_time = live_details.get("actualEndTime")
             if actual_end_time is None:
-                logging.info(f"Dropping {video_id}: no actualEndTime (still live or no data)")
+                logging.info(
+                    f"Dropping {video_id}: no actualEndTime (still live or no data)"
+                )
                 continue
 
-            end_dt = datetime.fromisoformat(actual_end_time.replace('Z', '+00:00'))
+            end_dt = datetime.fromisoformat(actual_end_time.replace("Z", "+00:00"))
             elapsed = datetime.now(timezone.utc) - end_dt
 
             # (c) cheap pre-probe skip: obviously too fresh
@@ -300,7 +309,9 @@ def filter_finished_streams(
             if status in READY_LIVE_STATUSES:
                 kept.append(video)
             else:
-                logging.info(f"Dropping {video_id}: live_status={status!r} (not a ready VOD)")
+                logging.info(
+                    f"Dropping {video_id}: live_status={status!r} (not a ready VOD)"
+                )
 
         except Exception as e:
             # FR5: fail-closed — drop only this candidate, never crash the task.
@@ -309,12 +320,14 @@ def filter_finished_streams(
 
     logging.info(
         "Finished-stream guard: %d candidate(s), %d kept, %d dropped.",
-        len(videos), len(kept), len(videos) - len(kept),
+        len(videos),
+        len(kept),
+        len(videos) - len(kept),
     )
 
-    result = dict(plenary_videos)            # preserve target_date + any extra keys
-    result['videos'] = kept
-    result['total_matches'] = len(kept)
+    result = dict(plenary_videos)  # preserve target_date + any extra keys
+    result["videos"] = kept
+    result["total_matches"] = len(kept)
     return result
 
 
@@ -340,12 +353,12 @@ def get_video_details(plenary_videos, min_hours_since_end: int = 12):
         - total_videos: Number of videos
         - videos: List of video details with duration, timing, etc.
     """
-    if not plenary_videos or not plenary_videos.get('videos'):
+    if not plenary_videos or not plenary_videos.get("videos"):
         logging.warning("No plenary videos to process")
-        return {'total_videos': 0, 'videos': []}
+        return {"total_videos": 0, "videos": []}
 
     # Get YouTube API key from environment
-    youtube_api_key = os.getenv('YOUTUBE_API_KEY')
+    youtube_api_key = os.getenv("YOUTUBE_API_KEY")
 
     if not youtube_api_key:
         error_msg = "YOUTUBE_API_KEY environment variable not set"
@@ -354,35 +367,36 @@ def get_video_details(plenary_videos, min_hours_since_end: int = 12):
 
     try:
         # Build YouTube service with API key (no OAuth needed for public data)
-        youtube = build('youtube', 'v3', developerKey=youtube_api_key)
+        youtube = build("youtube", "v3", developerKey=youtube_api_key)
 
         enriched_videos = []
-        for video in plenary_videos['videos']:
-            video_id = video['video_id']
+        for video in plenary_videos["videos"]:
+            video_id = video["video_id"]
 
             # Get detailed video information
-            video_response = youtube.videos().list(
-                part='snippet,contentDetails,liveStreamingDetails',
-                id=video_id
-            ).execute()
+            video_response = (
+                youtube.videos()
+                .list(part="snippet,contentDetails,liveStreamingDetails", id=video_id)
+                .execute()
+            )
 
-            if not video_response.get('items'):
+            if not video_response.get("items"):
                 logging.warning(f"Video not found: {video_id}")
                 continue
 
-            video_details = video_response['items'][0]
-            live_details = video_details.get('liveStreamingDetails', {})
+            video_details = video_response["items"][0]
+            live_details = video_details.get("liveStreamingDetails", {})
 
             # VOD freshness guard: skip just-ended broadcasts whose VOD may
             # still be processing on YouTube.
-            actual_end_time = live_details.get('actualEndTime')
+            actual_end_time = live_details.get("actualEndTime")
             if actual_end_time is None:
                 logging.info(
                     f"Skipping {video_id}: no actualEndTime (still live or no data)"
                 )
                 continue
 
-            end_dt = datetime.fromisoformat(actual_end_time.replace('Z', '+00:00'))
+            end_dt = datetime.fromisoformat(actual_end_time.replace("Z", "+00:00"))
             elapsed = datetime.now(timezone.utc) - end_dt
             if elapsed < timedelta(hours=min_hours_since_end):
                 logging.info(
@@ -392,10 +406,12 @@ def get_video_details(plenary_videos, min_hours_since_end: int = 12):
                 continue
 
             # Extract duration
-            duration_iso = video_details['contentDetails']['duration']
+            duration_iso = video_details["contentDetails"]["duration"]
 
             # Parse ISO 8601 duration (PT2H30M15S -> 2:30:15)
-            duration_match = re.match(r'PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?', duration_iso)
+            duration_match = re.match(
+                r"PT(?:(\d+)H)?(?:(\d+)M)?(?:(\d+)S)?", duration_iso
+            )
             if duration_match:
                 hours = int(duration_match.group(1) or 0)
                 minutes = int(duration_match.group(2) or 0)
@@ -409,22 +425,25 @@ def get_video_details(plenary_videos, min_hours_since_end: int = 12):
                 # Issue #25: explicitly set title from the real API response so the
                 # actual snippet.title always wins over any placeholder from the input
                 # dict (e.g. the mock title injected by create_test_video_data()).
-                'title': video_details['snippet']['title'],
-                'duration_seconds': duration_seconds,
-                'duration_formatted': f"{hours}:{minutes:02d}:{seconds:02d}",
-                'actual_start_time': live_details.get('actualStartTime'),
-                'actual_end_time': live_details.get('actualEndTime'),
-                'youtube_url': f"https://www.youtube.com/watch?v={video_id}",
+                "title": video_details["snippet"]["title"],
+                "duration_seconds": duration_seconds,
+                "duration_formatted": f"{hours}:{minutes:02d}:{seconds:02d}",
+                "actual_start_time": live_details.get("actualStartTime"),
+                "actual_end_time": live_details.get("actualEndTime"),
+                "youtube_url": f"https://www.youtube.com/watch?v={video_id}",
             }
 
-            logging.info(f"Video details: {video['title']} - Duration: {enriched_video['duration_formatted']}")
+            published_at = video_details["snippet"].get("publishedAt")
+            if published_at:
+                enriched_video["published_at"] = published_at
+
+            logging.info(
+                f"Video details: {video['title']} - Duration: {enriched_video['duration_formatted']}"
+            )
             enriched_videos.append(enriched_video)
 
         logging.info(f"Total videos enriched: {len(enriched_videos)}")
-        return {
-            'total_videos': len(enriched_videos),
-            'videos': enriched_videos
-        }
+        return {"total_videos": len(enriched_videos), "videos": enriched_videos}
 
     except (ValueError, RuntimeError):
         # Re-raise known errors
@@ -450,12 +469,12 @@ def get_video_descriptions(plenary_videos):
         - total_videos: Number of videos
         - videos: List with video_id and full description
     """
-    if not plenary_videos or not plenary_videos.get('videos'):
+    if not plenary_videos or not plenary_videos.get("videos"):
         logging.warning("No plenary videos to process")
-        return {'total_videos': 0, 'videos': []}
+        return {"total_videos": 0, "videos": []}
 
     # Get YouTube API key from environment
-    youtube_api_key = os.getenv('YOUTUBE_API_KEY')
+    youtube_api_key = os.getenv("YOUTUBE_API_KEY")
 
     if not youtube_api_key:
         error_msg = "YOUTUBE_API_KEY environment variable not set"
@@ -464,40 +483,38 @@ def get_video_descriptions(plenary_videos):
 
     try:
         # Build YouTube service with API key
-        youtube = build('youtube', 'v3', developerKey=youtube_api_key)
+        youtube = build("youtube", "v3", developerKey=youtube_api_key)
 
         video_descriptions = []
-        for video in plenary_videos['videos']:
-            video_id = video['video_id']
+        for video in plenary_videos["videos"]:
+            video_id = video["video_id"]
 
             # Get full video description
-            video_response = youtube.videos().list(
-                part='snippet',
-                id=video_id
-            ).execute()
+            video_response = (
+                youtube.videos().list(part="snippet", id=video_id).execute()
+            )
 
-            if not video_response.get('items'):
+            if not video_response.get("items"):
                 logging.warning(f"Video not found: {video_id}")
                 continue
 
-            video_details = video_response['items'][0]
-            full_description = video_details['snippet'].get('description', '')
+            video_details = video_response["items"][0]
+            full_description = video_details["snippet"].get("description", "")
 
             video_desc_data = {
-                'video_id': video_id,
-                'title': video['title'],
-                'description': full_description,
-                'description_length': len(full_description)
+                "video_id": video_id,
+                "title": video["title"],
+                "description": full_description,
+                "description_length": len(full_description),
             }
 
-            logging.info(f"Description fetched: {video['title']} ({len(full_description)} chars)")
+            logging.info(
+                f"Description fetched: {video['title']} ({len(full_description)} chars)"
+            )
             video_descriptions.append(video_desc_data)
 
         logging.info(f"Total descriptions fetched: {len(video_descriptions)}")
-        return {
-            'total_videos': len(video_descriptions),
-            'videos': video_descriptions
-        }
+        return {"total_videos": len(video_descriptions), "videos": video_descriptions}
 
     except (ValueError, RuntimeError):
         # Re-raise known errors
@@ -520,20 +537,20 @@ def parse_description_links(video_descriptions):
         - total_videos: Number of videos processed
         - videos: List with video_id, press_release_link, agenda_link
     """
-    if not video_descriptions or not video_descriptions.get('videos'):
+    if not video_descriptions or not video_descriptions.get("videos"):
         logging.warning("No video descriptions to parse")
-        return {'total_videos': 0, 'videos': []}
+        return {"total_videos": 0, "videos": []}
 
     # Patterns to find links
     # Look for "Nota de prensa:" followed by URL
-    press_release_pattern = r'Nota de prensa:\s*(https?://[^\s]+)'
+    press_release_pattern = r"Nota de prensa:\s*(https?://[^\s]+)"
     # Look for "Orden del día:" followed by URL (PDF)
-    agenda_pattern = r'Orden del día:\s*(https?://[^\s]+)'
+    agenda_pattern = r"Orden del día:\s*(https?://[^\s]+)"
 
     parsed_videos = []
-    for video in video_descriptions['videos']:
-        description = video.get('description', '')
-        video_id = video['video_id']
+    for video in video_descriptions["videos"]:
+        description = video.get("description", "")
+        video_id = video["video_id"]
 
         # Find press release link
         press_match = re.search(press_release_pattern, description, re.IGNORECASE)
@@ -544,20 +561,19 @@ def parse_description_links(video_descriptions):
         agenda_link = agenda_match.group(1) if agenda_match else None
 
         parsed_data = {
-            'video_id': video_id,
-            'title': video['title'],
-            'press_release_link': press_link,
-            'agenda_link': agenda_link,
+            "video_id": video_id,
+            "title": video["title"],
+            "press_release_link": press_link,
+            "agenda_link": agenda_link,
         }
 
-        logging.info(f"Links parsed for {video['title']}: Press={bool(press_link)}, Agenda={bool(agenda_link)}")
+        logging.info(
+            f"Links parsed for {video['title']}: Press={bool(press_link)}, Agenda={bool(agenda_link)}"
+        )
         parsed_videos.append(parsed_data)
 
     logging.info(f"Total videos parsed: {len(parsed_videos)}")
-    return {
-        'total_videos': len(parsed_videos),
-        'videos': parsed_videos
-    }
+    return {"total_videos": len(parsed_videos), "videos": parsed_videos}
 
 
 def scrape_press_release(parsed_links):
@@ -574,24 +590,24 @@ def scrape_press_release(parsed_links):
         - total_scraped: Number of press releases scraped
         - videos: List with video_id, press_release_url, press_release_content
     """
-    if not parsed_links or not parsed_links.get('videos'):
+    if not parsed_links or not parsed_links.get("videos"):
         logging.warning("No parsed links to scrape")
-        return {'total_scraped': 0, 'videos': []}
+        return {"total_scraped": 0, "videos": []}
 
     # Headers to make the request look like it's from a real browser
     headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept': 'text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive',
-        'Upgrade-Insecure-Requests': '1'
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "text/html,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
     }
 
     scraped_releases = []
-    for video in parsed_links['videos']:
-        video_id = video['video_id']
-        press_link = video.get('press_release_link')
+    for video in parsed_links["videos"]:
+        video_id = video["video_id"]
+        press_link = video.get("press_release_link")
 
         if not press_link:
             logging.info(f"No press release link for {video['title']}")
@@ -600,59 +616,78 @@ def scrape_press_release(parsed_links):
         try:
             # Follow redirects to get actual URL
             logging.info(f"Fetching press release from {press_link}")
-            response = requests.get(press_link, timeout=10, allow_redirects=True, verify=False, headers=headers)
+            response = requests.get(
+                press_link,
+                timeout=10,
+                allow_redirects=True,
+                verify=False,
+                headers=headers,
+            )
             response.raise_for_status()
 
             actual_url = response.url
             logging.info(f"Resolved to: {actual_url}")
 
             # Parse HTML content
-            soup = BeautifulSoup(response.content, 'html.parser')
+            soup = BeautifulSoup(response.content, "html.parser")
 
             # Extract main content (adjust selectors based on actual site structure)
             # Try common content containers
             content = None
-            for selector in ['article', 'main', '.content', '#content', '.post-content']:
+            for selector in [
+                "article",
+                "main",
+                ".content",
+                "#content",
+                ".post-content",
+            ]:
                 element = soup.select_one(selector)
                 if element:
-                    content = element.get_text(strip=True, separator='\n')
+                    content = element.get_text(strip=True, separator="\n")
                     break
 
             if not content:
                 # Fallback: get all paragraph text
-                paragraphs = soup.find_all('p')
-                content = '\n'.join([p.get_text(strip=True) for p in paragraphs if p.get_text(strip=True)])
+                paragraphs = soup.find_all("p")
+                content = "\n".join(
+                    [
+                        p.get_text(strip=True)
+                        for p in paragraphs
+                        if p.get_text(strip=True)
+                    ]
+                )
 
             # Extract title
-            title_tag = soup.find('h1') or soup.find('title')
+            title_tag = soup.find("h1") or soup.find("title")
             page_title = title_tag.get_text(strip=True) if title_tag else "No title"
 
             scraped_data = {
-                'video_id': video_id,
-                'video_title': video['title'],
-                'press_release_url': actual_url,
-                'press_release_title': page_title,
-                'press_release_content': content,
-                'content_length': len(content) if content else 0
+                "video_id": video_id,
+                "video_title": video["title"],
+                "press_release_url": actual_url,
+                "press_release_title": page_title,
+                "press_release_content": content,
+                "content_length": len(content) if content else 0,
             }
 
-            logging.info(f"Press release scraped: {page_title} ({len(content) if content else 0} chars)")
+            logging.info(
+                f"Press release scraped: {page_title} ({len(content) if content else 0} chars)"
+            )
             scraped_releases.append(scraped_data)
 
         except Exception as e:
             logging.error(f"Error scraping press release for {video_id}: {e}")
-            scraped_releases.append({
-                'video_id': video_id,
-                'video_title': video['title'],
-                'press_release_url': press_link,
-                'error': str(e)
-            })
+            scraped_releases.append(
+                {
+                    "video_id": video_id,
+                    "video_title": video["title"],
+                    "press_release_url": press_link,
+                    "error": str(e),
+                }
+            )
 
     logging.info(f"Total press releases scraped: {len(scraped_releases)}")
-    return {
-        'total_scraped': len(scraped_releases),
-        'videos': scraped_releases
-    }
+    return {"total_scraped": len(scraped_releases), "videos": scraped_releases}
 
 
 def download_and_read_agenda(parsed_links, target_date: str):
@@ -668,27 +703,31 @@ def download_and_read_agenda(parsed_links, target_date: str):
         - total_downloaded: Number of PDFs downloaded
         - videos: List with video_id, agenda_url, agenda_file_path, agenda_text
     """
-    if not parsed_links or not parsed_links.get('videos'):
+    if not parsed_links or not parsed_links.get("videos"):
         logging.warning("No parsed links to download")
-        return {'total_downloaded': 0, 'videos': []}
+        return {"total_downloaded": 0, "videos": []}
 
     # Import path helpers
-    from congress_videos.config.paths import get_download_file_path, get_download_video_path, ensure_directory_exists
+    from congress_videos.config.paths import (
+        get_download_file_path,
+        get_download_video_path,
+        ensure_directory_exists,
+    )
 
     # Headers to make the request look like it's from a real browser
     headers = {
-        'User-Agent': 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36',
-        'Accept': 'application/pdf,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8',
-        'Accept-Language': 'es-ES,es;q=0.9,en;q=0.8',
-        'Accept-Encoding': 'gzip, deflate, br',
-        'Connection': 'keep-alive',
-        'Upgrade-Insecure-Requests': '1'
+        "User-Agent": "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36",
+        "Accept": "application/pdf,application/xhtml+xml,application/xml;q=0.9,image/webp,*/*;q=0.8",
+        "Accept-Language": "es-ES,es;q=0.9,en;q=0.8",
+        "Accept-Encoding": "gzip, deflate, br",
+        "Connection": "keep-alive",
+        "Upgrade-Insecure-Requests": "1",
     }
 
     downloaded_agendas = []
-    for video in parsed_links['videos']:
-        video_id = video['video_id']
-        agenda_link = video.get('agenda_link')
+    for video in parsed_links["videos"]:
+        video_id = video["video_id"]
+        agenda_link = video.get("agenda_link")
 
         if not agenda_link:
             logging.info(f"No agenda link for {video['title']}")
@@ -697,7 +736,13 @@ def download_and_read_agenda(parsed_links, target_date: str):
         try:
             # Follow redirects to get actual URL
             logging.info(f"Downloading agenda from {agenda_link}")
-            response = requests.get(agenda_link, timeout=30, allow_redirects=True, verify=False, headers=headers)
+            response = requests.get(
+                agenda_link,
+                timeout=30,
+                allow_redirects=True,
+                verify=False,
+                headers=headers,
+            )
             response.raise_for_status()
 
             actual_url = response.url
@@ -710,7 +755,7 @@ def download_and_read_agenda(parsed_links, target_date: str):
             # Save PDF as: downloads/{date}/{video_id}/agenda.pdf
             pdf_path = get_download_file_path(target_date, video_id, "agenda.pdf")
 
-            with open(pdf_path, 'wb') as f:
+            with open(pdf_path, "wb") as f:
                 f.write(response.content)
 
             logging.info(f"PDF saved: {pdf_path} ({len(response.content)} bytes)")
@@ -724,42 +769,45 @@ def download_and_read_agenda(parsed_links, target_date: str):
                     text_content += page.extract_text()
 
                 agenda_data = {
-                    'video_id': video_id,
-                    'video_title': video['title'],
-                    'agenda_url': actual_url,
-                    'agenda_file_path': pdf_path,
-                    'agenda_text': text_content,
-                    'pdf_pages': len(reader.pages),
-                    'text_length': len(text_content)
+                    "video_id": video_id,
+                    "video_title": video["title"],
+                    "agenda_url": actual_url,
+                    "agenda_file_path": pdf_path,
+                    "agenda_text": text_content,
+                    "pdf_pages": len(reader.pages),
+                    "text_length": len(text_content),
                 }
 
-                logging.info(f"PDF read: {len(reader.pages)} pages, {len(text_content)} chars")
+                logging.info(
+                    f"PDF read: {len(reader.pages)} pages, {len(text_content)} chars"
+                )
                 downloaded_agendas.append(agenda_data)
 
             except Exception as pdf_error:
                 logging.error(f"Error reading PDF {pdf_path}: {pdf_error}")
-                downloaded_agendas.append({
-                    'video_id': video_id,
-                    'video_title': video['title'],
-                    'agenda_url': actual_url,
-                    'agenda_file_path': pdf_path,
-                    'error': f"PDF read error: {str(pdf_error)}"
-                })
+                downloaded_agendas.append(
+                    {
+                        "video_id": video_id,
+                        "video_title": video["title"],
+                        "agenda_url": actual_url,
+                        "agenda_file_path": pdf_path,
+                        "error": f"PDF read error: {str(pdf_error)}",
+                    }
+                )
 
         except Exception as e:
             logging.error(f"Error downloading agenda for {video_id}: {e}")
-            downloaded_agendas.append({
-                'video_id': video_id,
-                'video_title': video['title'],
-                'agenda_url': agenda_link,
-                'error': str(e)
-            })
+            downloaded_agendas.append(
+                {
+                    "video_id": video_id,
+                    "video_title": video["title"],
+                    "agenda_url": agenda_link,
+                    "error": str(e),
+                }
+            )
 
     logging.info(f"Total agendas downloaded: {len(downloaded_agendas)}")
-    return {
-        'total_downloaded': len(downloaded_agendas),
-        'videos': downloaded_agendas
-    }
+    return {"total_downloaded": len(downloaded_agendas), "videos": downloaded_agendas}
 
 
 def extract_session_date(agendas, target_date: str):
@@ -779,41 +827,52 @@ def extract_session_date(agendas, target_date: str):
         - total_processed: Number of agendas processed
         - videos: List with video_id, session_number, target_date, agenda_section
     """
-    if not agendas or not agendas.get('videos'):
+    if not agendas or not agendas.get("videos"):
         logging.warning("No agendas to process for session number")
-        return {'total_processed': 0, 'videos': []}
+        return {"total_processed": 0, "videos": []}
 
     # Parse target date
     target_date_obj = datetime.strptime(target_date, "%Y-%m-%d")
 
     # Spanish month names (lowercase)
     spanish_months = {
-        'enero': 1, 'febrero': 2, 'marzo': 3, 'abril': 4,
-        'mayo': 5, 'junio': 6, 'julio': 7, 'agosto': 8,
-        'septiembre': 9, 'octubre': 10, 'noviembre': 11, 'diciembre': 12
+        "enero": 1,
+        "febrero": 2,
+        "marzo": 3,
+        "abril": 4,
+        "mayo": 5,
+        "junio": 6,
+        "julio": 7,
+        "agosto": 8,
+        "septiembre": 9,
+        "octubre": 10,
+        "noviembre": 11,
+        "diciembre": 12,
     }
 
     session_results = []
-    for video in agendas['videos']:
-        video_id = video['video_id']
-        agenda_text = video.get('agenda_text', '')
+    for video in agendas["videos"]:
+        video_id = video["video_id"]
+        agenda_text = video.get("agenda_text", "")
 
-        if not agenda_text or 'error' in video:
+        if not agenda_text or "error" in video:
             logging.warning(f"No agenda text for {video_id}")
             continue
 
         # Pattern to extract session number: "Sesión nº135" or "Sesión nº 135"
-        session_pattern = r'Sesión\s+nº\s*(\d+)'
+        session_pattern = r"Sesión\s+nº\s*(\d+)"
         session_match = re.search(session_pattern, agenda_text, re.IGNORECASE)
 
         if not session_match:
             logging.warning(f"No session number found in agenda for {video_id}")
-            session_results.append({
-                'video_id': video_id,
-                'video_title': video.get('video_title'),
-                'target_date': target_date,
-                'error': 'Session number not found in agenda'
-            })
+            session_results.append(
+                {
+                    "video_id": video_id,
+                    "video_title": video.get("video_title"),
+                    "target_date": target_date,
+                    "error": "Session number not found in agenda",
+                }
+            )
             continue
 
         base_session_number = int(session_match.group(1))
@@ -821,7 +880,7 @@ def extract_session_date(agendas, target_date: str):
 
         # Pattern to match Spanish date headers like "MARTES, 7 DE OCTUBRE" (uppercase only)
         # Matches: DAY_NAME, DAY_NUMBER DE MONTH_NAME [DE YEAR]
-        date_pattern = r'([A-ZÁÉÍÓÚÑ]+),\s*(\d{1,2})\s+[Dd][Ee]\s+([A-ZÁÉÍÓÚÑ]+)(?:\s+[Dd][Ee]\s+(\d{4}))?'
+        date_pattern = r"([A-ZÁÉÍÓÚÑ]+),\s*(\d{1,2})\s+[Dd][Ee]\s+([A-ZÁÉÍÓÚÑ]+)(?:\s+[Dd][Ee]\s+(\d{4}))?"
 
         # Find all date sections in the agenda
         date_matches = list(re.finditer(date_pattern, agenda_text))
@@ -829,16 +888,18 @@ def extract_session_date(agendas, target_date: str):
         if not date_matches:
             logging.warning(f"No date headers found in agenda for {video_id}")
             # Assume target date is first date (offset = 0)
-            session_results.append({
-                'video_id': video_id,
-                'video_title': video.get('video_title'),
-                'target_date': target_date,
-                'session_number': base_session_number,
-                'base_session_number': base_session_number,
-                'date_offset': 0,
-                'agenda_section': agenda_text,
-                'warning': 'Could not parse date headers, using base session number and full agenda'
-            })
+            session_results.append(
+                {
+                    "video_id": video_id,
+                    "video_title": video.get("video_title"),
+                    "target_date": target_date,
+                    "session_number": base_session_number,
+                    "base_session_number": base_session_number,
+                    "date_offset": 0,
+                    "agenda_section": agenda_text,
+                    "warning": "Could not parse date headers, using base session number and full agenda",
+                }
+            )
             continue
 
         # Step 1: Extract all dates from the agenda and parse them
@@ -857,37 +918,45 @@ def extract_session_date(agendas, target_date: str):
 
             try:
                 section_date = datetime(year, month_num, day_num).date()
-                parsed_dates.append({
-                    'date': section_date,
-                    'day_name': day_name,
-                    'match': match,
-                    'original_index': len(parsed_dates)
-                })
+                parsed_dates.append(
+                    {
+                        "date": section_date,
+                        "day_name": day_name,
+                        "match": match,
+                        "original_index": len(parsed_dates),
+                    }
+                )
             except ValueError as e:
-                logging.warning(f"Invalid date in agenda: {day_num}/{month_num}/{year} - {e}")
+                logging.warning(
+                    f"Invalid date in agenda: {day_num}/{month_num}/{year} - {e}"
+                )
                 continue
 
         if not parsed_dates:
             logging.warning(f"Could not parse any dates in agenda for {video_id}")
-            session_results.append({
-                'video_id': video_id,
-                'video_title': video.get('video_title'),
-                'target_date': target_date,
-                'session_number': base_session_number,
-                'base_session_number': base_session_number,
-                'date_offset': 0,
-                'agenda_section': agenda_text,
-                'warning': 'Could not parse dates, using base session number and full agenda'
-            })
+            session_results.append(
+                {
+                    "video_id": video_id,
+                    "video_title": video.get("video_title"),
+                    "target_date": target_date,
+                    "session_number": base_session_number,
+                    "base_session_number": base_session_number,
+                    "date_offset": 0,
+                    "agenda_section": agenda_text,
+                    "warning": "Could not parse dates, using base session number and full agenda",
+                }
+            )
             continue
 
         # Step 2: Sort dates chronologically
-        sorted_dates = sorted(parsed_dates, key=lambda x: x['date'])
+        sorted_dates = sorted(parsed_dates, key=lambda x: x["date"])
 
         # Log all dates found
         logging.info(f"Found {len(sorted_dates)} dates in agenda:")
         for i, date_info in enumerate(sorted_dates):
-            logging.info(f"  Position {i}: {date_info['day_name'].upper()}, {date_info['date']}")
+            logging.info(
+                f"  Position {i}: {date_info['day_name'].upper()}, {date_info['date']}"
+            )
 
         # Step 3: Find target date position in sorted list
         date_offset = None
@@ -895,56 +964,61 @@ def extract_session_date(agendas, target_date: str):
         found_target = False
 
         for i, date_info in enumerate(sorted_dates):
-            if date_info['date'] == target_date_obj.date():
+            if date_info["date"] == target_date_obj.date():
                 date_offset = i  # 0 for first date, 1 for second date, etc.
                 target_date_info = date_info
                 found_target = True
-                logging.info(f"Target date {target_date} found at position {i} (offset = {date_offset})")
+                logging.info(
+                    f"Target date {target_date} found at position {i} (offset = {date_offset})"
+                )
                 break
 
         # Step 4: Build result
         if not found_target:
             logging.warning(f"Target date {target_date} not found in agenda dates")
-            all_dates_str = ", ".join([str(d['date']) for d in sorted_dates])
-            session_results.append({
-                'video_id': video_id,
-                'video_title': video.get('video_title'),
-                'target_date': target_date,
-                'session_number': base_session_number,
-                'base_session_number': base_session_number,
-                'date_offset': 0,
-                'agenda_dates_found': all_dates_str,
-                'full_agenda_file_path': video.get('agenda_file_path'),
-                'warning': f'Target date {target_date} not found in agenda. Found dates: {all_dates_str}'
-            })
+            all_dates_str = ", ".join([str(d["date"]) for d in sorted_dates])
+            session_results.append(
+                {
+                    "video_id": video_id,
+                    "video_title": video.get("video_title"),
+                    "target_date": target_date,
+                    "session_number": base_session_number,
+                    "base_session_number": base_session_number,
+                    "date_offset": 0,
+                    "agenda_dates_found": all_dates_str,
+                    "full_agenda_file_path": video.get("agenda_file_path"),
+                    "warning": f"Target date {target_date} not found in agenda. Found dates: {all_dates_str}",
+                }
+            )
             continue
 
         # Calculate final session number: base + offset
         calculated_session_number = base_session_number + date_offset
 
         # List all dates found in the agenda
-        all_dates_list = [str(d['date']) for d in sorted_dates]
+        all_dates_list = [str(d["date"]) for d in sorted_dates]
 
         result = {
-            'video_id': video_id,
-            'video_title': video.get('video_title'),
-            'target_date': target_date,
-            'session_number': calculated_session_number,
-            'base_session_number': base_session_number,
-            'date_offset': date_offset,
-            'agenda_dates': all_dates_list,  # List of all dates in the agenda
-            'full_agenda_file_path': video.get('agenda_file_path')
+            "video_id": video_id,
+            "video_title": video.get("video_title"),
+            "target_date": target_date,
+            "session_number": calculated_session_number,
+            "base_session_number": base_session_number,
+            "date_offset": date_offset,
+            "agenda_dates": all_dates_list,  # List of all dates in the agenda
+            "full_agenda_file_path": video.get("agenda_file_path"),
         }
 
         session_results.append(result)
-        logging.info(f"✓ Session {calculated_session_number} (base {base_session_number} + offset {date_offset})")
-        logging.info(f"  Target date {target_date} is at position {date_offset} of {len(all_dates_list)} dates")
+        logging.info(
+            f"✓ Session {calculated_session_number} (base {base_session_number} + offset {date_offset})"
+        )
+        logging.info(
+            f"  Target date {target_date} is at position {date_offset} of {len(all_dates_list)} dates"
+        )
 
     logging.info(f"Total session dates processed: {len(session_results)}")
-    return {
-        'total_processed': len(session_results),
-        'videos': session_results
-    }
+    return {"total_processed": len(session_results), "videos": session_results}
 
 
 def extract_agenda_section(agendas, session_date_info):
@@ -963,77 +1037,91 @@ def extract_agenda_section(agendas, session_date_info):
         - total_extracted: Number of agenda sections extracted
         - videos: List with video_id, target_date, agenda_section
     """
-    if not agendas or not agendas.get('videos'):
+    if not agendas or not agendas.get("videos"):
         logging.warning("No agendas to extract sections from")
-        return {'total_extracted': 0, 'videos': []}
+        return {"total_extracted": 0, "videos": []}
 
-    if not session_date_info or not session_date_info.get('videos'):
+    if not session_date_info or not session_date_info.get("videos"):
         logging.warning("No session date info provided")
-        return {'total_extracted': 0, 'videos': []}
+        return {"total_extracted": 0, "videos": []}
 
     # Parse target date
     target_date_obj = datetime.strptime(
-        session_date_info['videos'][0]['target_date'],
-        "%Y-%m-%d"
+        session_date_info["videos"][0]["target_date"], "%Y-%m-%d"
     )
 
     # Spanish month names (lowercase)
     spanish_months = {
-        'enero': 1, 'febrero': 2, 'marzo': 3, 'abril': 4,
-        'mayo': 5, 'junio': 6, 'julio': 7, 'agosto': 8,
-        'septiembre': 9, 'octubre': 10, 'noviembre': 11, 'diciembre': 12
+        "enero": 1,
+        "febrero": 2,
+        "marzo": 3,
+        "abril": 4,
+        "mayo": 5,
+        "junio": 6,
+        "julio": 7,
+        "agosto": 8,
+        "septiembre": 9,
+        "octubre": 10,
+        "noviembre": 11,
+        "diciembre": 12,
     }
 
     extracted_sections = []
 
     # Match agenda with session_date by video_id
-    for session_info in session_date_info['videos']:
-        video_id = session_info['video_id']
-        target_date = session_info['target_date']
+    for session_info in session_date_info["videos"]:
+        video_id = session_info["video_id"]
+        target_date = session_info["target_date"]
 
         # Find corresponding agenda
         agenda_item = None
-        for agenda in agendas['videos']:
-            if agenda['video_id'] == video_id:
+        for agenda in agendas["videos"]:
+            if agenda["video_id"] == video_id:
                 agenda_item = agenda
                 break
 
         if not agenda_item:
             logging.warning(f"No agenda found for video_id {video_id}")
-            extracted_sections.append({
-                'video_id': video_id,
-                'target_date': target_date,
-                'error': 'No agenda found for this video'
-            })
+            extracted_sections.append(
+                {
+                    "video_id": video_id,
+                    "target_date": target_date,
+                    "error": "No agenda found for this video",
+                }
+            )
             continue
 
-        agenda_text = agenda_item.get('agenda_text', '')
-        if not agenda_text or 'error' in agenda_item:
+        agenda_text = agenda_item.get("agenda_text", "")
+        if not agenda_text or "error" in agenda_item:
             logging.warning(f"No agenda text for {video_id}")
-            extracted_sections.append({
-                'video_id': video_id,
-                'target_date': target_date,
-                'error': 'No agenda text available'
-            })
+            extracted_sections.append(
+                {
+                    "video_id": video_id,
+                    "target_date": target_date,
+                    "error": "No agenda text available",
+                }
+            )
             continue
 
         # Pattern to match Spanish date headers like "MARTES, 7 DE OCTUBRE" (uppercase only)
         # Matches: DAY_NAME, DAY_NUMBER DE MONTH_NAME [DE YEAR]
-        date_pattern = r'([A-ZÁÉÍÓÚÑ]+),\s*(\d{1,2})\s+[Dd][Ee]\s+([A-ZÁÉÍÓÚÑ]+)(?:\s+[Dd][Ee]\s+(\d{4}))?'
+        date_pattern = r"([A-ZÁÉÍÓÚÑ]+),\s*(\d{1,2})\s+[Dd][Ee]\s+([A-ZÁÉÍÓÚÑ]+)(?:\s+[Dd][Ee]\s+(\d{4}))?"
 
         # Find all date sections in the agenda
         date_matches = list(re.finditer(date_pattern, agenda_text))
 
         if not date_matches:
             logging.warning(f"No date headers found in agenda for {video_id}")
-            extracted_sections.append({
-                'video_id': video_id,
-                'video_title': session_info.get('video_title'),
-                'target_date': target_date,
-                'session_number': session_info.get('session_number'),
-                'agenda_section': agenda_text,  # Return full text as fallback
-                'warning': 'Could not parse date headers, returning full agenda'
-            })
+            extracted_sections.append(
+                {
+                    "video_id": video_id,
+                    "video_title": session_info.get("video_title"),
+                    "target_date": target_date,
+                    "session_number": session_info.get("session_number"),
+                    "agenda_section": agenda_text,  # Return full text as fallback
+                    "warning": "Could not parse date headers, returning full agenda",
+                }
+            )
             continue
 
         # Find the match that corresponds to our target date
@@ -1063,14 +1151,21 @@ def extract_agenda_section(agendas, session_date_info):
                     next_match = None
                     for other_match in date_matches:
                         if other_match.start() > start_pos:
-                            if next_match is None or other_match.start() < next_match.start():
+                            if (
+                                next_match is None
+                                or other_match.start() < next_match.start()
+                            ):
                                 next_match = other_match
 
                     end_pos = next_match.start() if next_match else len(agenda_text)
                     target_section = agenda_text[start_pos:end_pos].strip()
 
-                    logging.info(f"Extracted agenda section for {day_name.upper()}, {day_num} de {month_name}")
-                    logging.info(f"  Section: {len(target_section)} chars (lines {start_pos} to {end_pos})")
+                    logging.info(
+                        f"Extracted agenda section for {day_name.upper()}, {day_num} de {month_name}"
+                    )
+                    logging.info(
+                        f"  Section: {len(target_section)} chars (lines {start_pos} to {end_pos})"
+                    )
                     break
 
             except ValueError as e:
@@ -1078,29 +1173,32 @@ def extract_agenda_section(agendas, session_date_info):
                 continue
 
         if target_section:
-            extracted_sections.append({
-                'video_id': video_id,
-                'video_title': session_info.get('video_title'),
-                'target_date': target_date,
-                'session_number': session_info.get('session_number'),
-                'agenda_section': target_section,
-                'section_length': len(target_section),
-                'full_agenda_file_path': agenda_item.get('agenda_file_path')
-            })
-            logging.info(f"✓ Extracted agenda for session {session_info.get('session_number')}, date {target_date}")
+            extracted_sections.append(
+                {
+                    "video_id": video_id,
+                    "video_title": session_info.get("video_title"),
+                    "target_date": target_date,
+                    "session_number": session_info.get("session_number"),
+                    "agenda_section": target_section,
+                    "section_length": len(target_section),
+                    "full_agenda_file_path": agenda_item.get("agenda_file_path"),
+                }
+            )
+            logging.info(
+                f"✓ Extracted agenda for session {session_info.get('session_number')}, date {target_date}"
+            )
         else:
             logging.warning(f"Could not find section for target date {target_date}")
-            extracted_sections.append({
-                'video_id': video_id,
-                'video_title': session_info.get('video_title'),
-                'target_date': target_date,
-                'session_number': session_info.get('session_number'),
-                'agenda_section': agenda_text,  # Fallback to full text
-                'warning': f'Could not find section for {target_date}, returning full agenda'
-            })
+            extracted_sections.append(
+                {
+                    "video_id": video_id,
+                    "video_title": session_info.get("video_title"),
+                    "target_date": target_date,
+                    "session_number": session_info.get("session_number"),
+                    "agenda_section": agenda_text,  # Fallback to full text
+                    "warning": f"Could not find section for {target_date}, returning full agenda",
+                }
+            )
 
     logging.info(f"Total agenda sections extracted: {len(extracted_sections)}")
-    return {
-        'total_extracted': len(extracted_sections),
-        'videos': extracted_sections
-    }
+    return {"total_extracted": len(extracted_sections), "videos": extracted_sections}

--- a/congress_videos/reap_shorts_uploader_dag.py
+++ b/congress_videos/reap_shorts_uploader_dag.py
@@ -36,10 +36,27 @@ POSTGRES_SCHEMA = os.getenv("POSTGRES_SCHEMA", "development")
 
 
 def _resolve_speakers(ch: dict) -> tuple[str, str]:
-    speakers = ch.get("key_speakers") or ch.get("speakers") or []
-    if not speakers:
+    """Return (primary_speaker, rest_speakers) filtering placeholders.
+
+    Priority: key_speakers (placeholder-filtered) before speakers
+    (placeholder-filtered). Deduplicates order-preserving. Returns ("", "")
+    when the combined pool is empty after filtering.
+    """
+    from congress_videos.modules.speaker_placeholders import is_placeholder
+
+    key_speakers: list[str] = ch.get("key_speakers") or []
+    speakers: list[str] = ch.get("speakers") or []
+
+    seen: set[str] = set()
+    pool: list[str] = []
+    for name in list(key_speakers) + list(speakers):
+        if not is_placeholder(name) and name not in seen:
+            pool.append(name)
+            seen.add(name)
+
+    if not pool:
         return ("", "")
-    return (speakers[0].strip(), ", ".join(speakers[1:]))
+    return (pool[0].strip(), ", ".join(pool[1:]))
 
 
 _MONTHS = [

--- a/congress_videos/sql/migrations/020_add_resolved_participant_slug.sql
+++ b/congress_videos/sql/migrations/020_add_resolved_participant_slug.sql
@@ -1,0 +1,39 @@
+-- Migration 020: Add resolved_participant_slug column to video_chapters
+-- Created: 2026-08-11
+-- Depends on: 018_add_participant_slug.sql (congress_participants.slug must exist)
+--             017_create_speaker_normalization_cache.sql
+--
+-- Adds a nullable FK column linking a chapter to a verified congress_participants row.
+-- Fill is LLM-free and async: normalize_chapter_speakers writes the slug after
+-- confirming a 'matched' cache entry. NULL is the honest unresolved state.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS + CREATE INDEX IF NOT EXISTS.
+-- Runner sets search_path before executing, so table names are UNQUALIFIED.
+--
+-- One-time backfill: fills rows whose chapter_id appears in speaker_normalization_cache
+-- with status='matched' and whose resolved_participant_slug is currently NULL.
+-- The JOIN through congress_participants guarantees FK integrity: only slugs that
+-- exist in congress_participants are written; rows with no matching slug are skipped.
+--
+-- Rollback: DROP COLUMN IF EXISTS resolved_participant_slug (additive/nullable, safe).
+
+-- 1) Add nullable column (idempotent).
+ALTER TABLE video_chapters
+    ADD COLUMN IF NOT EXISTS resolved_participant_slug TEXT
+        REFERENCES congress_participants(slug);
+
+-- 2) Create an index for FK lookups / downstream JOINs (idempotent).
+CREATE INDEX IF NOT EXISTS idx_video_chapters_resolved_participant_slug
+    ON video_chapters (resolved_participant_slug);
+
+-- 3) One-time idempotent backfill: set slug for matched cache rows where not yet set.
+--    JOIN congress_participants guarantees only valid slugs are written (FK integrity).
+--    WHERE IS NULL makes this a no-op for already-filled rows.
+UPDATE video_chapters vc
+    SET resolved_participant_slug = cp.slug
+    FROM speaker_normalization_cache snc
+    JOIN congress_participants cp
+        ON cp.normalized_name = snc.participant_normalized_name
+    WHERE snc.chapter_id = vc.chapter_id
+      AND snc.status = 'matched'
+      AND vc.resolved_participant_slug IS NULL;

--- a/congress_videos/sql/migrations/021_expose_resolved_participant_slug_in_uploadable_chapters.sql
+++ b/congress_videos/sql/migrations/021_expose_resolved_participant_slug_in_uploadable_chapters.sql
@@ -1,0 +1,54 @@
+-- Migration: Expose resolved_participant_slug in uploadable_chapters
+-- Created: 2026-08-12
+-- Depends on: 010_add_timeline_column.sql (uploadable_chapters view),
+--             020_add_resolved_participant_slug.sql (video_chapters.resolved_participant_slug)
+--
+-- Surfaces the authoritative participant slug written by speaker normalization
+-- (fuzzy match or institutional-role resolution) so the chapter uploader can
+-- build the thumbnail with the resolved person instead of re-fuzzy-matching the
+-- raw speaker string at thumbnail time.
+--
+-- Idempotent: CREATE OR REPLACE VIEW is safe to re-run. The new column is
+-- appended at the END of the select list, which CREATE OR REPLACE VIEW allows
+-- without a DROP (existing column names/order/types are unchanged).
+-- The migration runner runs `SET search_path TO {schema}, public` before
+-- executing, so table/view names are intentionally UNQUALIFIED.
+--
+-- Example (development): psql ... -c "SET search_path TO development, public;" -f 021_expose_resolved_participant_slug_in_uploadable_chapters.sql
+-- Example (production):  psql ... -c "SET search_path TO production, public;"  -f 021_expose_resolved_participant_slug_in_uploadable_chapters.sql
+
+CREATE OR REPLACE VIEW uploadable_chapters AS
+SELECT
+    vc.chapter_id,
+    vc.video_id,
+    ysv.video_title AS source_video_title,
+    ysv.session_number,
+    ysv.session_date,
+    vc.title AS chapter_title,
+    vc.description,
+    vc.duration_minutes,
+    vc.speakers,
+    vc.topics,
+    vc.timeline,
+    vc.start_time,
+    vc.end_time,
+    vc.relevance_score,
+    vc.speaker_relevance_points,
+    vc.topic_relevance_points,
+    vc.public_interest_points,
+    vc.scoring_reasoning,
+    vc.key_speakers,
+    vc.is_current_topic,
+    vc.is_uploaded_to_youtube,
+    vc.created_at,
+    CURRENT_DATE - DATE(vc.created_at) AS days_since_created,
+    vc.resolved_participant_slug
+FROM video_chapters vc
+JOIN youtube_source_videos ysv ON vc.video_id = ysv.video_id
+WHERE
+    vc.is_uploaded_to_youtube = FALSE
+    AND vc.relevance_score >= 2
+ORDER BY
+    ysv.session_date DESC NULLS LAST,
+    vc.relevance_score DESC,
+    vc.created_at DESC;

--- a/congress_videos/youtube_channel_monitor_dag.py
+++ b/congress_videos/youtube_channel_monitor_dag.py
@@ -563,12 +563,27 @@ with DAG(
         from congress_videos.modules.database import CongressionalVideoDB
         from utils.postgres_helpers import PostgresConnection
 
+        from datetime import datetime
+
         ti = context["ti"]
         db_save_results = ti.xcom_pull(key="db_save_results")
 
         if not db_save_results:
             logging.info("_normalize_speakers: no db_save_results XCom — skipping")
             return True
+
+        # Map each video to its session date so institutional-role mentions can be
+        # resolved point-in-time (which minister/spokesperson held the role then).
+        session_date_info = ti.xcom_pull(key="session_date") or {}
+        video_dates = {}
+        for entry in session_date_info.get("videos", []):
+            raw_date = entry.get("target_date")
+            try:
+                video_dates[entry.get("video_id")] = (
+                    datetime.strptime(raw_date, "%Y-%m-%d").date() if raw_date else None
+                )
+            except (ValueError, TypeError):
+                video_dates[entry.get("video_id")] = None
 
         pg = PostgresConnection()
         chapters_table = pg.get_qualified_table("video_chapters")
@@ -602,6 +617,7 @@ with DAG(
                                 timeline_raw,
                                 conn,
                                 snc,
+                                session_date=video_dates.get(video_id),
                             )
                             if result.updated:
                                 logging.info(

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -153,20 +153,24 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     else:
         session = str(session_date) if session_date else None
 
-    # Fuzzy matching is confined to this raw-speaker boundary. Downstream
-    # thumbnail code receives only the stable participant slug.
-    try:
-        raw_speaker = _resolve_speaker_name(chapter)
-        participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
-        slug = participant.get("slug") if participant else None
-    except Exception as exc:
-        logging.warning(
-            "_prepare_thumbnail_config: speaker resolution failed for "
-            "chapter_id=%s: %s — setting slug=None",
-            chapter_id,
-            exc,
-        )
-        slug = None
+    # Prefer the authoritative slug written by speaker normalization (fuzzy or
+    # institutional-role resolution). Fall back to a raw-speaker fuzzy match only
+    # when the chapter was never resolved. Fuzzy matching stays confined to this
+    # boundary; downstream thumbnail code receives only the stable slug.
+    slug = chapter.get("resolved_participant_slug") or None
+    if not slug:
+        try:
+            raw_speaker = _resolve_speaker_name(chapter)
+            participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
+            slug = participant.get("slug") if participant else None
+        except Exception as exc:
+            logging.warning(
+                "_prepare_thumbnail_config: speaker resolution failed for "
+                "chapter_id=%s: %s — setting slug=None",
+                chapter_id,
+                exc,
+            )
+            slug = None
 
     return {
         "chapter_id": chapter_id,

--- a/openspec/changes/fix-issue-25-test-mode-video-title/apply-progress.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/apply-progress.md
@@ -1,0 +1,66 @@
+# Apply Progress: Make test-mode video metadata authoritative
+
+## Completed implementation tasks
+
+- [x] RED — reproduced the failure using `create_test_video_data()` input and a distinct non-empty API `snippet.publishedAt`.
+- [x] GREEN — conditionally enrich `published_at` only from a truthy API `snippet.publishedAt`, preserving the existing API-authoritative title.
+- [x] TRIANGULATE — parameterized omitted and empty `publishedAt` fallback coverage preserves the selected record's publication time.
+- [x] REFACTOR — kept the focused regression module and production change limited to the designated two implementation files.
+
+Persisted task checkbox updates: the four implementation-owned rows in `tasks.md` are marked `- [x]`. The parent-owned bounded-review action remains unchecked and byte-for-byte unchanged.
+
+## Files changed
+
+- `congress_videos/modules/youtube/youtube_channel.py`
+- `tests/congress_videos/modules/youtube/test_youtube_channel_title.py`
+
+## TDD Cycle Evidence
+
+| Cycle | Evidence | Result |
+| --- | --- | --- |
+| RED | `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q` before the production edit | Failed at `test_enriched_video_contains_real_api_metadata` on `published_at`: placeholder `2025-01-01T10:00:00Z` instead of API `2025-01-15T08:00:00Z`; title coverage remained valid. |
+| GREEN | Added truthy-only `snippet.publishedAt` assignment after the existing enriched-record construction. | `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q --no-cov`: 4 passed. |
+| TRIANGULATE | Added parameterized omitted and empty `publishedAt` cases using fresh `create_test_video_data()` input. | Both fallback cases pass under the focused no-coverage command. |
+| REFACTOR | Reused the existing focused module and response factory; inspected the diff. | Only the two designated implementation files changed (46 additions, 26 deletions; 72 changed lines). |
+
+## Verification evidence
+
+- `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q --no-cov` — **PASS**, 4 passed.
+- `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q` — test cases passed (4 passed), but the process exited 1 because the repository-wide 80% coverage threshold measured 2.83% for this focused run.
+- `git diff --check` — PASS.
+
+## Deviations and risks
+
+- The configured focused command cannot return zero in isolation because the repository-wide coverage threshold applies to this narrow test selection. This is unrelated to the regression behavior but must be treated as failed native attempt evidence.
+- No design deviation in production behavior: title remains API-authoritative, and publication time changes only for truthy API values.
+
+## Workload and boundary
+
+- Delivery boundary: one focused work unit, `metadata-enrichment-and-regression`; 72 changed implementation lines, within the acquired 100-line budget.
+- Rollback boundary: revert only the two implementation files; no schema, persistence, migration, or API-contract rollback is required.
+
+## Structured status consumed
+
+- `changeName`: `fix-issue-25-test-mode-video-title`
+- `artifactStore`: `openspec`
+- `applyState`: `ready`
+- `actionContext.mode`: `repo-local`
+- `allowedEditRoots`: `/home/alozur/src/github.com/alozur/airflow-dags-worktrees/fix-issue-25-test-mode-video-title`
+- Warning: none.
+
+## Remaining tasks
+
+No unchecked implementation-owned tasks remain.
+
+Deferred parent lifecycle action:
+
+- [ ] Start or reuse bounded review for the single focused work unit after apply-owned verification has frozen the candidate. <!-- sdd-owner: parent -->
+
+## Native attempt settlement
+
+- Token: `sha256:49c7f916a00cacf63306182d169f7c4e2fe0e8dc2859cb60ff0a6009810e5acc`
+- Request ID: `settle-issue-25-20260811-001`
+- Evidence revision: `sha256:088a601265a8d465fa9330f17819dc9d7130c1e6b36e406e9e075d248023a0d0`
+- Submitted outcome: `failed` (the configured focused command exited 1 solely on the repository-wide coverage threshold despite four passing tests).
+- Settle response: `state: blocked`, `reason: maintainer_decision`.
+- Native continuation: inspect `gentle-ai sdd-attempt status --cwd <repo> --change fix-issue-25-test-mode-video-title`, then ask a maintainer to rescope or reset the objective, or disable receipt-driven review for this clone to proceed under ordinary repository policy.

--- a/openspec/changes/fix-issue-25-test-mode-video-title/design.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/design.md
@@ -1,0 +1,77 @@
+# Make per-video snippet metadata authoritative
+
+`get_video_details()` remains the sole enrichment boundary. It will preserve the selected video's input shape, always use the detailed API response for `title`, and replace `published_at` only when the detailed response supplies a truthy `snippet.publishedAt` value.
+
+## Decision
+
+| Area | Design |
+| --- | --- |
+| Authority | The per-video `videos().list(part='snippet,contentDetails,liveStreamingDetails')` response is authoritative for `snippet.title` and a supplied `snippet.publishedAt`. |
+| Publication-time fallback | Start with `**video`; after building the enriched record, assign `published_at` only if `video_details['snippet'].get('publishedAt')` is truthy. Missing or `""` therefore leaves the incoming value untouched. |
+| Test-mode boundary | `create_test_video_data()` remains unchanged and supplies the real placeholder record used by the regression test. Test mode selects the video only. |
+| Out of scope | No persistence, schema, selection, migration, API-request, or unrelated metadata changes. |
+
+## Data flow
+
+1. Test mode creates a selected-video record through `create_test_video_data()`, including placeholder title and publication time.
+2. `get_video_details()` requests the selected video using its existing per-video details request.
+3. Once the existing VOD freshness guard accepts the response, the enrichment step spreads the selected record, sets `title` from `snippet.title`, and conditionally replaces `published_at` from non-empty `snippet.publishedAt`.
+4. The enriched record is returned unchanged to existing downstream consumers; persistence receives the corrected values without any database-specific change.
+
+## Implementation plan
+
+### `congress_videos/modules/youtube/youtube_channel.py`
+
+At the existing `enriched_video` construction in `get_video_details()`:
+
+- Keep the current explicit API-title assignment intact.
+- Read `snippet.publishedAt` from the already-fetched `video_details['snippet']`.
+- If the value is truthy, set `enriched_video['published_at']` to it; otherwise do not write that key after the `**video` spread.
+- Do not change the API `part` list, freshness guard, duration parsing, output envelope, or exception behavior.
+
+This conditional assignment is deliberately preferred to assigning `None` or `""` in the dict literal: the incoming value stays intact for both omitted and empty API values.
+
+## Strict-TDD regression strategy
+
+Keep the focused test module at `tests/congress_videos/modules/youtube/test_youtube_channel_title.py` so the approved command remains stable; extend it from title-only coverage into the narrow metadata regression.
+
+### RED
+
+1. Change test setup to call `create_test_video_data(test_url)` from `congress_videos.modules.youtube.download`; do not hand-build the input record.
+2. Mock the existing `youtube_channel.build` seam and return a historical `actualEndTime`, valid duration, a title distinct from the producer's placeholder, and a distinct non-empty `snippet.publishedAt`.
+3. Call `get_video_details(..., min_hours_since_end=0)` and assert the returned record has the API title and API publication time, each differing from the producer's placeholders.
+4. Run `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q`. Before the production change, the new publication-time assertion fails because the input placeholder survives; existing title assertions may remain green.
+
+### GREEN
+
+1. Apply only the conditional `published_at` enrichment described above.
+2. Re-run the same focused command and expect all title and publication-time cases to pass.
+3. Add or retain parameterized preservation coverage using a newly produced `create_test_video_data()` record for each API shape: omitted `publishedAt` and `publishedAt: ""`. Assert that each returned `published_at` equals the producer's original placeholder date.
+
+The mock remains deterministic: it performs no network, Airflow, database, or clock-sensitive waiting; the historical end time and zero-hour margin satisfy the existing freshness guard.
+
+## Contracts and acceptance mapping
+
+| Requirement | Evidence |
+| --- | --- |
+| API title and supplied publication time win | Test-mode producer input plus a distinct detailed API title and `publishedAt`; assert both returned values. |
+| Omitted or empty publication time preserves input | Parameterized response shapes; assert the original producer `published_at` remains. |
+| Test mode only selects a video | The test uses the unmodified real placeholder producer and verifies enrichment solely through `get_video_details()`. |
+| No persistence/API-contract changes | Implementation is restricted to the post-response enriched-record construction; request parameters and downstream interfaces are untouched. |
+
+## Files to change during apply
+
+- `congress_videos/modules/youtube/youtube_channel.py`
+- `tests/congress_videos/modules/youtube/test_youtube_channel_title.py`
+
+## Rollout and rollback
+
+The change has no migration, configuration, or deployment sequencing. Deploy it with the ordinary application release. Reverting the two focused file changes restores prior propagation behavior; no stored-data rollback is required.
+
+## Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Empty API data overwrites a usable selected-record value | Assign only a truthy `snippet.publishedAt`. |
+| Test no longer represents test mode | Obtain every regression input from `create_test_video_data()`. |
+| Accidental scope expansion | Keep the change at the enrichment seam and retain the existing test file and focused command. |

--- a/openspec/changes/fix-issue-25-test-mode-video-title/explore.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/explore.md
@@ -1,0 +1,44 @@
+# Exploration: Test-mode video metadata authority
+
+## Scope
+
+Issue #25 says test mode should choose only a YouTube video ID/URL. Canonical persisted metadata must be refreshed from `youtube.videos().list(part='snippet,contentDetails,liveStreamingDetails')`, rather than retaining placeholder values from `create_test_video_data()`.
+
+## Data flow
+
+1. `congress_videos/youtube_channel_monitor_dag.py` branches on `isTesting`.
+2. The test branch calls `download.create_test_video_data()` and writes `plenary_videos` to XCom. Its one video has placeholder `title` (`Test Video - Sesión Plenaria`) and `published_at` (`2025-01-01T10:00:00Z`).
+3. Both test and production paths invoke `youtube_channel.get_video_details()` with that `plenary_videos` XCom. The production path instead originates in `fetch_youtube_channel_videos()`, which gets `snippet.title` and `snippet.publishedAt` from YouTube search results.
+4. `get_video_details()` obtains the authoritative per-video API response and enriches the incoming dict. Downstream download/chapter transformations propagate `video['title']` into `video_title`.
+5. `CongressionalVideoDB.save_youtube_chapters_to_db()` writes `video_title` to `youtube_source_videos`; its `ON CONFLICT (video_id) DO UPDATE` overwrites `video_title` with the submitted value.
+
+## Current state and finding
+
+The worktree already contains the title correction in `congress_videos/modules/youtube/youtube_channel.py`: after `**video`, it explicitly assigns `title: video_details['snippet']['title']`. It also contains `tests/congress_videos/modules/youtube/test_youtube_channel_title.py`, whose mocked API response has a title distinct from the placeholder and asserts that the API title wins.
+
+Consequently, the existing title test is deterministic and tight, but it is currently expected to be green rather than RED. It is not evidence that the issue remains unfixed in this worktree. No code or tests were changed during exploration.
+
+The API details request already includes `snippet`, so `snippet.publishedAt` is available when YouTube provides it. `get_video_details()` currently does **not** replace the incoming `published_at` with `video_details['snippet'].get('publishedAt')`; therefore test mode can still carry the placeholder date. This is the remaining metadata-authority gap.
+
+## Recommended regression seam
+
+Use a focused unit test for `get_video_details()` in `tests/congress_videos/modules/youtube/test_youtube_channel_title.py` (or a narrowly renamed metadata test):
+
+- Arrange with `create_test_video_data(test_url)` to exercise the real test-mode placeholder producer, not a hand-built approximation.
+- Patch `youtube_channel.build`; return one `videos().list(...).execute()` response with an old `actualEndTime`, valid `contentDetails.duration`, `snippet.title` different from the placeholder, and `snippet.publishedAt` different from the placeholder date.
+- Call `get_video_details(..., min_hours_since_end=0)`.
+- Assert one enriched video; assert its `title` equals the API title and differs from the placeholder; assert `published_at` equals the API `publishedAt` when supplied.
+
+Command: `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q`.
+
+This test is isolated from Airflow, database, network, and clock-sensitive freshness behavior (the end time is historical and the margin is zero). In the current worktree, its title assertion is green because the title fix exists; the `published_at` assertion is RED-capable against the currently missing propagation.
+
+## Context and ADRs
+
+`CONTEXT.md` and `docs/adr/` are absent in this worktree, so there is no applicable ADR conflict to report. `docs/agents/domain.md` directs this absence to be handled silently.
+
+## Constraints
+
+- Preserve production behavior and the original test-mode selection mechanism.
+- Only make API metadata authoritative when the response provides the relevant value; do not replace a value with a missing/empty API field.
+- The database upsert is correctly behaving as designed: it persists the metadata passed by upstream code; the correction belongs at enrichment.

--- a/openspec/changes/fix-issue-25-test-mode-video-title/proposal.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/proposal.md
@@ -1,0 +1,40 @@
+# Make test-mode video metadata authoritative
+
+## Intent
+Prevent test-mode placeholder metadata from overwriting persisted YouTube video records. Test mode must select a video only; supplied per-video YouTube metadata remains canonical.
+
+## Goals
+- In `get_video_details()`, retain the existing API-authoritative `title` behavior.
+- Set `published_at` from `snippet.publishedAt` when the per-video YouTube response supplies a value.
+- Preserve the incoming `published_at` when the API omits or provides an empty `publishedAt` value.
+- Add focused regression coverage using the real test-mode placeholder producer and a distinct API `publishedAt` value.
+
+## Scope and affected areas
+- `congress_videos/modules/youtube/youtube_channel.py`: enrich `published_at` from supplied per-video snippet metadata.
+- `tests/congress_videos/modules/youtube/test_youtube_channel_title.py` (or a narrowly renamed metadata test): prove API title and publication time supersede test-mode placeholders.
+
+## Non-goals
+- Database upsert behavior or persisted-schema changes.
+- Test-mode video/channel selection behavior.
+- YouTube API request contract changes.
+- Migrations, backfills, or metadata fields beyond `title` and `published_at`.
+
+## Acceptance criteria
+- Given test-mode data from `create_test_video_data()` and a per-video API response with distinct `snippet.title` and `snippet.publishedAt`, `get_video_details()` returns those API values for `title` and `published_at`.
+- When `snippet.publishedAt` is absent or empty, `get_video_details()` does not replace an existing `published_at` value with a missing value.
+- Test mode continues to affect only the selected video; downstream consumers receive enriched metadata without database-specific changes.
+- Focused regression proof passes:
+  `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q`
+
+## Risks and mitigations
+| Risk | Mitigation |
+| --- | --- |
+| Missing API publication time erases an existing value | Assign only a supplied, non-empty `snippet.publishedAt`. |
+| Regression test proves a synthetic path rather than the issue | Build input with `create_test_video_data()` and use API values distinct from placeholders. |
+| Scope expands into persistence behavior | Limit implementation and assertions to enrichment before downstream persistence. |
+
+## Rollback
+Revert the focused enrichment and regression-test change. This restores the prior placeholder propagation behavior without schema, migration, API-contract, or database rollback work.
+
+## Success criteria
+Test-mode runs propagate API-supplied title and publication time into the enriched video record, so later persistence cannot overwrite production metadata with placeholders. The focused test remains deterministic, isolated from Airflow, database, network, and clock-sensitive freshness behavior.

--- a/openspec/changes/fix-issue-25-test-mode-video-title/specs/youtube-video-metadata/spec.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/specs/youtube-video-metadata/spec.md
@@ -1,0 +1,49 @@
+# YouTube Video Metadata Specification
+
+## Purpose
+
+Ensure that per-video YouTube snippet metadata is authoritative after test-mode video selection, preventing test-mode placeholders from reaching downstream consumers as video metadata.
+
+## Requirements
+
+### Requirement: API-supplied video metadata is authoritative
+
+The system MUST return the per-video API response's `snippet.title` as the video `title` and a non-empty `snippet.publishedAt` as the video `published_at` when those values are supplied for the selected video.
+
+#### Scenario: Test-mode placeholder metadata is enriched from the per-video response
+
+- GIVEN a video record produced by test mode with placeholder `title` and `published_at` values
+- AND a per-video API response for the selected video supplies a title and a non-empty publication time distinct from those placeholders
+- WHEN video details are retrieved
+- THEN the returned video `title` MUST equal the API-supplied `snippet.title`
+- AND the returned video `published_at` MUST equal the API-supplied `snippet.publishedAt`
+
+### Requirement: Missing API publication time preserves existing metadata
+
+The system MUST retain the selected video's existing `published_at` value when the per-video API response omits `snippet.publishedAt` or provides it as an empty value.
+
+#### Scenario: Publication time is absent from the per-video response
+
+- GIVEN a selected video with an existing `published_at` value
+- AND its per-video API response has no `snippet.publishedAt`
+- WHEN video details are retrieved
+- THEN the returned video `published_at` MUST equal its existing value
+
+#### Scenario: Publication time is empty in the per-video response
+
+- GIVEN a selected video with an existing `published_at` value
+- AND its per-video API response provides an empty `snippet.publishedAt`
+- WHEN video details are retrieved
+- THEN the returned video `published_at` MUST equal its existing value
+
+### Requirement: Test mode is limited to video selection
+
+Test mode MUST affect selection of the video to retrieve and MUST NOT make test-mode placeholder metadata authoritative over supplied per-video API snippet metadata.
+
+#### Scenario: Downstream consumers receive enriched metadata without persistence changes
+
+- GIVEN test mode selects a video
+- AND the selected video's per-video API response supplies snippet metadata
+- WHEN video details are retrieved for downstream processing
+- THEN downstream processing MUST receive the enriched video metadata
+- AND no database-specific behavior, schema, migration, or API request contract change SHALL be required

--- a/openspec/changes/fix-issue-25-test-mode-video-title/tasks.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/tasks.md
@@ -1,0 +1,39 @@
+# Tasks: Make test-mode video metadata authoritative
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 45–80 (two implementation files; SDD artifacts excluded) |
+| 400-line budget risk | Low |
+| Chained PRs recommended | No |
+| Suggested split | Single PR: focused metadata enrichment and regression coverage |
+| Delivery strategy | auto-forecast |
+| Chain strategy | pending |
+
+Decision needed before apply: No
+Chained PRs recommended: No
+Chain strategy: pending
+400-line budget risk: Low
+
+## Implementation work
+
+### RED — reproduce API publication-time authority failure
+
+- [x] In `tests/congress_videos/modules/youtube/test_youtube_channel_title.py`, replace the hand-built selected-video fixture path with `create_test_video_data(test_url)` from `congress_videos.modules.youtube.download`; extend `_make_api_response` (or its focused replacement) to supply a non-empty `snippet.publishedAt` distinct from the producer placeholder, retain a historical `actualEndTime`, and assert `get_video_details(..., min_hours_since_end=0)` returns both the API title and API publication time. Run `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q` and record the expected RED failure specifically at the new `published_at` assertion while title coverage remains valid. Rollback boundary: revert only this focused test edit. <!-- sdd-owner: implementation -->
+
+### GREEN — enrich only supplied publication time
+
+- [x] In `congress_videos/modules/youtube/youtube_channel.py` at `get_video_details()`'s `enriched_video` construction, preserve the existing API-title assignment and conditionally assign `enriched_video['published_at']` only when `video_details['snippet'].get('publishedAt')` is truthy; do not change the request `part` list, freshness guard, duration parsing, response shape, persistence, or exception behavior. Re-run `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q` and record GREEN. Rollback boundary: remove only this conditional enrichment, restoring the prior selected-record value behavior. <!-- sdd-owner: implementation -->
+
+### TRIANGULATE — prove omitted and empty fallback behavior
+
+- [x] In `tests/congress_videos/modules/youtube/test_youtube_channel_title.py`, add focused parameterized coverage for an omitted `snippet.publishedAt` and `snippet.publishedAt: ""`, creating a fresh input through `create_test_video_data(test_url)` for each case and asserting the returned `published_at` equals that input's original placeholder value; keep API/network, Airflow, database, and clock-sensitive behavior mocked or bypassed through the existing build seam and `min_hours_since_end=0`. Run `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q` and record all authority and fallback cases passing. Rollback boundary: revert only these fallback cases without changing production behavior. <!-- sdd-owner: implementation -->
+
+### REFACTOR — confirm narrow, readable regression coverage
+
+- [x] Refactor only `tests/congress_videos/modules/youtube/test_youtube_channel_title.py` as needed to remove duplicated API-response or placeholder setup while preserving explicit assertions that API title and non-empty API publication time win, and that omitted/empty publication time preserves the input; keep the test module name and focused command unchanged. Run `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q` after the refactor and inspect the diff to confirm only `congress_videos/modules/youtube/youtube_channel.py` and this focused test changed. Rollback boundary: revert the focused production-and-test work unit; no schema, migration, API contract, or persistence rollback is required. <!-- sdd-owner: implementation -->
+
+## Parent lifecycle actions
+
+- [x] Review decision recorded: the user declined the candidate-specific bounded review; no review authority or receipt was created, and delivery follows ordinary repository policy. <!-- sdd-owner: parent -->

--- a/openspec/changes/fix-issue-25-test-mode-video-title/verify-report.md
+++ b/openspec/changes/fix-issue-25-test-mode-video-title/verify-report.md
@@ -1,0 +1,98 @@
+# Verification Report: Make test-mode video metadata authoritative
+
+## Result
+
+**PASS WITH WARNINGS** — all requested focused functional and repository-integrity checks pass. The canonical `spec.md` artifact is absent, so formal spec coverage could not be verified from the artifact store. The checked-in design, tasks, user-supplied scenarios, code, and focused tests provide the coverage described below.
+
+## Structured status and action context
+
+| Field | Finding |
+|---|---|
+| Change | `fix-issue-25-test-mode-video-title` |
+| Native status | Parent-provided native status: `nextRecommended: verify` |
+| Task state | All four implementation tasks are checked; see task completion below. |
+| Action context | `repo-local`; allowed edit root is `/home/alozur/src/github.com/alozur/airflow-dags-worktrees/fix-issue-25-test-mode-video-title` (recorded in apply progress). |
+| Review policy | User declined the candidate-specific bounded review. No ordinary-review receipt exists; delivery follows ordinary repository policy. This is not a verification blocker. |
+
+## Artifact completeness
+
+- Read: `proposal.md`, `design.md`, `tasks.md`, and `apply-progress.md`.
+- Missing: `openspec/changes/fix-issue-25-test-mode-video-title/spec.md`.
+- The missing canonical spec prevents a formal artifact-to-implementation scenario trace. Scenario coverage below is traced to the user-supplied verification requirements, proposal, design, tasks, implementation, and tests instead.
+
+## Scenario coverage
+
+| Required behavior | Evidence | Result |
+|---|---|---|
+| API `title` and non-empty `snippet.publishedAt` override test-mode placeholders | `test_enriched_video_contains_real_api_title` builds input with `create_test_video_data()` and asserts distinct API values for both fields; `get_video_details()` sets `title` from the API and conditionally assigns `published_at`. | PASS |
+| Omitted `publishedAt` preserves input | Parameterized `test_enriched_video_keeps_input_publication_time_when_api_omits_it` covers the omitted-key shape and asserts the original producer value. | PASS |
+| Empty `publishedAt` preserves input | The same parameterized test covers `publishedAt: ""` and asserts the original producer value. | PASS |
+| No persistence, selection, or API request contract change | Only the designated production and focused-test files changed. The per-video request remains `part="snippet,contentDetails,liveStreamingDetails"`; the enrichment branch is after the existing response/freshness handling. No persistence or selection code changed. | PASS |
+
+## Task completion
+
+- No unchecked implementation task markers remain.
+- The only unchecked task marker is parent-owned and non-implementation:
+  - `- [ ] Start or reuse bounded review for the single focused work unit after apply-owned verification has frozen the candidate. <!-- sdd-owner: parent -->`
+- It is reconciled by the recorded user decision to decline candidate-specific bounded review; it does not represent remaining implementation scope.
+
+## Validation commands
+
+| Command | Result |
+|---|---|
+| `uv run ruff format --check congress_videos/modules/youtube/youtube_channel.py tests/congress_videos/modules/youtube/test_youtube_channel_title.py` | PASS — `2 files already formatted` |
+| `uv run pytest tests/congress_videos/modules/youtube/test_youtube_channel_title.py -q --no-cov` | PASS — `4 passed in 2.09s` |
+| `git diff --check` | PASS — no output |
+
+The directed no-coverage focused command was used once with the user's authorization because the ordinary focused command's only nonzero result is the repository-wide 80% coverage threshold. No full suite was run: the delegated verification instructions required exactly the three commands above.
+
+## Strict TDD compliance
+
+| Check | Result | Details |
+|---|---|---|
+| Strict TDD enabled | PASS | `openspec/config.yaml` has `strict_tdd: true`. |
+| TDD evidence reported | PASS | `apply-progress.md` contains a `TDD Cycle Evidence` table. |
+| RED evidence | PASS | Records a pre-production focused failure at the new `published_at` assertion. |
+| GREEN still true | PASS | The reported focused test file exists and currently passes all 4 tests. |
+| Triangulation | PASS | Distinct non-empty, omitted, and empty API publication-time cases are present. |
+| Refactor boundary | PASS | Tests and production code remain limited to the two designated implementation files. |
+
+### Test layer distribution
+
+| Layer | Tests | Files | Tools |
+|---|---:|---:|---|
+| Unit | 4 | 1 | `pytest` with the YouTube build seam mocked |
+| Integration | 0 | 0 | Not exercised |
+| E2E | 0 | 0 | Not exercised |
+| **Total** | **4** | **1** | |
+
+### Assertion quality
+
+**Assertion quality: PASS** — the changed test calls the production function, uses independent literal API values and the real `create_test_video_data()` producer, checks both override and preservation behavior, has no tautologies, no ghost loops, no type-only or smoke-only assertions, and no CSS or mock-call-count implementation assertions.
+
+## Review workload / PR boundary
+
+| Check | Finding |
+|---|---|
+| Forecast | Single PR; 45–80 estimated changed lines; 400-line risk low; no chained PR. |
+| Actual boundary | Only the two assigned implementation files changed. |
+| Actual diff size | 888 changed lines: 442 additions / 344 deletions in `youtube_channel.py`, and 70 additions / 32 deletions in the focused test. |
+| Scope finding | WARNING — final Ruff normalization reformatted much of `youtube_channel.py`, raising the review workload above the forecast and 400-line threshold. No `size:exception` is recorded in `tasks.md`. The functional change remains within the assigned slice, but the delivery record should explicitly acknowledge the normalization exception before archive/PR handoff. |
+
+## Risks and blockers
+
+### Warnings
+
+1. Canonical `spec.md` is missing, so formal stored-spec coverage was skipped.
+2. Ruff normalization expanded the diff to 888 changed lines without a recorded `size:exception`.
+
+### Blockers
+
+None for the focused functional verification and native attempt settlement.
+
+## Native attempt evidence
+
+- Attempt token: `sha256:0d182e1fbe505ba7b5a99695c98a4c24ada06529f1eb91d74e2eeb70cca6531b`
+- Evidence revision: `sha256:1c08e298a1b81f214804232b60432e6397d69bac4751819413ccdc61aa2c0c89` (SHA-256 of the final candidate binary diff used for this verification).
+- Settlement command completed exactly once with request ID `settle-issue25-verify-20260811-a1`.
+- Native settle output: `{ "state": "complete" }`.

--- a/tests/congress_videos/modules/test_speaker_helpers.py
+++ b/tests/congress_videos/modules/test_speaker_helpers.py
@@ -34,22 +34,26 @@ class TestFormatSpeakerList:
         result = format_speaker_list(speakers)
         assert result == "- Ana García"
 
-    def test_single_speaker_missing_name_key_uses_desconocido(self):
+    def test_single_speaker_missing_name_key_omits_placeholder(self):
+        """Task 1.7 RED: format_speaker_list MUST NOT emit 'Desconocido' literal.
+
+        When speaker_name key is missing, the entry should be skipped rather than
+        emitting a hardcoded placeholder string.
+        """
         speakers = [{"role": "Diputado"}]
         result = format_speaker_list(speakers)
-        assert "Desconocido" in result
-        assert "Diputado" in result
+        assert "Desconocido" not in result
 
     def test_multiple_speakers_each_on_own_line(self):
         speakers = [
-            {"speaker_name": "Ana", "role": "Presidenta"},
-            {"speaker_name": "Juan", "role": "Diputado"},
+            {"speaker_name": "Ana García", "role": "Presidenta"},
+            {"speaker_name": "Juan Pérez", "role": "Diputado"},
         ]
         result = format_speaker_list(speakers)
         lines = result.split("\n")
         assert len(lines) == 2
-        assert "Ana" in lines[0]
-        assert "Juan" in lines[1]
+        assert "Ana García" in lines[0]
+        assert "Juan Pérez" in lines[1]
 
     def test_include_role_false_omits_roles(self):
         speakers = [{"speaker_name": "Ana García", "role": "Presidenta"}]
@@ -58,30 +62,30 @@ class TestFormatSpeakerList:
         assert "Ana García" in result
 
     def test_max_speakers_limits_output(self):
-        speakers = [{"speaker_name": f"Speaker{i}", "role": "Rol"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "Rol"} for i in range(5)]
         result = format_speaker_list(speakers, max_speakers=3)
         lines = [line for line in result.split("\n") if line.startswith("-")]
         assert len(lines) == 3
 
     def test_overflow_singular_one_more(self):
         # Exactly max_speakers + 1 → "1 participante más" (singular)
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(4)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(4)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "y 1 participante más" in result
 
     def test_overflow_plural_multiple_more(self):
         # max_speakers + 2 → "2 participantes más" (plural)
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "y 2 participantes más" in result
 
     def test_no_overflow_message_when_exactly_at_max(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(3)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(3)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert "más" not in result
 
     def test_overflow_message_with_default_max_10(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(12)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(12)]
         result = format_speaker_list(speakers)
         assert "y 2 participantes más" in result
 
@@ -91,7 +95,7 @@ class TestFormatSpeakerList:
         (10, "participantes"),
     ])
     def test_overflow_singular_plural_parametrized(self, remaining: int, expected_word: str):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(3 + remaining)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(3 + remaining)]
         result = format_speaker_list(speakers, max_speakers=3)
         assert expected_word in result
 
@@ -117,43 +121,48 @@ class TestFormatSpeakerContext:
         assert "Ana García" in result
         assert "()" not in result
 
-    def test_single_speaker_missing_name_key_uses_unknown(self):
+    def test_single_speaker_missing_name_key_omits_placeholder(self):
+        """Task 1.7 RED: format_speaker_context MUST NOT emit 'Unknown' literal.
+
+        When speaker_name key is missing, the entry should be skipped rather than
+        emitting a hardcoded placeholder string.
+        """
         speakers = [{"role": "Diputado"}]
         result = format_speaker_context(speakers)
-        assert "Unknown" in result
+        assert "Unknown" not in result
 
     def test_prefix_is_included(self):
-        speakers = [{"speaker_name": "Ana", "role": "R"}]
+        speakers = [{"speaker_name": "Ana García", "role": "R"}]
         result = format_speaker_context(speakers, prefix="Participan")
         assert result.startswith("Participan:")
 
     def test_custom_prefix(self):
-        speakers = [{"speaker_name": "Ana", "role": "R"}]
+        speakers = [{"speaker_name": "Ana García", "role": "R"}]
         result = format_speaker_context(speakers, prefix="Speakers")
         assert result.startswith("Speakers:")
 
     def test_max_speakers_limits_output(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_context(speakers, max_speakers=2)
-        assert "S2" not in result
-        assert "S3" not in result
+        assert "Orador Numero2" not in result
+        assert "Orador Numero3" not in result
 
     def test_multiple_speakers_joined_by_comma(self):
         speakers = [
-            {"speaker_name": "Ana", "role": "Presidenta"},
-            {"speaker_name": "Juan", "role": "Diputado"},
+            {"speaker_name": "Ana García", "role": "Presidenta"},
+            {"speaker_name": "Juan Pérez", "role": "Diputado"},
         ]
         result = format_speaker_context(speakers)
-        assert "Ana (Presidenta), Juan (Diputado)" in result
+        assert "Ana García (Presidenta), Juan Pérez (Diputado)" in result
 
     def test_default_max_speakers_is_3(self):
-        speakers = [{"speaker_name": f"S{i}", "role": "R"} for i in range(5)]
+        speakers = [{"speaker_name": f"Orador Numero{i}", "role": "R"} for i in range(5)]
         result = format_speaker_context(speakers)
-        assert "S3" not in result
-        assert "S4" not in result
+        assert "Orador Numero3" not in result
+        assert "Orador Numero4" not in result
 
     def test_speaker_without_role_no_parentheses(self):
-        speakers = [{"speaker_name": "Ana"}, {"speaker_name": "Juan"}]
+        speakers = [{"speaker_name": "Ana García"}, {"speaker_name": "Juan Pérez"}]
         result = format_speaker_context(speakers)
         assert "()" not in result
-        assert "Ana, Juan" in result
+        assert "Ana García, Juan Pérez" in result

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -531,6 +531,168 @@ class TestDedupeDirtySpeakersPlaceholderFilter:
 
 
 # ---------------------------------------------------------------------------
+# T-09 (Task 2.3 RED): update_chapter_speakers — optional resolved_participant_slug param
+# ---------------------------------------------------------------------------
+
+class TestUpdateChapterSpeakersSlugParam:
+    """Task 2.3 RED — update_chapter_speakers must accept and write resolved_participant_slug.
+
+    Tests the Database.update_chapter_speakers method in database.py.
+    """
+
+    def test_slug_written_when_provided(self, mock_psycopg2_connection):
+        """When resolved_participant_slug is provided, it must be included in the UPDATE."""
+        _, mock_conn, mock_cursor = mock_psycopg2_connection
+
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        db.update_chapter_speakers(
+            chapter_id=42,
+            speakers=["Pedro Sánchez"],
+            key_speakers=["Pedro Sánchez"],
+            timeline=[],
+            resolved_participant_slug="pedro-sanchez",
+        )
+
+        # Find the UPDATE call and assert resolved_participant_slug appears in it
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" in sql, (
+            "resolved_participant_slug column must be in the UPDATE SQL"
+        )
+        # Verify the slug value is in the params
+        params = update_calls[0].args[1]
+        assert "pedro-sanchez" in params, (
+            "resolved_participant_slug value must be passed as a parameter"
+        )
+
+    def test_slug_not_written_when_none(self, mock_psycopg2_connection):
+        """When resolved_participant_slug is None (default), it must NOT appear in UPDATE SQL."""
+        _, mock_conn, mock_cursor = mock_psycopg2_connection
+
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        db.update_chapter_speakers(
+            chapter_id=99,
+            speakers=["Ana López"],
+            key_speakers=[],
+            timeline=[],
+        )
+
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" not in sql, (
+            "resolved_participant_slug must not be in the UPDATE SQL when not provided"
+        )
+
+
+# ---------------------------------------------------------------------------
+# T-10 (Task 2.5 RED): normalize_chapter_speakers — slug fill on matched entry
+# ---------------------------------------------------------------------------
+
+class TestNormalizeChapterSpeakersSlugFill:
+    """Task 2.5 RED — normalize_chapter_speakers must write resolved_participant_slug on match.
+
+    After AI confirms 'match', the function derives the slug from the candidate's
+    normalized_name and writes it via update_chapter_speakers (or direct UPDATE).
+    No LLM call is triggered by the slug fill itself.
+    """
+
+    def test_matched_cache_entry_triggers_slug_write(self, mock_db_conn):
+        """A confirmed 'matched' cache entry must write resolved_participant_slug."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            normalize_chapter_speakers(
+                42, ["Pedro Sanchez"], ["Pedro Sanchez"], [],
+                mock_conn, _make_config()
+            )
+
+        # The bulk UPDATE on video_chapters must include resolved_participant_slug
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert update_calls, "Expected UPDATE video_chapters to be called"
+        sql = str(update_calls[0].args[0])
+        assert "resolved_participant_slug" in sql, (
+            "resolved_participant_slug must be set in the UPDATE after a matched entry"
+        )
+        params = update_calls[0].args[1]
+        # Slug derived from normalized_name "pedro sanchez" → "pedro-sanchez"
+        assert "pedro-sanchez" in params, (
+            "slug 'pedro-sanchez' must be passed as a parameter in the UPDATE"
+        )
+
+    def test_unresolved_chapter_slug_stays_null(self, mock_db_conn):
+        """When there is no match, resolved_participant_slug must not be written."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                99, ["Unknown Speaker"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # No UPDATE should have been issued (no match, no write)
+        update_calls = [
+            c for c in mock_cursor.execute.call_args_list
+            if "UPDATE" in str(c.args[0]).upper() and "video_chapters" in str(c.args[0]).lower()
+        ]
+        assert not update_calls, (
+            "UPDATE video_chapters must NOT be called when there is no match"
+        )
+
+    def test_no_llm_call_on_slug_fill_path(self, mock_db_conn):
+        """Slug fill must not trigger any additional LLM calls beyond the match itself."""
+        mock_conn, mock_cursor = mock_db_conn
+
+        candidate = _make_participant("Pedro Sánchez", "pedro sanchez")
+        ai_result = _make_ai_result("match", confidence=0.95)
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=candidate),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion",
+                  return_value=ai_result) as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            normalize_chapter_speakers(
+                42, ["Pedro Sanchez"], [], [],
+                mock_conn, _make_config()
+            )
+
+        # cached_json_completion called exactly once (for the match decision only)
+        assert mock_ai.call_count == 1, (
+            "cached_json_completion must be called exactly once — slug fill is LLM-free"
+        )
+
+
+# ---------------------------------------------------------------------------
 # T-07 (Bonus from task description): ENABLED=False → immediate return
 # ---------------------------------------------------------------------------
 

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -718,3 +718,73 @@ class TestEnabledFalse:
         assert result.updated is False
         assert result.corrections == {}
         assert result.cache_rows == []
+
+
+# ---------------------------------------------------------------------------
+# T-07: Institutional-role resolution (PR2)
+# ---------------------------------------------------------------------------
+
+class TestInstitutionalRoleResolution:
+    """Role-only mentions resolve to a canonical name via the bundled catalog."""
+
+    def test_role_mention_resolved_for_non_deputy_uses_catalog_name(self, mock_db_conn):
+        from datetime import date
+
+        mock_conn, mock_cursor = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_by_slug",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy") as mock_fuzzy,
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion") as mock_ai,
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                7, ["Ministra de Defensa"], [], [],
+                mock_conn, _make_config(), session_date=date(2026, 6, 1),
+            )
+
+        assert result.corrections["Ministra de Defensa"] == "Robles Fernández, Margarita"
+        # A deterministic role hit must not consult fuzzy matching or the LLM.
+        mock_fuzzy.assert_not_called()
+        mock_ai.assert_not_called()
+
+    def test_role_mention_prefers_participant_row_display_name(self, mock_db_conn):
+        from datetime import date
+
+        mock_conn, _ = mock_db_conn
+        row = _make_participant("Puente Santiago, Óscar", "oscar puente santiago")
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_by_slug",
+                  return_value=row),
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy"),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                8, ["el Ministro de Transportes"], [], [],
+                mock_conn, _make_config(), session_date=date(2026, 6, 1),
+            )
+
+        assert result.corrections["el Ministro de Transportes"] == "Puente Santiago, Óscar"
+
+    def test_missing_session_date_skips_role_resolution(self, mock_db_conn):
+        mock_conn, _ = mock_db_conn
+
+        with (
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_by_slug") as mock_slug,
+            patch("congress_videos.modules.speaker_normalization.lookup_participant_fuzzy",
+                  return_value=None),
+            patch("congress_videos.modules.speaker_normalization.cached_json_completion"),
+        ):
+            from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
+            result = normalize_chapter_speakers(
+                9, ["Ministra de Defensa"], [], [],
+                mock_conn, _make_config(),
+            )
+
+        # Without a session date the catalog is never consulted; the role-only
+        # mention is left to the placeholder filter, so it is not corrected.
+        assert "Ministra de Defensa" not in result.corrections
+        mock_slug.assert_not_called()

--- a/tests/congress_videos/modules/test_speaker_normalization.py
+++ b/tests/congress_videos/modules/test_speaker_normalization.py
@@ -185,7 +185,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -201,7 +201,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -218,7 +218,7 @@ class TestFuzzyThresholdMiss:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["UnknownSpeakerXYZ"], [], [],
+                1, ["Carlos Romero Alias"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -250,7 +250,7 @@ class TestAINoMatch:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroSanchezVariant"], [], [],
+                1, ["Pedro Sanchez Variant"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -273,7 +273,7 @@ class TestAINoMatch:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroSanchezVariant"], [], [],
+                1, ["Pedro Sanchez Variant"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -302,7 +302,7 @@ class TestAINeedsManual:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroAmbiguous"], [], [],
+                1, ["Pedro Ambiguo Real"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -322,7 +322,7 @@ class TestAINeedsManual:
         ):
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
-                1, ["PedroAmbiguous"], [], [],
+                1, ["Pedro Ambiguo Real"], [], [],
                 mock_conn, _make_config()
             )
 
@@ -341,8 +341,8 @@ class TestMultipleSpeakers:
         mock_conn, mock_cursor = mock_db_conn
 
         participant_map = {
-            "Speaker One": _make_participant("Speaker One", "speaker one"),
-            "Speaker Two": _make_participant("Speaker Two", "speaker two"),
+            "Ana Ruiz Pérez": _make_participant("Ana Ruiz Pérez", "ana ruiz perez"),
+            "Juan García López": _make_participant("Juan García López", "juan garcia lopez"),
         }
 
         def fuzzy_side(name, threshold):
@@ -359,22 +359,22 @@ class TestMultipleSpeakers:
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
                 7,
-                ["Speaker One", "Speaker Two", "Unknown"],
+                ["Ana Ruiz Pérez", "Juan García López", "María Fernández Gil"],
                 [],
                 [],
                 mock_conn,
                 _make_config(),
             )
 
-        # One cache row per unique dirty speaker
+        # One cache row per unique dirty speaker (all three are real multi-word names)
         assert len(result.cache_rows) == 3
 
     def test_only_matched_speakers_corrected(self, mock_db_conn):
         mock_conn, mock_cursor = mock_db_conn
 
         def fuzzy_side(name, threshold):
-            if name == "Speaker One":
-                return _make_participant("Speaker One", "speaker one")
+            if name == "Ana Ruiz Pérez":
+                return _make_participant("Ana Ruiz Pérez", "ana ruiz perez")
             return None
 
         ai_result = _make_ai_result("match", confidence=0.90)
@@ -388,16 +388,16 @@ class TestMultipleSpeakers:
             from congress_videos.modules.speaker_normalization import normalize_chapter_speakers
             result = normalize_chapter_speakers(
                 7,
-                ["Speaker One", "Speaker Two", "Unknown"],
+                ["Ana Ruiz Pérez", "Juan García López", "María Fernández Gil"],
                 [],
                 [],
                 mock_conn,
                 _make_config(),
             )
 
-        assert "Speaker One" in result.corrections
-        assert "Speaker Two" not in result.corrections
-        assert "Unknown" not in result.corrections
+        assert "Ana Ruiz Pérez" in result.corrections
+        assert "Juan García López" not in result.corrections
+        assert "María Fernández Gil" not in result.corrections
 
 
 # ---------------------------------------------------------------------------
@@ -449,6 +449,85 @@ class TestAICallError:
         assert result.updated is False
         calls_sql = [str(c.args[0]).lower() for c in mock_cursor.execute.call_args_list]
         assert not any("update" in s and "video_chapters" in s for s in calls_sql)
+
+
+# ---------------------------------------------------------------------------
+# T-08: _dedupe_dirty_speakers drops placeholder names (Task 1.7 RED)
+# ---------------------------------------------------------------------------
+
+class TestDedupeDirtySpeakersPlaceholderFilter:
+    """Task 1.7 RED — _dedupe_dirty_speakers must filter placeholders before dedup."""
+
+    def test_desconocido_dropped_from_speakers(self):
+        """'Desconocido' must not appear in the deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Desconocido", "Pedro Sánchez"],
+            [],
+            [],
+        )
+        assert "Desconocido" not in result
+        assert "Pedro Sánchez" in result
+
+    def test_unknown_dropped_from_speakers(self):
+        """'Unknown' must not appear in the deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Unknown", "María López"],
+            [],
+            [],
+        )
+        assert "Unknown" not in result
+        assert "María López" in result
+
+    def test_no_especificado_dropped_from_key_speakers(self):
+        """'(No especificado)' in key_speakers must be filtered."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            [],
+            ["(No especificado)", "Ana Martínez"],
+            [],
+        )
+        assert "(No especificado)" not in result
+        assert "Ana Martínez" in result
+
+    def test_placeholder_in_timeline_speaker_dropped(self):
+        """Placeholder in timeline[].speaker must be filtered."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            [],
+            [],
+            [{"speaker": "Desconocido", "content": "...", "time": "00:01:00"}],
+        )
+        assert "Desconocido" not in result
+
+    def test_all_real_speakers_preserved(self):
+        """Non-placeholder names must still appear in deduped output."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Ana Ruiz", "Pedro García"],
+            ["Laura Gómez"],
+            [],
+        )
+        assert "Ana Ruiz" in result
+        assert "Pedro García" in result
+        assert "Laura Gómez" in result
+
+    def test_mix_placeholders_and_real_names(self):
+        """Mixed list: only real names survive, order preserved."""
+        from congress_videos.modules.speaker_normalization import _dedupe_dirty_speakers
+
+        result = _dedupe_dirty_speakers(
+            ["Desconocido", "Ana Ruiz", "Unknown"],
+            ["Pedro García"],
+            [{"speaker": "No especificado", "content": "", "time": "00:00"}],
+        )
+        assert result == ["Ana Ruiz", "Pedro García"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/congress_videos/modules/test_speaker_placeholders.py
+++ b/tests/congress_videos/modules/test_speaker_placeholders.py
@@ -1,0 +1,166 @@
+"""Tests for congress_videos.modules.speaker_placeholders (Task 1.1 RED).
+
+Covers:
+- PLACEHOLDER_SPEAKERS frozenset membership (casefolded exact set)
+- is_placeholder: 5 spec scenarios (exact match, single-token, role-only,
+  role+propername fail-open, unrecognised fail-open)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+class TestPlaceholderSpeakersSet:
+    """PLACEHOLDER_SPEAKERS is a frozenset of casefolded exact placeholder strings."""
+
+    def test_frozenset_is_importable(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert isinstance(PLACEHOLDER_SPEAKERS, frozenset)
+
+    def test_desconocido_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "desconocido" in PLACEHOLDER_SPEAKERS
+
+    def test_unknown_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "unknown" in PLACEHOLDER_SPEAKERS
+
+    def test_interviniente_no_especificado_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "interviniente no especificado" in PLACEHOLDER_SPEAKERS
+
+    def test_no_especificado_parenthesized_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "(no especificado)" in PLACEHOLDER_SPEAKERS
+
+    def test_no_especificado_plain_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "no especificado" in PLACEHOLDER_SPEAKERS
+
+    def test_empty_string_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "" in PLACEHOLDER_SPEAKERS
+
+    def test_real_name_not_in_set(self):
+        from congress_videos.modules.speaker_placeholders import PLACEHOLDER_SPEAKERS
+
+        assert "pedro sánchez" not in PLACEHOLDER_SPEAKERS
+        assert "Ana Martínez" not in PLACEHOLDER_SPEAKERS
+
+
+class TestIsPlaceholderExactMatch:
+    """Scenario: Known placeholder exact match → is_placeholder returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Desconocido",
+        "desconocido",
+        "DESCONOCIDO",
+        "Unknown",
+        "unknown",
+        "UNKNOWN",
+        "Interviniente no especificado",
+        "INTERVINIENTE NO ESPECIFICADO",
+        "(No especificado)",
+        "(NO ESPECIFICADO)",
+        "No especificado",
+        "NO ESPECIFICADO",
+        "",
+    ])
+    def test_exact_placeholder_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderSingleToken:
+    """Scenario: Single-token string with no whitespace → is_placeholder returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Portavoz",
+        "PP",
+        "PSOE",
+        "Diputado",
+        "Diputada",
+        "Senador",
+        "Presidente",
+        "Presidenta",
+        "Ministro",
+        "Ministra",
+        "Secretario",
+        "Vocal",
+        "Interveniente",
+        "Interviniente",
+    ])
+    def test_single_token_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderRoleOnly:
+    """Scenario: Role-keyword prefix without a proper name → returns True."""
+
+    @pytest.mark.parametrize("name", [
+        "Presidenta",
+        "Ministro",
+        "Portavoz del grupo",
+        "Diputado del PP",
+    ])
+    def test_role_only_returns_true(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is True, f"Expected is_placeholder({name!r}) == True"
+
+
+class TestIsPlaceholderRoleWithProperName:
+    """Scenario: Role prefix followed by a proper name → fail-open, returns False."""
+
+    @pytest.mark.parametrize("name", [
+        "Presidente Sánchez",
+        "Ministra González",
+        "Portavoz López",
+        "Diputado Martínez García",
+    ])
+    def test_role_plus_propername_returns_false(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is False, f"Expected is_placeholder({name!r}) == False"
+
+
+class TestIsPlaceholderUnrecognisedFailOpen:
+    """Scenario: Unrecognised shape → fail-open, returns False (real name, not filtered)."""
+
+    @pytest.mark.parametrize("name", [
+        "Ana Martínez",
+        "Pedro López",
+        "Laura Gómez",
+        "María José Rodríguez",
+        "José Antonio Fernández",
+        "Xi Jinping",
+        "Joe Biden",
+        "Cualquier Nombre Real",
+    ])
+    def test_real_name_returns_false(self, name: str):
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder(name) is False, f"Expected is_placeholder({name!r}) == False"
+
+    def test_whitespace_only_treated_as_placeholder(self):
+        """Whitespace-only strings collapse to empty string → placeholder."""
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder("   ") is True
+
+    def test_none_equivalent_empty_string_is_placeholder(self):
+        """Empty string is in PLACEHOLDER_SPEAKERS."""
+        from congress_videos.modules.speaker_placeholders import is_placeholder
+
+        assert is_placeholder("") is True

--- a/tests/congress_videos/modules/youtube/test_download.py
+++ b/tests/congress_videos/modules/youtube/test_download.py
@@ -1913,3 +1913,159 @@ class TestDownloadGuardForwarding:
         )
 
         assert spy.call_args.kwargs["guard_live_status"] is False
+
+
+# ---------------------------------------------------------------------------
+# PR3 — _flatten_speakers wired into identify_interesting_chapters (Task 3.7 RED)
+# ---------------------------------------------------------------------------
+
+class TestIdentifyInterestingChaptersFlattenSpeakers:
+    """Assert that identify_interesting_chapters flattens structured speaker
+    objects (new LLM prompt format) to list[str] before returning chapters.
+
+    The 'speakers' field in every interesting_chapter must be list[str]
+    regardless of whether the LLM returned the new object form or the legacy
+    flat-string form — backward compat is required in both paths.
+    """
+
+    def _make_summarized_chunk(self, number=1, duration_minutes=130):
+        return {
+            "chunk_number": number,
+            "start_time": "00:00:00",
+            "end_time": "02:10:00",
+            "duration_seconds": duration_minutes * 60,
+            "duration_minutes": duration_minutes,
+            "speakers": [{"name": "Diputado López", "role": "Diputado"}],
+            "topics": ["Presupuestos"],
+            "summary": "Debate largo sobre presupuestos"
+        }
+
+    def _make_srt_chunk(self, number=1, duration_minutes=130):
+        return {
+            "chunk_number": number,
+            "start_time": "00:00:00",
+            "end_time": "02:10:00",
+            "duration_minutes": duration_minutes,
+            "content": "1\n00:00:01,000 --> 00:00:05,000\nContenido de prueba"
+        }
+
+    def test_structured_speaker_objects_flattened_to_strings(self, mocker):
+        """LLM returns new object-form speakers → chapter['speakers'] is list[str]."""
+        # LLM returns structured speaker objects (new prompt format)
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate Presupuestos",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": [
+                    {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.95},
+                    {"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.3},
+                ],
+                "topics": ["Presupuestos"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        assert result["total_videos"] == 1
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        assert len(chapters) == 1
+        speakers = chapters[0]["speakers"]
+        # Must be flat list[str], not list[dict]
+        assert all(isinstance(s, str) for s in speakers), (
+            f"speakers must be list[str], got: {speakers!r}"
+        )
+        # Null speaker_name must be dropped; real name must be kept
+        assert "Ana López" in speakers
+        assert len(speakers) == 1, "null speaker_name entry must be dropped"
+
+    def test_legacy_flat_string_speakers_pass_through(self, mocker):
+        """LLM returns old flat-string speaker list → chapter['speakers'] unchanged."""
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": ["Ana López", "Pedro García"],
+                "topics": ["Política"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        speakers = chapters[0]["speakers"]
+        assert speakers == ["Ana López", "Pedro García"], (
+            f"flat-string speakers must pass through unchanged, got: {speakers!r}"
+        )
+
+    def test_all_null_speaker_names_yields_empty_list(self, mocker):
+        """LLM returns only null speaker_name objects → speakers list is empty."""
+        chapters_json = json.dumps({
+            "interesting_chapters": [{
+                "title": "Debate",
+                "description": "Desc",
+                "start_time": "00:00:00",
+                "end_time": "01:00:00",
+                "duration_minutes": 60,
+                "speakers": [
+                    {"speaker_name": None, "speaker_role": "Portavoz PP", "speaker_confidence": None},
+                    {"speaker_name": None, "speaker_role": "Portavoz PSOE", "speaker_confidence": None},
+                ],
+                "topics": ["Política"]
+            }]
+        })
+        _patch_completion(mocker, chapters_json)
+
+        from congress_videos.modules.youtube.download import identify_interesting_chapters
+
+        chunk_summaries = {"videos": [{
+            "video_id": "v1",
+            "video_title": "Test",
+            "summarized_chunks": [self._make_summarized_chunk(1)]
+        }]}
+        chunked_srt = {"videos": [{
+            "video_id": "v1",
+            "chunks": [self._make_srt_chunk(1)]
+        }]}
+
+        result = identify_interesting_chapters(chunk_summaries, chunked_srt, "2025-01-01",
+                                               min_chapter_duration=15, max_optimal_duration=120)
+
+        chapters = result["videos"][0]["chunks_with_chapters"][0]["interesting_chapters"]
+        speakers = chapters[0]["speakers"]
+        assert speakers == [], (
+            f"all-null speaker_name objects must yield empty list, got: {speakers!r}"
+        )

--- a/tests/congress_videos/modules/youtube/test_youtube_channel_title.py
+++ b/tests/congress_videos/modules/youtube/test_youtube_channel_title.py
@@ -10,10 +10,11 @@ the enriched_video dict so the API value always wins.
 
 from __future__ import annotations
 
-import os
 from unittest.mock import MagicMock, patch
 
 import pytest
+
+from congress_videos.modules.youtube.download import create_test_video_data
 
 
 @pytest.fixture(autouse=True)
@@ -21,14 +22,19 @@ def set_api_key(monkeypatch):
     monkeypatch.setenv("YOUTUBE_API_KEY", "fake-api-key")
 
 
-def _make_api_response(video_id: str, api_title: str):
+_UNSET = object()
+
+
+def _make_api_response(video_id: str, api_title: str, published_at=_UNSET):
     """Build a minimal youtube.videos().list() response."""
+    snippet = {"title": api_title}
+    if published_at is not _UNSET:
+        snippet["publishedAt"] = published_at
+
     return {
         "items": [
             {
-                "snippet": {
-                    "title": api_title,
-                },
+                "snippet": snippet,
                 "contentDetails": {
                     "duration": "PT2H30M15S",
                 },
@@ -48,7 +54,7 @@ def _plenary_videos(video_id: str, mock_title: str):
         "videos": [
             {
                 "video_id": video_id,
-                "title": mock_title,         # placeholder / mock title
+                "title": mock_title,  # placeholder / mock title
                 "url": f"https://www.youtube.com/watch?v={video_id}",
                 "published_at": "2025-01-15T08:00:00Z",
                 "is_live": False,
@@ -59,59 +65,91 @@ def _plenary_videos(video_id: str, mock_title: str):
 
 
 class TestGetVideoDetailsPropagatesRealTitle:
-
     def test_enriched_video_contains_real_api_title(self):
         """The 'title' key in the enriched video dict must come from snippet.title,
         NOT from the placeholder title in the input mock dict."""
-        video_id = "ZBU0bVpYXM4"
-        mock_placeholder_title = "Test Video - Sesión Plenaria"
+        selected_video = create_test_video_data(
+            "https://www.youtube.com/watch?v=ZBU0bVpYXM4"
+        )
+        placeholder = selected_video["videos"][0]
         real_api_title = "Sesión Plenaria 15 enero 2025"
+        real_api_published_at = "2025-01-15T08:00:00Z"
 
-        api_response = _make_api_response(video_id, real_api_title)
+        api_response = _make_api_response(
+            placeholder["video_id"], real_api_title, real_api_published_at
+        )
         mock_yt_service = MagicMock()
-        mock_yt_service.videos.return_value.list.return_value.execute.return_value = api_response
+        mock_yt_service.videos.return_value.list.return_value.execute.return_value = (
+            api_response
+        )
 
         with patch(
             "congress_videos.modules.youtube.youtube_channel.build",
             return_value=mock_yt_service,
         ):
-            from congress_videos.modules.youtube.youtube_channel import get_video_details
-
-            result = get_video_details(
-                _plenary_videos(video_id, mock_placeholder_title),
-                min_hours_since_end=0,
+            from congress_videos.modules.youtube.youtube_channel import (
+                get_video_details,
             )
+
+            result = get_video_details(selected_video, min_hours_since_end=0)
 
         assert result["total_videos"] == 1
         enriched = result["videos"][0]
-        # The real API title must win over the placeholder
-        assert enriched["title"] == real_api_title, (
-            f"Expected real API title '{real_api_title}', got '{enriched['title']}'"
-        )
+        assert enriched["title"] == real_api_title
+        assert enriched["title"] != placeholder["title"]
+        assert enriched["published_at"] == real_api_published_at
+        assert enriched["published_at"] != placeholder["published_at"]
 
     def test_placeholder_title_does_not_appear_when_api_returns_different_title(self):
         """Regression: the old spread (**video) allowed placeholder to propagate."""
-        video_id = "ABCDEFGHIJK"
-        mock_placeholder_title = "Test Video - Sesión Plenaria"
+        selected_video = create_test_video_data(
+            "https://www.youtube.com/watch?v=ABCDEFGHIJK"
+        )
+        placeholder = selected_video["videos"][0]
         real_api_title = "Sesión Extraordinaria 20 febrero 2025"
 
-        api_response = _make_api_response(video_id, real_api_title)
+        api_response = _make_api_response(placeholder["video_id"], real_api_title)
         mock_yt_service = MagicMock()
-        mock_yt_service.videos.return_value.list.return_value.execute.return_value = api_response
+        mock_yt_service.videos.return_value.list.return_value.execute.return_value = (
+            api_response
+        )
 
         with patch(
             "congress_videos.modules.youtube.youtube_channel.build",
             return_value=mock_yt_service,
         ):
-            from congress_videos.modules.youtube.youtube_channel import get_video_details
-
-            result = get_video_details(
-                _plenary_videos(video_id, mock_placeholder_title),
-                min_hours_since_end=0,
+            from congress_videos.modules.youtube.youtube_channel import (
+                get_video_details,
             )
 
+            result = get_video_details(selected_video, min_hours_since_end=0)
+
         enriched = result["videos"][0]
-        assert enriched["title"] != mock_placeholder_title, (
-            "Placeholder title must NOT appear in the enriched video dict"
-        )
+        assert enriched["title"] != placeholder["title"]
         assert enriched["title"] == real_api_title
+
+
+@pytest.mark.parametrize("published_at", [_UNSET, ""])
+def test_enriched_video_keeps_input_publication_time_when_api_omits_it(published_at):
+    """Missing and empty API publication time preserve the selected record."""
+    selected_video = create_test_video_data(
+        "https://www.youtube.com/watch?v=ZBU0bVpYXM4"
+    )
+    placeholder = selected_video["videos"][0]
+    api_response = _make_api_response(
+        placeholder["video_id"], "API title", published_at
+    )
+    mock_yt_service = MagicMock()
+    mock_yt_service.videos.return_value.list.return_value.execute.return_value = (
+        api_response
+    )
+
+    with patch(
+        "congress_videos.modules.youtube.youtube_channel.build",
+        return_value=mock_yt_service,
+    ):
+        from congress_videos.modules.youtube.youtube_channel import get_video_details
+
+        result = get_video_details(selected_video, min_hours_since_end=0)
+
+    assert result["videos"][0]["published_at"] == placeholder["published_at"]

--- a/tests/congress_videos/sql/test_migration_020.py
+++ b/tests/congress_videos/sql/test_migration_020.py
@@ -1,0 +1,110 @@
+"""[RED] Test: migration 020 — add resolved_participant_slug to video_chapters.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, column added idempotently, FK references congress_participants(slug),
+index created, backfill is idempotent (WHERE slug IS NULL), unqualified table names.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "020_add_resolved_participant_slug.sql"
+)
+
+
+class TestMigration020FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration020ColumnDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_adds_column_if_not_exists(self):
+        """Migration must use ADD COLUMN IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG" in sql
+
+    def test_column_is_text(self):
+        """resolved_participant_slug column must be TEXT type."""
+        sql = self._sql().upper()
+        # ADD COLUMN IF NOT EXISTS resolved_participant_slug TEXT
+        assert re.search(r"RESOLVED_PARTICIPANT_SLUG\s+TEXT", sql)
+
+    def test_column_references_congress_participants_slug(self):
+        """Column must have FK REFERENCES congress_participants(slug)."""
+        sql = self._sql()
+        assert "REFERENCES congress_participants(slug)" in sql
+
+    def test_creates_index_if_not_exists(self):
+        """Migration must create an index with CREATE INDEX IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "CREATE INDEX IF NOT EXISTS" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG" in sql
+
+
+class TestMigration020Backfill:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_backfill_updates_video_chapters(self):
+        """Backfill must UPDATE video_chapters."""
+        sql = self._sql().upper()
+        assert "UPDATE VIDEO_CHAPTERS" in sql
+
+    def test_backfill_joins_speaker_normalization_cache(self):
+        """Backfill must JOIN speaker_normalization_cache."""
+        sql = self._sql().upper()
+        assert "SPEAKER_NORMALIZATION_CACHE" in sql
+
+    def test_backfill_joins_congress_participants(self):
+        """Backfill must JOIN congress_participants to get authoritative slug."""
+        sql = self._sql().upper()
+        assert "CONGRESS_PARTICIPANTS" in sql
+
+    def test_backfill_filters_matched_status(self):
+        """Backfill must only apply to cache rows with status='matched'."""
+        sql = self._sql()
+        assert "'matched'" in sql or "= 'matched'" in sql
+
+    def test_backfill_is_idempotent_null_guard(self):
+        """Backfill WHERE clause must guard with IS NULL to avoid overwriting filled rows."""
+        sql = self._sql().upper()
+        assert "IS NULL" in sql
+        assert "RESOLVED_PARTICIPANT_SLUG IS NULL" in sql
+
+    def test_backfill_sets_cp_slug(self):
+        """Backfill must set resolved_participant_slug to cp.slug (authoritative FK source)."""
+        sql = self._sql()
+        # Accepts either 'cp.slug' or aliased equivalent
+        assert "cp.slug" in sql or "congress_participants.slug" in sql
+
+
+class TestMigration020TableNames:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_no_schema_qualified_table_names(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        content = self._sql()
+        assert not re.search(r"\bpublic\.video_chapters\b", content)
+        assert not re.search(r"\bpublic\.congress_participants\b", content)
+        assert not re.search(r"\bpublic\.speaker_normalization_cache\b", content)

--- a/tests/congress_videos/sql/test_migration_021.py
+++ b/tests/congress_videos/sql/test_migration_021.py
@@ -1,0 +1,50 @@
+"""Test: migration 021 — expose resolved_participant_slug in uploadable_chapters.
+
+Reads the SQL file statically and asserts structural properties: file exists,
+recreates the view via CREATE OR REPLACE, appends resolved_participant_slug at
+the END of the select list (required for CREATE OR REPLACE VIEW), and uses
+unqualified names. No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "021_expose_resolved_participant_slug_in_uploadable_chapters.sql"
+)
+
+
+def _sql() -> str:
+    return MIGRATION_PATH.read_text(encoding="utf-8")
+
+
+def test_migration_file_exists():
+    assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+def test_recreates_view_idempotently():
+    sql = _sql().upper()
+    assert "CREATE OR REPLACE VIEW UPLOADABLE_CHAPTERS" in sql
+
+
+def test_exposes_resolved_participant_slug():
+    assert "vc.resolved_participant_slug" in _sql()
+
+
+def test_new_column_appended_at_end():
+    """CREATE OR REPLACE VIEW can only append columns; the new column must come
+    after the previously-last column (days_since_created)."""
+    sql = _sql()
+    assert sql.index("days_since_created") < sql.index("vc.resolved_participant_slug")
+
+
+def test_no_schema_qualified_names():
+    content = _sql()
+    assert not re.search(r"\bpublic\.uploadable_chapters\b", content)
+    assert not re.search(r"\bpublic\.video_chapters\b", content)

--- a/tests/congress_videos/test_institutional_role_resolver.py
+++ b/tests/congress_videos/test_institutional_role_resolver.py
@@ -60,7 +60,10 @@ def test_bundled_catalog_has_the_v1_contract():
     assert catalog.version == 1
     assert catalog.roles
     assert catalog.assignments
-    assert all(role.scope in {"ministerial", "presidency_mesa"} for role in catalog.roles)
+    assert all(
+        role.scope in {"ministerial", "presidency_mesa", "parliamentary_group"}
+        for role in catalog.roles
+    )
     assert all(assignment.is_valid for assignment in catalog.assignments)
 
 
@@ -115,6 +118,57 @@ def test_loader_marks_duplicate_assignment_ids_non_resolvable(tmp_path):
         "duplicate_assignment_id",
         "duplicate_assignment_id",
     ]
+
+
+def test_loader_accepts_parliamentary_group_scope(tmp_path):
+    document = valid_catalog()
+    document["roles"].append(
+        {
+            "key": "portavoz de esquerra republicana",
+            "scope": "parliamentary_group",
+            "aliases": ["portavoz del grupo parlamentario republicano"],
+        }
+    )
+    document["assignments"].append(
+        {
+            "id": "erc-spokesperson-2023-gabriel-rufian",
+            "role": "portavoz de esquerra republicana",
+            "participant_slug": "gabriel-rufian-romero",
+            "validity": {"from": "2023-08-17", "to": "open"},
+            "provenance": {
+                "publisher": "Congress of Deputies",
+                "reference_url": "https://www.congreso.es/grupos",
+                "evidence_note": "Parliamentary group spokesperson reviewed against the official Congress record.",
+                "reviewed_on": "2026-08-12",
+            },
+        }
+    )
+
+    catalog = CatalogLoader(write_catalog(tmp_path, document)).load()
+
+    role = next(item for item in catalog.roles if item.key == "portavoz de esquerra republicana")
+    assert role.scope == "parliamentary_group"
+    assert all(assignment.is_valid for assignment in catalog.assignments)
+
+
+def test_bundled_catalog_resolves_expected_current_holders():
+    catalog = CatalogLoader(CATALOG_PATH).load()
+
+    open_holders = {
+        assignment.role: assignment.participant_slug
+        for assignment in catalog.valid_assignments
+        if assignment.is_open_ended
+    }
+
+    assert open_holders["presidencia del gobierno"] == "pedro-sanchez-perez-castejon"
+    assert open_holders["ministerio de transportes y movilidad sostenible"] == "oscar-puente-santiago"
+    assert open_holders["ministerio de trabajo y economia social"] == "yolanda-diaz-perez"
+    assert open_holders["lider de la oposicion"] == "alberto-nunez-feijoo"
+    assert open_holders["presidencia de vox"] == "santiago-abascal-conde"
+    assert open_holders["portavoz de esquerra republicana"] == "gabriel-rufian-romero"
+    assert open_holders["portavoz de junts per catalunya"] == "miriam-nogueras-i-camero"
+    assert open_holders["portavoz de euskal herria bildu"] == "mertxe-aizpurua-arzallus"
+    assert open_holders["secretaria general de podemos"] == "ione-belarra-urteaga"
 
 
 def test_loader_requires_complete_nondereferenced_provenance(tmp_path):

--- a/tests/congress_videos/test_institutional_role_resolver.py
+++ b/tests/congress_videos/test_institutional_role_resolver.py
@@ -170,6 +170,20 @@ def test_bundled_catalog_resolves_expected_current_holders():
     assert open_holders["portavoz de euskal herria bildu"] == "mertxe-aizpurua-arzallus"
     assert open_holders["secretaria general de podemos"] == "ione-belarra-urteaga"
 
+    # Parliamentary group spokespersons (verified sitting deputies).
+    assert open_holders["portavoz del grupo parlamentario socialista"] == "patxi-lopez-alvarez"
+    assert open_holders["portavoz del grupo parlamentario popular"] == "miguel-tellado-filgueira"
+    assert open_holders["portavoz del grupo parlamentario vox"] == "maria-jose-rodriguez-de-millan-parro"
+    assert open_holders["portavoz del grupo plurinacional sumar"] == "veronica-martinez-barbero"
+
+    # Full cabinet coverage (most ministers are not sitting deputies; the slug is
+    # derived from the official name and will not match a participant row).
+    assert open_holders["ministerio del interior"] == "fernando-grande-marlaska-gomez"
+    assert open_holders["ministerio de defensa"] == "margarita-robles-fernandez"
+    assert open_holders["ministerio de hacienda"] == "arcadi-espana-garcia"
+    assert open_holders["ministerio de cultura"] == "ernest-urtasun-domenech"
+    assert open_holders["ministerio de juventud e infancia"] == "sira-rego"
+
 
 def test_loader_requires_complete_nondereferenced_provenance(tmp_path):
     document = valid_catalog()

--- a/tests/congress_videos/test_institutional_role_resolver.py
+++ b/tests/congress_videos/test_institutional_role_resolver.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from datetime import date
 import json
 from pathlib import Path
 
@@ -193,3 +194,53 @@ def test_loader_requires_complete_nondereferenced_provenance(tmp_path):
 
     assert catalog.assignments[0].is_valid is False
     assert catalog.assignments[0].diagnostic == "invalid_provenance"
+
+
+# ---------------------------------------------------------------------------
+# Point-in-time resolution
+# ---------------------------------------------------------------------------
+
+def bundled_catalog():
+    return CatalogLoader(CATALOG_PATH).load()
+
+
+def test_resolve_matches_role_key_at_covering_date():
+    catalog = bundled_catalog()
+
+    assert catalog.resolve("presidencia del gobierno", date(2024, 1, 1)) == (
+        "pedro-sanchez-perez-castejon"
+    )
+
+
+def test_resolve_matches_alias_case_and_accent_insensitively():
+    catalog = bundled_catalog()
+
+    # Aliases carry the actual office-holder's gender; matching ignores case,
+    # accents, and surrounding whitespace.
+    assert catalog.resolve("Ministro de Hacienda", date(2026, 6, 1)) == "arcadi-espana-garcia"
+    assert catalog.resolve("  la   MINISTRA  de Defensa ", date(2026, 6, 1)) == (
+        "margarita-robles-fernandez"
+    )
+    assert catalog.resolve("el PORTAVOZ de vox", date(2026, 6, 1)) == (
+        "maria-jose-rodriguez-de-millan-parro"
+    )
+
+
+def test_resolve_is_point_in_time_for_closed_and_open_assignments():
+    catalog = bundled_catalog()
+
+    # Batet held the presidency of Congress in the XIV Legislature; Armengol holds it now.
+    assert catalog.resolve("presidenta del congreso", date(2022, 1, 1)) == (
+        "meritxell-batet-lamana"
+    )
+    assert catalog.resolve("presidenta del congreso", date(2026, 1, 1)) == (
+        "francina-armengol-socias"
+    )
+
+
+def test_resolve_returns_none_before_validity_and_for_unknown_roles():
+    catalog = bundled_catalog()
+
+    # Before Armengol's term and after Batet's — no assignment covers this date.
+    assert catalog.resolve("presidenta del congreso", date(2023, 7, 1)) is None
+    assert catalog.resolve("ministro de teletransporte", date(2026, 1, 1)) is None

--- a/tests/congress_videos/test_institutional_role_resolver.py
+++ b/tests/congress_videos/test_institutional_role_resolver.py
@@ -244,3 +244,29 @@ def test_resolve_returns_none_before_validity_and_for_unknown_roles():
     # Before Armengol's term and after Batet's — no assignment covers this date.
     assert catalog.resolve("presidenta del congreso", date(2023, 7, 1)) is None
     assert catalog.resolve("ministro de teletransporte", date(2026, 1, 1)) is None
+
+
+def test_resolve_assignment_exposes_display_name_for_non_deputy_minister():
+    catalog = bundled_catalog()
+
+    assignment = catalog.resolve_assignment("Ministro del Interior", date(2026, 6, 1))
+
+    assert assignment is not None
+    assert assignment.participant_slug == "fernando-grande-marlaska-gomez"
+    assert assignment.display_name == "Grande-Marlaska Gómez, Fernando"
+
+
+def test_resolve_assignment_exposes_display_name_for_deputy():
+    catalog = bundled_catalog()
+
+    assignment = catalog.resolve_assignment("presidencia del gobierno", date(2024, 1, 1))
+
+    assert assignment is not None
+    assert assignment.participant_slug == "pedro-sanchez-perez-castejon"
+    assert assignment.display_name == "Sánchez Pérez-Castejón, Pedro"
+
+
+def test_resolve_assignment_returns_none_for_unknown_role():
+    catalog = bundled_catalog()
+
+    assert catalog.resolve_assignment("ministro de teletransporte", date(2026, 1, 1)) is None

--- a/tests/congress_videos/test_institutional_role_resolver.py
+++ b/tests/congress_videos/test_institutional_role_resolver.py
@@ -1,0 +1,127 @@
+"""V1 institutional-role catalog contract tests."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from congress_videos.modules.institutional_role_resolver import (
+    CatalogLoader,
+    CatalogValidationError,
+)
+
+
+CATALOG_PATH = (
+    Path(__file__).parents[2]
+    / "congress_videos"
+    / "catalogs"
+    / "institutional_roles.v1.json"
+)
+
+
+def valid_catalog() -> dict:
+    return {
+        "catalog_version": 1,
+        "roles": [
+            {
+                "key": "presidencia del congreso",
+                "scope": "presidency_mesa",
+                "aliases": ["presidenta del congreso"],
+            }
+        ],
+        "assignments": [
+            {
+                "id": "mesa-presidency-2023",
+                "role": "presidencia del congreso",
+                "participant_slug": "francina-armengol-socias",
+                "validity": {"from": "2023-08-17", "to": "open"},
+                "provenance": {
+                    "publisher": "Congress of Deputies",
+                    "reference_url": "https://www.congreso.es/mesa",
+                    "evidence_note": "Mesa composition reviewed against the official Congress record.",
+                    "reviewed_on": "2023-08-17",
+                },
+            }
+        ],
+    }
+
+
+def write_catalog(tmp_path: Path, document: dict) -> Path:
+    path = tmp_path / "catalog.json"
+    path.write_text(json.dumps(document), encoding="utf-8")
+    return path
+
+
+def test_bundled_catalog_has_the_v1_contract():
+    catalog = CatalogLoader(CATALOG_PATH).load()
+
+    assert catalog.version == 1
+    assert catalog.roles
+    assert catalog.assignments
+    assert all(role.scope in {"ministerial", "presidency_mesa"} for role in catalog.roles)
+    assert all(assignment.is_valid for assignment in catalog.assignments)
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (lambda doc: doc.update(catalog_version=2), "catalog_version"),
+        (lambda doc: doc.update(roles={}), "roles"),
+        (lambda doc: doc["roles"][0].update(key="Presidencia del Congreso"), "normalized"),
+        (lambda doc: doc["roles"][0].update(aliases=["presidencia del congreso"]), "collides"),
+        (lambda doc: doc["roles"][0].update(scope="state_secretary"), "scope"),
+    ],
+)
+def test_loader_rejects_invalid_v1_document_shape(tmp_path, mutate, message):
+    document = valid_catalog()
+    mutate(document)
+
+    with pytest.raises(CatalogValidationError, match=message):
+        CatalogLoader(write_catalog(tmp_path, document)).load()
+
+
+@pytest.mark.parametrize(
+    ("mutate", "reason"),
+    [
+        (lambda assignment: assignment.pop("provenance"), "missing_provenance"),
+        (lambda assignment: assignment["validity"].update(**{"from": "17/08/2023"}), "invalid_from"),
+        (lambda assignment: assignment["validity"].update(to=""), "invalid_to"),
+        (lambda assignment: assignment["validity"].update(to="2023-08-16"), "invalid_interval"),
+        (lambda assignment: assignment.update(role="undeclared role"), "undeclared_role"),
+        (lambda assignment: assignment.update(participant_slug=""), "missing_participant_slug"),
+    ],
+)
+def test_loader_keeps_invalid_assignments_non_resolvable(tmp_path, mutate, reason):
+    document = valid_catalog()
+    mutate(document["assignments"][0])
+
+    catalog = CatalogLoader(write_catalog(tmp_path, document)).load()
+
+    assert catalog.valid_assignments == ()
+    assert catalog.assignments[0].is_valid is False
+    assert catalog.assignments[0].diagnostic == reason
+
+
+def test_loader_marks_duplicate_assignment_ids_non_resolvable(tmp_path):
+    document = valid_catalog()
+    document["assignments"].append(document["assignments"][0].copy())
+
+    catalog = CatalogLoader(write_catalog(tmp_path, document)).load()
+
+    assert catalog.valid_assignments == ()
+    assert [assignment.diagnostic for assignment in catalog.assignments] == [
+        "duplicate_assignment_id",
+        "duplicate_assignment_id",
+    ]
+
+
+def test_loader_requires_complete_nondereferenced_provenance(tmp_path):
+    document = valid_catalog()
+    document["assignments"][0]["provenance"]["reference_url"] = "ftp://example.invalid/evidence"
+
+    catalog = CatalogLoader(write_catalog(tmp_path, document)).load()
+
+    assert catalog.assignments[0].is_valid is False
+    assert catalog.assignments[0].diagnostic == "invalid_provenance"

--- a/tests/congress_videos/test_reap_uploader_dag.py
+++ b/tests/congress_videos/test_reap_uploader_dag.py
@@ -316,22 +316,27 @@ class TestMarkShortsUploaded:
 
 class TestResolveSpeakers:
     def test_resolve_speakers_uses_key_speakers_first(self):
+        """key_speakers take priority; speakers adds non-duplicate real names to the pool."""
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": ["A", "B"], "speakers": ["C"]})
-        assert result == ("A", "B")
+        result = _resolve_speakers({
+            "key_speakers": ["Ana García", "Pedro López"],
+            "speakers": ["María Ruiz"],
+        })
+        # Pool: [Ana García, Pedro López, María Ruiz] — key_speakers first, then new speakers
+        assert result == ("Ana García", "Pedro López, María Ruiz")
 
     def test_resolve_speakers_falls_back_to_speakers(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"speakers": ["X", "Y"]})
-        assert result == ("X", "Y")
+        result = _resolve_speakers({"speakers": ["Xose Fernández", "Yolanda Díaz"]})
+        assert result == ("Xose Fernández", "Yolanda Díaz")
 
     def test_resolve_speakers_key_speakers_empty_list(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": [], "speakers": ["Z"]})
-        assert result == ("Z", "")
+        result = _resolve_speakers({"key_speakers": [], "speakers": ["Zoila Martínez"]})
+        assert result == ("Zoila Martínez", "")
 
     def test_resolve_speakers_empty_both(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
@@ -342,14 +347,93 @@ class TestResolveSpeakers:
     def test_resolve_speakers_single_speaker(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
-        result = _resolve_speakers({"key_speakers": ["Solo"]})
-        assert result == ("Solo", "")
+        result = _resolve_speakers({"key_speakers": ["Pedro Sánchez"]})
+        assert result == ("Pedro Sánchez", "")
 
     def test_resolve_speakers_none_values(self):
         from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
 
         result = _resolve_speakers({"key_speakers": None, "speakers": None})
         assert result == ("", "")
+
+    # -------------------------------------------------------------------------
+    # Placeholder-aware _resolve_speakers spec scenarios (Task 1.4 RED)
+    # -------------------------------------------------------------------------
+
+    def test_key_speakers_real_name_wins_over_speakers_placeholder(self):
+        """Spec scenario 1: key_speakers has a real name; speakers[0] is placeholder.
+
+        GIVEN key_speakers=["Ana Martínez"], speakers=["Desconocido", "Pedro López"]
+        THEN  primary="Ana Martínez", secondary="Pedro López"
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Ana Martínez"],
+            "speakers": ["Desconocido", "Pedro López"],
+        })
+        assert result == ("Ana Martínez", "Pedro López"), (
+            f"Expected ('Ana Martínez', 'Pedro López'), got {result!r}"
+        )
+
+    def test_placeholder_at_speakers_index_0_is_skipped(self):
+        """Spec scenario 2: key_speakers empty; speakers[1] is real, speakers[0] is placeholder.
+
+        GIVEN key_speakers=[], speakers=["Portavoz", "Pedro López"]
+        THEN  primary="Pedro López", secondary=""
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": [],
+            "speakers": ["Portavoz", "Pedro López"],
+        })
+        assert result == ("Pedro López", ""), (
+            f"Expected ('Pedro López', ''), got {result!r}"
+        )
+
+    def test_all_placeholders_returns_empty_sentinel(self):
+        """Spec scenario 3: All speakers are placeholders → ("", ""), no crash.
+
+        GIVEN key_speakers=["Desconocido"], speakers=["(No especificado)"]
+        THEN  returns ("", "")
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Desconocido"],
+            "speakers": ["(No especificado)"],
+        })
+        assert result == ("", ""), (
+            f"Expected ('', ''), got {result!r}"
+        )
+
+    def test_both_arrays_empty_returns_empty_sentinel(self):
+        """Spec scenario 4: Both arrays empty → ("", "").
+
+        GIVEN key_speakers=[], speakers=[]
+        THEN  returns ("", "")
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({"key_speakers": [], "speakers": []})
+        assert result == ("", "")
+
+    def test_only_key_speakers_real_speakers_empty(self):
+        """Spec scenario 5: Only key_speakers has a real name; speakers is empty.
+
+        GIVEN key_speakers=["Laura Gómez"], speakers=[]
+        THEN  primary="Laura Gómez", secondary=""
+        """
+        from congress_videos.reap_shorts_uploader_dag import _resolve_speakers
+
+        result = _resolve_speakers({
+            "key_speakers": ["Laura Gómez"],
+            "speakers": [],
+        })
+        assert result == ("Laura Gómez", ""), (
+            f"Expected ('Laura Gómez', ''), got {result!r}"
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -482,6 +482,7 @@ def _make_chapter(
     session_date: str | None = "2025-06-10",
     key_speakers: list | None = None,
     speakers: list | None = None,
+    resolved_participant_slug: str | None = None,
 ) -> dict:
     return {
         "chapter_id": chapter_id,
@@ -493,6 +494,7 @@ def _make_chapter(
         if key_speakers is not None
         else [{"name": "Ana García"}],
         "speakers": speakers if speakers is not None else ["Ana García"],
+        "resolved_participant_slug": resolved_participant_slug,
     }
 
 
@@ -527,6 +529,42 @@ class TestPrepareThumbnailConfig:
         assert result["debate_summary"] != ""
         assert result["session"] is not None
         assert result["chapter_id"] == 42
+
+    def test_resolved_participant_slug_is_preferred_over_fuzzy(self):
+        """A chapter's resolved_participant_slug wins; no fuzzy lookup is spent."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(
+            chapter_id=7,
+            key_speakers=[{"name": "Ministra de Defensa"}],
+            resolved_participant_slug="margarita-robles-fernandez",
+        )
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+        ) as lookup:
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["slug"] == "margarita-robles-fernandez"
+        lookup.assert_not_called()
+
+    def test_falls_back_to_fuzzy_when_no_resolved_slug(self):
+        """Without a resolved slug the raw-speaker fuzzy path still applies."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter(
+            key_speakers=[{"name": "Ana García"}],
+            resolved_participant_slug=None,
+        )
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value={"slug": "garcia-ana"},
+        ) as lookup:
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert result["slug"] == "garcia-ana"
+        lookup.assert_called_once_with("Ana García")
 
     def test_lookup_error_sets_slug_to_none(self):
         """A speaker lookup failure yields slug=None without raising."""

--- a/tests/utils/test_ai_chapter_analyzer.py
+++ b/tests/utils/test_ai_chapter_analyzer.py
@@ -540,3 +540,143 @@ class TestDetectSilenceGapsAdaptive:
 
         assert len(result) == 1
         assert result[0]["gap_duration_seconds"] == pytest.approx(295, rel=1e-2)
+
+
+# --------------------------------------------------------------------------- #
+# _flatten_speakers (PR3 — Task 3.1 RED)
+# --------------------------------------------------------------------------- #
+
+class TestFlattenSpeakers:
+    """Tests for _flatten_speakers: object-form + plain-string tolerance.
+
+    Spec: https://github.com/alozur/airflow-dags/issues/56
+    """
+
+    def test_object_form_real_name_extracted(self):
+        """Object with non-null speaker_name → name extracted to list[str]."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.95}]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López"]
+
+    def test_object_form_null_speaker_name_dropped(self):
+        """Object with speaker_name=null → element dropped from output list."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.3}]
+        result = _flatten_speakers(raw)
+
+        assert result == []
+
+    def test_object_form_empty_string_speaker_name_dropped(self):
+        """Object with speaker_name='' → element dropped (empty is treated as unknown)."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [{"speaker_name": "", "speaker_role": "Ministro", "speaker_confidence": 0.5}]
+        result = _flatten_speakers(raw)
+
+        assert result == []
+
+    def test_old_flat_string_form_tolerated(self):
+        """Old flat-string list element → passed through unchanged (backward compat)."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = ["Ana López"]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López"]
+
+    def test_mixed_list_only_real_names_kept(self):
+        """Mixed list of objects and strings → only real names kept; nulls dropped."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [
+            {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.9},
+            {"speaker_name": None, "speaker_role": "Portavoz", "speaker_confidence": 0.2},
+            "Pedro García",  # old flat-string format
+            {"speaker_name": "", "speaker_role": "Presidente", "speaker_confidence": 0.1},
+        ]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López", "Pedro García"]
+
+    def test_empty_list_returns_empty(self):
+        """Empty input → empty output."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        assert _flatten_speakers([]) == []
+
+    def test_multiple_objects_all_real_names(self):
+        """Multiple object entries with real names → all extracted in order."""
+        from utils.ai_chapter_analyzer import _flatten_speakers
+
+        raw = [
+            {"speaker_name": "Ana López", "speaker_role": "Diputada", "speaker_confidence": 0.9},
+            {"speaker_name": "Pedro García", "speaker_role": "Ministro", "speaker_confidence": 0.8},
+        ]
+        result = _flatten_speakers(raw)
+
+        assert result == ["Ana López", "Pedro García"]
+
+
+# --------------------------------------------------------------------------- #
+# CHAPTER_IDENTIFICATION prompt structure (PR3 — Task 3.4 RED)
+# --------------------------------------------------------------------------- #
+
+class TestChapterIdentificationPromptStructure:
+    """Golden/structural assertions on the CHAPTER_IDENTIFICATION prompts.
+
+    Verifies that the restructured prompt instructs the LLM to return
+    speaker objects with speaker_name/speaker_role/speaker_confidence fields
+    and does NOT use 'Desconocido' as a literal fallback value.
+    """
+
+    def test_system_prompt_contains_speaker_name_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_name' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_name" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_name field"
+        )
+
+    def test_system_prompt_contains_speaker_role_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_role' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_role" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_role field"
+        )
+
+    def test_system_prompt_contains_speaker_confidence_field(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must mention 'speaker_confidence' field."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "speaker_confidence" in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must instruct LLM to return speaker_confidence field"
+        )
+
+    def test_system_prompt_does_not_use_desconocido_fallback(self):
+        """CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must NOT use 'Desconocido' as fallback value."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_SYSTEM_PROMPT
+
+        assert "Desconocido" not in CHAPTER_IDENTIFICATION_SYSTEM_PROMPT, (
+            "CHAPTER_IDENTIFICATION_SYSTEM_PROMPT must not use 'Desconocido' literal; use null instead"
+        )
+
+    def test_user_prompt_template_contains_speaker_name_field(self):
+        """CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE format section must reference speaker_name."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+
+        assert "speaker_name" in CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE, (
+            "CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must show speaker_name in response format"
+        )
+
+    def test_user_prompt_template_does_not_use_desconocido(self):
+        """CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must NOT use 'Desconocido' literal."""
+        from congress_videos.config.ai_prompts import CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE
+
+        assert "Desconocido" not in CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE, (
+            "CHAPTER_IDENTIFICATION_USER_PROMPT_TEMPLATE must not use 'Desconocido' literal"
+        )

--- a/utils/ai_chapter_analyzer.py
+++ b/utils/ai_chapter_analyzer.py
@@ -391,6 +391,36 @@ def format_seconds_to_timestamp(seconds: float) -> str:
     return f"{hours:02d}:{minutes:02d}:{secs:02d}"
 
 
+def _flatten_speakers(raw: list) -> list[str]:
+    """Flatten a speakers list that may contain object-form or plain-string elements.
+
+    Accepts the new structured form returned by the restructured
+    CHAPTER_IDENTIFICATION prompt (list of dicts with ``speaker_name``,
+    ``speaker_role``, ``speaker_confidence``) AND the legacy flat-string
+    form for backward compatibility.
+
+    Rules:
+    - dict with ``speaker_name`` key: include value only when non-null and non-empty.
+    - plain string: include as-is (backward compat with old prompt format).
+    - dict missing ``speaker_name``: skip.
+
+    Args:
+        raw: List of either dicts or strings from LLM speaker field.
+
+    Returns:
+        Flat ``list[str]`` of real speaker names; null/empty names are dropped.
+    """
+    result: list[str] = []
+    for element in raw:
+        if isinstance(element, dict):
+            name = element.get("speaker_name")
+            if name is not None and name != "":
+                result.append(name)
+        elif isinstance(element, str):
+            result.append(element)
+    return result
+
+
 def analyze_chapters_with_ai(
     srt_content: str,
     agenda_content: str,


### PR DESCRIPTION
## Summary

Promotes the accumulated work on `dev` to `main` (8 merged PRs, 25 commits).

## Included

- **Issue #55 — institutional-role speaker resolution** (PRs #75, #76, #77)
  - Curated role catalog (full cabinet + Mesa + party leaders + group spokespersons), verified against the production register and La Moncloa.
  - Point-in-time resolution API + integration into speaker normalization (runs before the placeholder filter).
  - Thumbnails driven by the resolved participant slug (migration 021).
- **Issue #56 — chapter speaker attribution** (PRs #70, #73, #72, #74)
  - Shared placeholder set + placeholder-aware resolution, `resolved_participant_slug` column + backfill (migration 020), prompt restructure.
- **Issue #25 — test-mode video title fix** (PR #69)

## Migrations

- `020_add_resolved_participant_slug.sql`
- `021_expose_resolved_participant_slug_in_uploadable_chapters.sql`

Both are idempotent and applied by the `run_migrations` DAG.

## Verification

- Full unit suite green on `dev` (1949 passed, coverage 86.66%).
- e2e smoke PASS — `airflow dags list-import-errors` empty.

Note: production Airflow git-syncs `dev`, so this promotion is a stable-release checkpoint rather than the live deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)