### PR TITLE
feat(speaker-turns): detection module + migration (PR1 of #86)

### DIFF
--- a/congress_videos/modules/speaker_turns.py
+++ b/congress_videos/modules/speaker_turns.py
@@ -1,0 +1,505 @@
+"""Speaker-turn detection for video_chapters.
+
+Pure orchestrator module. Fuses acoustic boundaries from an injectable
+``diarize_fn`` with Spanish president-announcement text from SRT blocks into a
+list of resolved ``Turn`` records.
+
+All business logic (postprocessing, text gate, extractor) is pure and unit-tested
+with stub data. The only side-effecting collaborators (DB cursor, Docker subprocess)
+are injected by the caller — this module never opens a connection or spawns a
+subprocess directly.
+
+``confirmed_block_duration_seconds`` is carried through the wire format but is
+NEVER used as an acceptance threshold.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import unicodedata
+from dataclasses import dataclass
+from typing import Callable
+
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level constants (tunable thresholds)
+# ---------------------------------------------------------------------------
+
+GAP_MERGE_SECONDS: float = 1.0
+"""Same-speaker segments closer than this are merged into one."""
+
+PINGPONG_B_MAX_SECONDS: float = 5.0
+"""Maximum B-segment duration for A→B→A ping-pong collapse."""
+
+PINGPONG_RETURN_SECONDS: float = 10.0
+"""Maximum gap between end-of-B and start-of-return-A for collapse."""
+
+# ---------------------------------------------------------------------------
+# Turn dataclass
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class Turn:
+    """A single resolved speaker turn within a video chapter.
+
+    Attributes:
+        start_seconds: Chapter-relative start time of the turn.
+        end_seconds: Chapter-relative end time of the turn.
+        speaker_label: Acoustic cluster label (e.g. "SPEAKER_01").
+        resolved_name: Canonical participant display_name, or None.
+        confidence: Attribution confidence in [0.0, 1.0].
+        source: One of "text_named", "text_confirmed", or "acoustic".
+    """
+
+    start_seconds: float
+    end_seconds: float
+    speaker_label: str
+    resolved_name: str | None
+    confidence: float
+    source: str
+
+
+# ---------------------------------------------------------------------------
+# Injectable diarisation type alias
+# ---------------------------------------------------------------------------
+
+# Wire format == benchmark postprocessed-speaker-changes.json.
+# input:  (wav_path, chapter_offset_seconds)
+# output: [{start_seconds, from_speaker, to_speaker,
+#           confirmed_block_duration_seconds}, ...]
+#         start_seconds already rebased to chapter-relative time.
+DiarizeFn = Callable[[str, float], list[dict]]
+
+# ---------------------------------------------------------------------------
+# Regex patterns (compiled once, accent-tolerant)
+# ---------------------------------------------------------------------------
+
+def _normalize_text(text: str) -> str:
+    """Strip diacritics for accent-tolerant matching."""
+    return unicodedata.normalize("NFD", text).encode("ascii", "ignore").decode("ascii")
+
+
+# Pattern capturing the name after "el señor / la señora"
+_RE_NAMED = re.compile(
+    r"tiene\s+la\s+palabra\s+(?:el\s+se[nñ]or|la\s+se[nñ]ora)\s+"
+    r"(?P<name>[\wÀ-ɏ.\- ]+?)(?:[.,]|\s*$)",
+    re.IGNORECASE,
+)
+
+# Phrase-only patterns (no name captured)
+_RE_SU_SENORIA = re.compile(
+    r"tiene\s+la\s+palabra\s+su\s+se[nñ]or[íi]a",
+    re.IGNORECASE,
+)
+
+_RE_GRACIAS_SENORIA = re.compile(
+    r"gracias,?\s+se[nñ]or[íi]a",
+    re.IGNORECASE,
+)
+
+# ---------------------------------------------------------------------------
+# President-announcement extractor (pure)
+# ---------------------------------------------------------------------------
+
+
+def extract_announcement(
+    srt_blocks: list[dict],
+    t: float,
+    window: float = 30.0,
+) -> tuple[str | None, bool]:
+    """Search SRT blocks near time *t* for a president-announcement phrase.
+
+    Scans blocks whose ``[start_secs, end_secs]`` intersects the window
+    ``[t − window, t + window]``. Within that window, prefers the block
+    closest to and before *t* (within 15–30 s) for name capture.
+
+    Patterns matched (case-insensitive, accent-tolerant):
+    - "Tiene la palabra el señor/la señora <name>" → returns (name, True)
+    - "Tiene la palabra su señoría" → returns (None, True)
+    - "Gracias, señoría" → returns (None, True)
+
+    Returns:
+        (raw_name_or_None, phrase_found)
+    """
+    lo = t - window
+    hi = t + window
+
+    # Collect blocks that overlap [lo, hi]
+    window_blocks = [
+        b for b in srt_blocks
+        if b["end_secs"] >= lo and b["start_secs"] <= hi
+    ]
+
+    if not window_blocks:
+        return (None, False)
+
+    # Sort by proximity: blocks ending closest before t are preferred for name capture.
+    # Prefer blocks that end before t (announcements precede the new speaker).
+    # Within those, prefer the one closest to t.
+    def _sort_key(b: dict) -> tuple[int, float]:
+        if b["end_secs"] <= t:
+            return (0, t - b["end_secs"])  # preceding blocks first, closest last
+        return (1, b["start_secs"] - t)    # following blocks after
+
+    sorted_blocks = sorted(window_blocks, key=_sort_key)
+
+    # First pass: look for a named announcement in the best (closest preceding) blocks
+    best_named: tuple[str | None, bool] | None = None
+    best_phrase: tuple[str | None, bool] | None = None
+
+    for block in sorted_blocks:
+        text = block["text"]
+        m = _RE_NAMED.search(text)
+        if m:
+            name = m.group("name").strip()
+            # Only accept first (closest) named match
+            if best_named is None:
+                best_named = (name, True)
+                break
+
+    if best_named is not None:
+        return best_named
+
+    for block in sorted_blocks:
+        text = block["text"]
+        if _RE_SU_SENORIA.search(text):
+            if best_phrase is None:
+                best_phrase = (None, True)
+                break
+        if _RE_GRACIAS_SENORIA.search(text):
+            if best_phrase is None:
+                best_phrase = (None, True)
+                break
+
+    if best_phrase is not None:
+        return best_phrase
+
+    return (None, False)
+
+
+# ---------------------------------------------------------------------------
+# Postprocessing pipeline (pure functions)
+# ---------------------------------------------------------------------------
+
+
+def _merge_gaps(segments: list[dict]) -> list[dict]:
+    """Merge adjacent same-label segments separated by less than GAP_MERGE_SECONDS.
+
+    Args:
+        segments: Segment dicts with keys ``start_seconds``, ``end_seconds``,
+                  ``speaker_label``.
+
+    Returns:
+        New list with qualifying gaps closed. Input dicts are never mutated.
+    """
+    if not segments:
+        return []
+
+    result: list[dict] = []
+    current = dict(segments[0])
+
+    for seg in segments[1:]:
+        gap = seg["start_seconds"] - current["end_seconds"]
+        if seg["speaker_label"] == current["speaker_label"] and gap < GAP_MERGE_SECONDS:
+            # Extend current segment end
+            current = {**current, "end_seconds": seg["end_seconds"]}
+        else:
+            result.append(current)
+            current = dict(seg)
+
+    result.append(current)
+    return result
+
+
+def _collapse_pingpong(segments: list[dict]) -> list[dict]:
+    """Collapse A→B→A ping-pong patterns where B is short.
+
+    Collapses the triple when:
+    - ``B_duration < PINGPONG_B_MAX_SECONDS``
+    - ``gap_between_B_end_and_A_return < PINGPONG_RETURN_SECONDS``
+
+    Args:
+        segments: Segment dicts ordered by ``start_seconds``.
+
+    Returns:
+        New list with collapsed patterns. Input dicts are never mutated.
+    """
+    if len(segments) < 3:
+        return list(segments)
+
+    result: list[dict] = []
+    i = 0
+
+    while i < len(segments):
+        if i + 2 < len(segments):
+            a1 = segments[i]
+            b = segments[i + 1]
+            a2 = segments[i + 2]
+
+            b_duration = b["end_seconds"] - b["start_seconds"]
+            return_gap = a2["start_seconds"] - b["end_seconds"]
+
+            if (
+                a1["speaker_label"] == a2["speaker_label"]
+                and a1["speaker_label"] != b["speaker_label"]
+                and b_duration < PINGPONG_B_MAX_SECONDS
+                and return_gap < PINGPONG_RETURN_SECONDS
+            ):
+                # Collapse: merge a1 and a2 into one, skip b
+                merged = {**a1, "end_seconds": a2["end_seconds"]}
+                result.append(merged)
+                i += 3
+                continue
+
+        result.append(segments[i])
+        i += 1
+
+    return result
+
+
+def _merge_same_name(turns: list[Turn]) -> list[Turn]:
+    """Merge adjacent turns with the same non-null resolved_name into one.
+
+    Args:
+        turns: Ordered list of Turn instances.
+
+    Returns:
+        New list with qualifying turns merged. Input is not mutated.
+    """
+    if not turns:
+        return []
+
+    result: list[Turn] = []
+    current = turns[0]
+
+    for turn in turns[1:]:
+        if (
+            current.resolved_name is not None
+            and turn.resolved_name is not None
+            and current.resolved_name == turn.resolved_name
+        ):
+            # Merge: extend end, keep higher confidence
+            new_confidence = max(current.confidence, turn.confidence)
+            current = Turn(
+                start_seconds=current.start_seconds,
+                end_seconds=turn.end_seconds,
+                speaker_label=current.speaker_label,
+                resolved_name=current.resolved_name,
+                confidence=new_confidence,
+                source=current.source,
+            )
+        else:
+            result.append(current)
+            current = turn
+
+    result.append(current)
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Text gate (assigns source/confidence, drops noise)
+# ---------------------------------------------------------------------------
+
+
+def _apply_text_gate(
+    segments: list[dict],
+    srt_blocks: list[dict],
+    name_resolver: Callable[[str], dict | None],
+) -> list[Turn]:
+    """Evaluate each segment against the SRT announcement window.
+
+    For each segment:
+    - Calls ``extract_announcement`` on the segment's ``start_seconds``.
+    - Routes source/confidence per design table.
+    - Drops same-speaker noise (both sides same label, no phrase).
+    - Builds ``Turn`` instances. Never reads ``confirmed_block_duration_seconds``
+      as a threshold.
+
+    Args:
+        segments: Postprocessed segment dicts.
+        srt_blocks: SRT blocks for the chapter window.
+        name_resolver: Callable mapping a raw name str to a participant dict or None.
+
+    Returns:
+        List of Turn instances.
+    """
+    turns: list[Turn] = []
+
+    for seg in segments:
+        t = seg["start_seconds"]
+        from_speaker = seg.get("from_speaker", "")
+        to_speaker = seg.get("to_speaker", seg.get("speaker_label", ""))
+        speaker_label = seg.get("speaker_label", to_speaker)
+
+        raw_name, phrase_found = extract_announcement(srt_blocks, t)
+
+        if phrase_found and raw_name is not None:
+            # Try to resolve name
+            resolved = name_resolver(raw_name)
+            if resolved is not None:
+                resolved_name = resolved.get("display_name") or raw_name
+                source = "text_named"
+                confidence = 0.95
+            else:
+                resolved_name = None
+                source = "text_confirmed"
+                confidence = 0.80
+        elif phrase_found:
+            # Phrase found but no name (su señoría / gracias señoría)
+            resolved_name = None
+            source = "text_confirmed"
+            confidence = 0.80
+        else:
+            # No phrase: drop if same-speaker noise (both sides same label)
+            if from_speaker and to_speaker and from_speaker == to_speaker:
+                # Same speaker on both sides, no phrase → noise, drop
+                continue
+            # Different speakers → acoustic fallback
+            resolved_name = None
+            source = "acoustic"
+            confidence = 0.50
+
+        end_seconds = seg.get("end_seconds", t)
+        turns.append(Turn(
+            start_seconds=t,
+            end_seconds=end_seconds,
+            speaker_label=speaker_label,
+            resolved_name=resolved_name,
+            confidence=confidence,
+            source=source,
+        ))
+
+    return turns
+
+
+# ---------------------------------------------------------------------------
+# Orchestrator
+# ---------------------------------------------------------------------------
+
+
+def detect_turns(
+    chapter: dict,
+    srt_blocks: list[dict],
+    diarize_fn: DiarizeFn,
+    name_resolver: Callable[[str], dict | None] | None = None,
+) -> list[Turn]:
+    """Detect speaker-turn boundaries within a video chapter.
+
+    Orchestrates: diarize_fn → gap-merge → ping-pong collapse → text gate
+    → same-name merge. Returns Turn[].
+
+    Never touches Airflow context, DB, or Docker directly. All
+    side-effecting collaborators are injected.
+
+    Args:
+        chapter: video_chapters row dict with at least chapter_id, video_id,
+                 session_date, start_time, end_time.
+        srt_blocks: SRT blocks pre-filtered to the chapter window. Pass []
+                    for acoustic-only processing (missing-SRT degradation).
+        diarize_fn: Injectable boundary producer. Must return the wire format:
+                    [{start_seconds, from_speaker, to_speaker,
+                      confirmed_block_duration_seconds}].
+        name_resolver: Callable mapping raw name → participant dict or None.
+                       Defaults to lookup_participant_fuzzy from participants_db.
+
+    Returns:
+        Ordered list of Turn instances.
+    """
+    if name_resolver is None:
+        from congress_videos.modules.participants_db import lookup_participant_fuzzy
+        name_resolver = lookup_participant_fuzzy
+
+    chapter_id = chapter.get("chapter_id")
+
+    # Build wav_path from chapter context (for diarize_fn caller)
+    # The DAG layer handles _find_source_video + extract_audio_wav;
+    # detect_turns receives the wav_path already resolved.
+    # For acoustic-only / missing-video, diarize_fn returns [] or raises.
+    try:
+        acoustic_changes: list[dict] = diarize_fn(
+            chapter.get("_wav_path", ""),
+            chapter.get("_chapter_offset_seconds", 0.0),
+        )
+    except Exception as exc:
+        log.warning("detect_turns: diarize_fn failed for chapter_id=%s: %s", chapter_id, exc)
+        return []
+
+    if not acoustic_changes:
+        return []
+
+    # Convert acoustic changes into candidate segments.
+    # Each change marks the START of a new speaker block; we need to build
+    # (start, end) pairs. End is the start of the next change (or a sentinel).
+    segments: list[dict] = []
+    for i, change in enumerate(acoustic_changes):
+        start = change["start_seconds"]
+        if i + 1 < len(acoustic_changes):
+            end = acoustic_changes[i + 1]["start_seconds"]
+        else:
+            end = start + 60.0  # sentinel: last turn extends 60s
+        seg = {
+            "start_seconds": start,
+            "end_seconds": end,
+            "speaker_label": change.get("to_speaker", f"SPEAKER_{i:02d}"),
+            "from_speaker": change.get("from_speaker", ""),
+            "to_speaker": change.get("to_speaker", f"SPEAKER_{i:02d}"),
+            "confirmed_block_duration_seconds": change.get("confirmed_block_duration_seconds", 0.0),
+        }
+        segments.append(seg)
+
+    # Postprocessing pipeline
+    segments = _merge_gaps(segments)
+    segments = _collapse_pingpong(segments)
+    turns = _apply_text_gate(segments, srt_blocks, name_resolver)
+    turns = _merge_same_name(turns)
+
+    return turns
+
+
+# ---------------------------------------------------------------------------
+# Persistence helper (idempotent upsert)
+# ---------------------------------------------------------------------------
+
+
+def _upsert_turns(cursor, chapter_id: int, turns: list[Turn]) -> None:
+    """Upsert Turn records into the speaker_turns table.
+
+    Each Turn is inserted; conflicts on (chapter_id, start_seconds) update
+    all mutable fields. Never calls cursor.commit() — the DAG controls
+    transactions.
+
+    Args:
+        cursor: DB cursor with an execute() method.
+        chapter_id: chapter_id FK value for all turns.
+        turns: Turns to persist.
+    """
+    if not turns:
+        return
+
+    sql = """
+        INSERT INTO speaker_turns
+            (chapter_id, start_seconds, end_seconds, speaker_label, resolved_name,
+             confidence, source, updated_at)
+        VALUES (%s, %s, %s, %s, %s, %s, %s, NOW())
+        ON CONFLICT (chapter_id, start_seconds) DO UPDATE SET
+            end_seconds   = EXCLUDED.end_seconds,
+            speaker_label = EXCLUDED.speaker_label,
+            resolved_name = EXCLUDED.resolved_name,
+            confidence    = EXCLUDED.confidence,
+            source        = EXCLUDED.source,
+            updated_at    = NOW()
+    """
+
+    for turn in turns:
+        cursor.execute(sql, (
+            chapter_id,
+            turn.start_seconds,
+            turn.end_seconds,
+            turn.speaker_label,
+            turn.resolved_name,
+            turn.confidence,
+            turn.source,
+        ))

--- a/congress_videos/sql/migrations/022_create_speaker_turns.sql
+++ b/congress_videos/sql/migrations/022_create_speaker_turns.sql
@@ -1,0 +1,24 @@
+-- Migration 022: Create speaker_turns table
+--
+-- Stores speaker-turn boundaries detected within video_chapters.
+-- Each row represents one resolved speaker turn with source signal (acoustic,
+-- text_confirmed, text_named), confidence, and optional resolved participant name.
+--
+-- Upsert on (chapter_id, start_seconds) makes re-runs idempotent.
+
+CREATE TABLE IF NOT EXISTS speaker_turns (
+    turn_id       SERIAL PRIMARY KEY,
+    chapter_id    INTEGER NOT NULL REFERENCES video_chapters(chapter_id) ON DELETE CASCADE,
+    start_seconds NUMERIC NOT NULL,
+    end_seconds   NUMERIC NOT NULL,
+    speaker_label TEXT    NOT NULL,
+    resolved_name TEXT,
+    confidence    NUMERIC NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+    source        TEXT    NOT NULL CHECK (source IN ('acoustic','text_confirmed','text_named')),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chapter_id, start_seconds)
+);
+
+CREATE INDEX IF NOT EXISTS idx_speaker_turns_chapter ON speaker_turns(chapter_id);
+CREATE INDEX IF NOT EXISTS idx_speaker_turns_name    ON speaker_turns(resolved_name);

--- a/openspec/changes/speaker-turns-detection/design.md
+++ b/openspec/changes/speaker-turns-detection/design.md
@@ -1,0 +1,208 @@
+# Design: Speaker-Turn Detection Inside video_chapters
+
+**Change:** `speaker-turns-detection`
+**Source:** GitHub issue #86 (epic #16, split from #17)
+**Status:** Design — resolves the open decisions the spec deferred
+
+## Decision
+
+Deliver a pure, Airflow-free module `congress_videos/modules/speaker_turns.py` fronted by a thin
+on-demand DAG `speaker_turns_dag.py`. The module fuses two signals — acoustic boundaries from an
+injectable `diarize_fn` (default: isolated Docker pyannote subprocess) and Spanish president-announcement
+text from SRT blocks — into a list of resolved `Turn` records, then upserts them idempotently into a new
+`speaker_turns` table. Everything except the Docker call and the DB upsert is a pure function, unit-tested
+with a stubbed `diarize_fn` and SRT-block fixtures. The pipeline is additive: no existing DAG, table, or
+module public interface changes.
+
+## Module Shape (`modules/speaker_turns.py`)
+
+```python
+@dataclass(frozen=True)
+class Turn:
+    start_seconds: float
+    end_seconds: float
+    speaker_label: str          # acoustic cluster label, e.g. "SPEAKER_01"
+    resolved_name: str | None   # canonical participant display_name, nullable
+    confidence: float           # 0.0–1.0
+    source: str                 # "text_named" | "text_confirmed" | "acoustic"
+
+# Injected boundary producer. Wire format == benchmark postprocessed-speaker-changes.json.
+DiarizeFn = Callable[[str, float], list[dict]]
+#   input:  (wav_path, chapter_offset_seconds)
+#   output: [{start_seconds, from_speaker, to_speaker, confirmed_block_duration_seconds}, ...]
+#           start_seconds already rebased to chapter-relative time (offset applied by caller of diarize).
+
+def detect_turns(
+    chapter: dict,
+    srt_blocks: list[dict],          # [{start_secs, end_secs, text}] pre-filtered to the chapter window
+    diarize_fn: DiarizeFn,
+    name_resolver: Callable[[str], dict | None] = lookup_participant_fuzzy,
+) -> list[Turn]: ...
+```
+
+`detect_turns` is the orchestrator: it calls `diarize_fn`, converts changes into candidate segments,
+runs the four-step postprocessing pipeline, and returns `Turn[]`. It touches no Airflow context, no DB,
+and no Docker — all side-effecting collaborators are injected. `confirmed_block_duration_seconds` is
+carried through but NEVER used as an acceptance threshold (Fase 0 dead end).
+
+## President-Announcement Extractor (pure)
+
+`extract_announcement(srt_blocks, t, window=30.0) -> tuple[str | None, bool]` scans blocks whose
+`[start_secs, end_secs]` intersect `[t − window, t + window]` and returns `(raw_name_or_None, phrase_found)`.
+
+Patterns (case-insensitive, accent-tolerant, compiled once):
+
+| Pattern | Captures |
+|---|---|
+| `tiene la palabra (?:el señor\|la señora)\s+(?P<name>[\wÁÉÍÓÚÑáéíóúñ.\- ]+?)(?:[.,]\|$)` | `name` → fuzzy lookup |
+| `tiene la palabra su señoría` | phrase-only (confirm, no name) |
+| `gracias,?\s+señoría` | phrase-only (handover marker, confirm) |
+
+Name pull: from the block(s) in the **~15–30 s window before** the change `t` (announcements precede the
+new speaker), preferring the closest preceding block. The captured name string is passed to `name_resolver`
+(default `lookup_participant_fuzzy`, threshold 0.90). When no phrase matches in the window, the extractor
+returns `(None, False)` and the caller falls back to `name_resolver(speaker_label)`-style fuzzy on any
+available context (nullable result). Pure and testable on SRT-block fixtures.
+
+## Source Routing and Confidence
+
+| Condition | `source` | `confidence` |
+|---|---|---|
+| phrase found AND name resolves to a participant | `text_named` | `0.95` |
+| phrase found BUT name not resolvable | `text_confirmed` | `0.80` |
+| no phrase in window (survives postprocessing) | `acoustic` | `0.50` |
+
+`text_named` / `text_confirmed` require `phrase_found=True`. An `acoustic` change is kept only if it is NOT
+rejected by ping-pong/same-speaker collapse; its `resolved_name` may be `None`. This makes the text layer
+the confirm/deny gate the audit prescribed — acoustic-only detections are deliberately low-confidence.
+
+## Postprocessing Pipeline (ordered, pure)
+
+1. **Gap merge** — adjacent same `speaker_label` with gap `< GAP_MERGE_SECONDS (1.0)` → one segment.
+2. **Ping-pong collapse** — `A → B → A` collapsed into one `A` when `B_duration < PINGPONG_B_MAX_SECONDS (5.0)`
+   AND `A` resumes within `PINGPONG_RETURN_SECONDS (10.0)`. Targets the audit's **26.9 % redundant duplicates**.
+3. **Text gate** — each surviving change evaluated via `extract_announcement`; assigns `source`/`confidence`
+   and drops changes that resolve to the same speaker on both sides with no phrase (same-speaker pitch shift,
+   the audit's noise class).
+4. **Same-name merge** — adjacent turns with identical non-null `resolved_name` → one turn.
+
+All thresholds are module constants (tunable), grounded in Fase 0 (`same_speaker_gap_seconds: 1.0` in the
+benchmark rules; B/return windows chosen to catch the 3–8 s ping-pong pairs observed in the audit).
+
+## Diarization Docker Subprocess
+
+Default `diarize_fn` wraps a subprocess call; tests inject a stub and never reach it:
+
+```
+docker run --rm --network none --memory 4g --cpuset-cpus 0-1 \
+  -v {wav_dir}:/in:ro -v {out_dir}:/out \
+  pyannote/speaker-diarization-community-1 \
+  --input /in/{wav_name} --output /out/changes.json
+```
+
+The module builds the arg list, runs it via `subprocess.run` with an adaptive timeout (audio is 4.6×
+realtime → `timeout ≈ base + factor·duration`), then reads and JSON-parses `/out/changes.json` into the
+wire format above. The worker needs `docker` access (NAS ops: `/usr/local/bin/docker`, no sudo). Source WAV
+mounted read-only; only the output dir is writable. pyannote/torch never enter the Airflow image.
+
+## Migration
+
+Highest on disk NOW is `019_create_video_thumbnails.sql`; `dev` may carry `020`. Next number is **`021`**
+(tasks phase MUST re-verify highest+1 against `dev` before creating the file).
+
+```sql
+-- 021_create_speaker_turns.sql
+CREATE TABLE IF NOT EXISTS speaker_turns (
+    turn_id       SERIAL PRIMARY KEY,
+    chapter_id    INTEGER NOT NULL REFERENCES video_chapters(chapter_id) ON DELETE CASCADE,
+    start_seconds NUMERIC NOT NULL,
+    end_seconds   NUMERIC NOT NULL,
+    speaker_label TEXT    NOT NULL,
+    resolved_name TEXT,
+    confidence    NUMERIC NOT NULL CHECK (confidence >= 0 AND confidence <= 1),
+    source        TEXT    NOT NULL CHECK (source IN ('acoustic','text_confirmed','text_named')),
+    created_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    UNIQUE (chapter_id, start_seconds)
+);
+CREATE INDEX IF NOT EXISTS idx_speaker_turns_chapter ON speaker_turns(chapter_id);
+CREATE INDEX IF NOT EXISTS idx_speaker_turns_name    ON speaker_turns(resolved_name);
+```
+
+Upsert: `INSERT ... ON CONFLICT (chapter_id, start_seconds) DO UPDATE SET ..., updated_at = NOW()`.
+
+## DAG Shape (`speaker_turns_dag.py`)
+
+`schedule=None`, conf-driven, mirrors `generic_thumbnail_generator_dag`. Task graph:
+
+```
+select_chapters (LIMIT from conf, uploadable_chapters view)
+    → process_chapters  (per chapter, graceful skip)
+        locate audio (_find_source_video → extract_audio_wav, bounded -ss/-t)
+          → detect_turns(chapter, window srt_blocks, diarize_fn, fuzzy)
+            → upsert speaker_turns (ON CONFLICT DO UPDATE)
+```
+
+Conf keys: `limit` (default e.g. 10), optional `chapter_ids`. `xcom_task` carries the selected chapter
+list. Per-chapter failures are caught: missing source video → log + skip (DAG succeeds); missing SRT →
+acoustic-only run. Never self-triggers; never chained into `youtube_upload_dag`.
+
+## Data Flow
+
+```
+video_chapters row ──▶ extract_audio_wav (transient WAV slice, chapter window)
+                          │
+                          ▼
+                     diarize_fn (Docker pyannote │ stub) ──▶ acoustic changes[]
+                          │
+   find_srt_for_chapter ──┤ (window blocks [t-30s, t+30s])
+   _parse_srt_blocks      ▼
+                     gap-merge → ping-pong collapse → text-gate/name → same-name merge
+                          │
+                          ▼
+                     Turn[] ──▶ upsert speaker_turns (idempotent)
+```
+
+## Reuse (unchanged)
+
+`extract_audio_wav`, `_find_source_video` (vad_helpers); `find_srt_for_chapter`, `_parse_srt_blocks`
+(srt_helpers, window-filtered exactly as `_prepare_thumbnail_config`); `lookup_participant_fuzzy`
+(participants_db); `xcom_task` (airflow_helpers). No signature or behavior change.
+
+## Testing Strategy (strict TDD)
+
+| Layer | What | Approach |
+|---|---|---|
+| Unit — postprocess | gap merge (<1.0 s) vs non-merge (≥1.0 s); ping-pong `A(60)→B(4)→A(90)` collapse; same-name merge across two labels | stub `diarize_fn` returning fixed change dicts; assert `Turn[]` |
+| Unit — text gate | phrase confirms+names (`text_named`); phrase-only (`text_confirmed`); no phrase same-speaker noise rejected; fuzzy fallback (`acoustic`) | SRT-block fixtures + fake `name_resolver` |
+| Unit — extractor | each regex pattern; name pulled from 15–30 s pre-change window; no-phrase → `(None, False)` | pure fixtures |
+| Unit — degradation | missing-video skip returns `[]`; missing-SRT → acoustic-only lower confidence | inject empty srt_blocks / None video path |
+| Unit — persistence | upsert idempotency: second run same `chapter_id` → row count unchanged, values updated | fake DB cursor asserting `ON CONFLICT` SQL |
+| Smoke | `speaker_turns_dag` imports with no errors | DAG-load test |
+
+No real Docker, pyannote, OpenAI, network, or live DB in tests — `diarize_fn`, `name_resolver`, and the DB
+cursor are all injected/faked. RED tests are written before each production slice.
+
+## Threat Matrix
+
+The default `diarize_fn` builds a `docker run` subprocess argument list.
+
+| Row | Status | Safe behavior / RED test |
+|---|---|---|
+| Shell/subprocess injection | Applicable | Arg-list `subprocess.run` (no `shell=True`); paths are module-built temp paths, not user text. Test asserts arg vector shape, `--network none`, `--memory 4g`. |
+| Untrusted input to command | Applicable | WAV path derived from `_find_source_video` + generated temp name; chapter conf ints only. Test: non-int `chapter_ids` rejected before shell. |
+| Resource exhaustion | Applicable | `--memory 4g`, `--cpuset-cpus`, adaptive subprocess timeout. Test asserts caps present in arg vector. |
+| Network egress | Applicable | `--network none`. Test asserts flag present. |
+| VCS/PR automation, executable-file classification, routing | N/A | No such boundary in this change. |
+
+## Migration / Rollout
+
+Additive. Deploy `021_create_speaker_turns.sql`, the module, the DAG, and tests together. Rollback: drop
+`speaker_turns_dag.py`, `modules/speaker_turns.py`, and `DROP TABLE speaker_turns`. No existing DAG or table
+is touched.
+
+## Open Questions
+
+- [ ] Ping-pong `B_MAX`/`RETURN` windows (5.0 s / 10.0 s) are first-cut defaults; confirm against a second
+      labelled chapter before locking (tunable constants, not blocking).
+- [ ] Exact `--cpuset-cpus` range depends on the target worker's core count (env-configurable).

--- a/openspec/changes/speaker-turns-detection/exploration.md
+++ b/openspec/changes/speaker-turns-detection/exploration.md
@@ -1,0 +1,69 @@
+# Exploration: Speaker-turn detection inside video_chapters
+
+**Change:** `speaker-turns-detection`
+**Source:** GitHub issue #86 (part of epic #16, split from #17)
+
+## Goal
+
+Detect speaker-turn boundaries **within** the existing thematic `video_chapters`
+and persist named sub-turns, **without cutting the video**. Materialization
+(1 speaker = 1 video) is issue #88; silence/applause trimming is #87.
+
+## Established context (verified against code)
+
+1. **Thematic chapters already exist.** `map_reduce_identify_chapters`
+   (`congress_videos/modules/youtube/map_reduce_chapters.py`) produces 15–45 min
+   chapters consumed in `youtube_upload_dag.py`. They carry `start_time`/
+   `end_time`/`title` + a `speakers[]` list (issue #56). They are the PRE-CUT
+   that bounds diarization to 30–60 min windows.
+2. **Decided design.** pyannote diarization = the turn BOUNDARY signal; SRT
+   president-announcement text ("Tiene la palabra el señor/la señora X") = the
+   NAME **and** the confirm/deny gate per acoustic change. Diarization runs
+   bounded per chapter, never on the full session.
+3. **Fase 0 (ear audit) DONE.** Report at
+   `benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/AUDIT_REPORT.md`.
+   32 detections → 6 noise, 7 redundant duplicates, 19 unique real changes;
+   precision 81% crude / 59% useful. **Critical finding:**
+   `confirmed_block_duration_seconds` is NOT a usable threshold (noise & real
+   scores overlap 3–8.4 s vs 1.8–108.7 s). Noise = same-speaker pitch shifts.
+
+## Current-state findings (file:line)
+
+- **Chapter reads:** `video_chapters` table (`congress_videos/sql/youtube_chapters_schema.sql:48`);
+  the `uploadable_chapters` view (`010_add_timeline_column.sql:28`) exposes
+  `start_time`, `end_time`, `video_id`, `session_date`.
+- **SRT access (reuse, no change):** `find_srt_for_chapter(video_id, chapter_id, session_date)`
+  + `_parse_srt_blocks(path)` → `[{start_secs, end_secs, text}]`
+  (`congress_videos/srt_helpers.py:21`). Filter to the chapter window exactly as
+  `_prepare_thumbnail_config` does (`youtube_upload_dag.py:186`).
+- **Audio slice (reuse, no change):** `vad_helpers._find_source_video(target_date, video_id)`
+  + `extract_audio_wav(video_path, wav_path, start_secs=…, duration_secs=…)`
+  (`vad_helpers.py:174`) already supports bounded `-ss`/`-t` extraction.
+  NOTE: a second single-arg `_find_source_video` exists in
+  `reap_clip_preparer_dag.py` — the `vad_helpers` one is the correct reuse.
+- **Name resolution (reuse):** `lookup_participant_fuzzy(name)` + `normalize_member_name`
+  (`participants_db.py:181`); idiomatic flow in `speaker_normalization.py:132`
+  (fuzzy → AI verify → upsert).
+- **No president-announcement phrase extractor exists** — this is new NLP work,
+  the highest-risk new component.
+- **Diarization is not importable** — the benchmark runs pyannote as an isolated
+  Docker container; a production module must call it fresh (Docker subprocess).
+- **DAG patterns:** `generic_thumbnail_generator_dag` (`schedule=None`, triggered
+  by conf) is the precedent thin worker; `xcom_task` (`utils/airflow_helpers.py:6`).
+- **Idempotency:** `ON CONFLICT … DO UPDATE SET … updated_at = NOW()` used across
+  `speaker_normalization_cache`, `video_thumbnails`, `congress_participants`.
+- **Migrations:** highest on `feat/issue-59…` branch is `019_create_video_thumbnails.sql`;
+  `dev` may carry `020`. The spec phase MUST re-verify highest+1.
+
+## Approaches
+
+| Approach | Pros | Cons |
+|----------|------|------|
+| **A — standalone on-demand DAG** | no coupling to upload; chapters processed independently; matches thumbnail-DAG pattern; restartable per chapter; injectable diarize_fn | needs a trigger |
+| B — tasks chained after `youtube_upload_dag` | turns fresh at upload | blocks upload on 4.6× realtime diarization; upload DAG already has a stale-tolerance timeout; couples slow audio to UI-critical flow |
+
+**Recommendation: Approach A** + Docker-subprocess diarization + pure-module-first.
+
+## Next
+
+sdd-propose (done), then sdd-spec.

--- a/openspec/changes/speaker-turns-detection/proposal.md
+++ b/openspec/changes/speaker-turns-detection/proposal.md
@@ -1,0 +1,107 @@
+# Proposal: Speaker-turn detection inside video_chapters
+
+**Change:** `speaker-turns-detection`
+**Source:** GitHub issue #86 (part of epic #16, split from #17)
+**Status:** Proposed — Fase 0 (ear audit) complete; Fases 1–3 scoped here
+
+## Intent
+
+Publishable `video_chapters` bundle multiple speaker turns into one 15–45 min
+segment. Downstream products (best-moment selection #17, per-speaker cuts #88)
+need the turn boundaries **within** a chapter and **who** speaks each turn,
+without cutting video. Fase 0 proved acoustic diarization alone is noisy;
+fusing pyannote boundaries with SRT president-announcement text confirms and
+names each turn. Deliver a standalone, on-demand pipeline that persists resolved
+sub-turns for reuse.
+
+## Scope
+
+### In scope
+
+- New standalone DAG `speaker_turns_dag` (`schedule=None`, triggered via conf
+  like `generic_thumbnail_generator_dag`), processing a LIMIT of
+  publication-intended chapters and re-queuing.
+- Pure module `congress_videos/modules/speaker_turns.py`: injectable `diarize_fn`
+  + president-announcement extractor + name resolution; the DAG is thin
+  orchestration.
+- Diarization backend = **Docker subprocess** (`docker run` isolated pyannote
+  container, `--network none`, 4 GiB cap); torch/pyannote never enter the
+  Airflow image.
+- Signal fusion: pyannote = turn BOUNDARY; SRT president-announcement phrase =
+  NAME + confirm/deny gate per acoustic change.
+- Postprocessing: (1) merge adjacent same-speaker (gap < 1.0 s); (2) collapse
+  A→B→A ping-pong in a short window (kills ~27 % duplicate redundancy);
+  (3) TEXT GATE each acoustic change vs SRT blocks in `[t-30s, t+30s]`;
+  (4) merge adjacent turns resolving to the same name.
+- New table `speaker_turns(turn_id, chapter_id FK, start_seconds, end_seconds,
+  speaker_label, resolved_name, confidence, source)`,
+  `source ∈ {acoustic, text_confirmed, text_named}`. Migration = next sequential
+  number (spec MUST re-verify highest+1; ≥ 020). Idempotent
+  `UNIQUE(chapter_id, start_seconds)` + `ON CONFLICT DO UPDATE`.
+- Reuse (no change): `extract_audio_wav` + `_find_source_video` (vad_helpers);
+  `find_srt_for_chapter` + `_parse_srt_blocks` (srt_helpers); `lookup_participant_fuzzy`
+  (participants_db).
+- Graceful degradation: missing source video → log + skip chapter, never fail
+  the DAG; missing SRT → acoustic-only, lower confidence, `source=acoustic`.
+
+### Out of scope
+
+- Video cutting / materialization (#88); silence/applause trimming (#87);
+  recall measurement (Fase 0 is precision-only); the generic best-moment engine
+  (#17).
+- Chaining into `youtube_upload_dag` (4.6× realtime diarization must not block
+  upload).
+- Using `confirmed_block_duration_seconds` as a threshold — Fase 0 proved
+  noise/real scores overlap; dead end, not implemented.
+
+## Approach
+
+Approach A (standalone on-demand DAG) + Docker-subprocess diarization +
+pure-module-first. Per chapter: locate audio (`extract_audio_wav` over
+`vad_helpers._find_source_video`), run `diarize_fn` (Docker subprocess, stubbed
+in tests) → acoustic boundaries; parse SRT window blocks; for each acoustic
+change gate/name against president-announcement phrases (new extractor; fallback
+to `lookup_participant_fuzzy` when phrase absent); run
+merge / ping-pong / text-gate / name-merge postprocessing; upsert into
+`speaker_turns`.
+
+## Affected areas
+
+| Area | Impact |
+|------|--------|
+| `congress_videos/speaker_turns_dag.py` | New — thin on-demand DAG (LIMIT + requeue) |
+| `congress_videos/modules/speaker_turns.py` | New — pure module (injectable diarize + extractor + postprocessing) |
+| `congress_videos/sql/migrations/0NN_create_speaker_turns.sql` | New — table + `UNIQUE(chapter_id,start_seconds)`; verify number (≥ 020) |
+| `congress_videos/modules/vad_helpers.py` | Reuse (no change) |
+| `congress_videos/srt_helpers.py` | Reuse (no change) |
+| `congress_videos/modules/participants_db.py` | Reuse (no change) |
+| `tests/congress_videos/...` | New — module unit tests (stub `diarize_fn`) + DAG-load test |
+
+## Risks
+
+| Risk | Likelihood | Mitigation |
+|------|------------|------------|
+| President-announcement extractor misses/mis-names turns | High | Fallback to fuzzy match; store `source`+`confidence`; precision-first |
+| Docker pyannote image unavailable on worker | Med | Injectable `diarize_fn`; skip+log chapter, never fail DAG |
+| Migration number collides with dev `020` | Med | Spec re-verifies highest migration, picks next |
+| Diarization cost (4.6× realtime) | Med | On-demand only, LIMIT + requeue, publication-intended chapters only |
+
+## Rollback
+
+Purely additive: drop `speaker_turns_dag.py`, `modules/speaker_turns.py`, and
+DROP the `speaker_turns` table. No existing DAG or table is touched.
+
+## Resolved assumptions (defaults accepted by owner)
+
+1. Persist EVERY confirmed acoustic change (`resolved_name` nullable), not only
+   named turns.
+2. Confidence = numeric 0–1.
+3. One LIMIT batch per DAG run; external re-trigger (no self-trigger).
+
+## Success criteria
+
+- [ ] `speaker_turns_dag` loads with no import errors and runs on a triggered chapter.
+- [ ] Named sub-turns persisted idempotently; re-run updates, never duplicates.
+- [ ] Missing source video → chapter skipped, DAG succeeds.
+- [ ] Missing SRT → acoustic-only rows with `source=acoustic`, lower confidence.
+- [ ] Module unit tests pass with stubbed `diarize_fn` (no Docker in CI).

--- a/openspec/changes/speaker-turns-detection/specs/speaker-turn-detection/spec.md
+++ b/openspec/changes/speaker-turns-detection/specs/speaker-turn-detection/spec.md
@@ -1,0 +1,324 @@
+# Speaker-Turn Detection Specification
+
+## Purpose
+
+Detect and persist named speaker-turn boundaries **within** existing publishable
+`video_chapters` (15–45 min thematic segments) so that downstream products
+(best-moment selection #17, per-speaker materialization #88) can consume
+resolved sub-turns without video cutting or re-encoding. Signal fusion — acoustic
+boundaries from pyannote diarization gated and named by SRT president-announcement
+phrases — provides precision-first attribution. The pipeline is fully additive:
+no existing DAG, table, or module is mutated.
+
+---
+
+## Requirements
+
+### Requirement: Chapter-Bounded Turn Detection Without Video Mutation
+
+The system MUST read publication-intended `video_chapters` rows (carrying
+`chapter_id`, `video_id`, `session_date`, `start_time`, `end_time`) and detect
+speaker-turn boundaries within each chapter's time window. The system MUST NOT
+cut, re-encode, move, rename, or otherwise mutate any video or audio file as
+part of turn detection. Audio extraction for diarization MUST be transient and
+scoped to the chapter window only.
+
+#### Scenario: Turn detection reads chapter bounds and leaves files intact
+
+- GIVEN a publishable `video_chapters` row with a known `video_id`, `start_time`,
+  and `end_time`
+- WHEN the turn-detection pipeline runs for that chapter
+- THEN speaker-turn rows are persisted in `speaker_turns` for the chapter
+- AND no video or audio file is created, modified, moved, or deleted in the
+  source-video storage location
+
+#### Scenario: Diarization is bounded to the chapter window
+
+- GIVEN a chapter that covers minutes 30–75 of a three-hour session video
+- WHEN diarization runs for that chapter
+- THEN the acoustic analysis input covers only the 45-minute chapter window
+- AND the full-session audio is never passed to the diarizer
+
+---
+
+### Requirement: Injectable Diarization Backend
+
+Turn boundaries MUST be produced by a pyannote diarization call that is supplied
+via an injectable `diarize_fn` parameter. The default production implementation
+MUST invoke pyannote as an isolated Docker subprocess (`--network none`, 4 GiB
+memory cap). Tests MUST be able to substitute a stub `diarize_fn` that returns
+pre-built boundary lists without Docker, network access, or GPU. The production
+diarizer MUST NOT be imported into the Airflow image.
+
+#### Scenario: Test stub replaces Docker diarizer
+
+- GIVEN a `diarize_fn` stub is injected that returns a fixed list of
+  `(start_secs, end_secs, speaker_label)` tuples
+- WHEN the speaker-turn module processes a chapter
+- THEN the pipeline completes without launching a Docker subprocess
+- AND the resulting `speaker_turns` rows reflect the stub boundaries
+
+#### Scenario: Production diarizer runs isolated
+
+- GIVEN no `diarize_fn` override is provided
+- WHEN the speaker-turn module processes a chapter in production
+- THEN a Docker subprocess is launched for the pyannote container with
+  `--network none` and a 4 GiB memory cap
+- AND pyannote is not imported into the Airflow worker process
+
+---
+
+### Requirement: Text Gate and Name Resolution via President-Announcement Phrases
+
+For each acoustic boundary detected at time `t`, the system MUST search SRT
+blocks in the window `[t − 30 s, t + 30 s]` for a president-announcement phrase
+of the form "Tiene la palabra el señor / la señora X". This text signal MUST
+serve both as a confirmation gate (accepts or rejects the acoustic change) and
+as the primary name source. When no announcement phrase is found, the system
+MUST fall back to `lookup_participant_fuzzy` for name resolution and MUST record
+the turn with a lower confidence value. The system MUST NOT use
+`confirmed_block_duration_seconds` as an acceptance threshold.
+
+#### Scenario: Announcement phrase confirms and names an acoustic change
+
+- GIVEN an acoustic boundary at time `t`
+- AND an SRT block in `[t − 30 s, t + 30 s]` contains the phrase
+  "Tiene la palabra la señora García"
+- WHEN signal fusion runs
+- THEN the turn is persisted with `source = text_named`, `resolved_name` set to
+  the fuzzy-resolved participant name for "García", and a higher confidence value
+
+#### Scenario: Announcement phrase is absent — fuzzy fallback fires
+
+- GIVEN an acoustic boundary at time `t`
+- AND no SRT block in `[t − 30 s, t + 30 s]` contains an announcement phrase
+- WHEN signal fusion runs
+- THEN `lookup_participant_fuzzy` is invoked with the acoustic speaker label
+- AND the turn is persisted with `source = acoustic`, `resolved_name` set to
+  the fuzzy result (nullable), and a lower confidence value
+
+#### Scenario: Announcement phrase rejects a noisy acoustic change
+
+- GIVEN an acoustic boundary detected at time `t`
+- AND the SRT window contains no announcement phrase
+- AND postprocessing determines the boundary is a same-speaker pitch shift
+  (the acoustic segment on both sides resolves to the same speaker label)
+- WHEN signal fusion and postprocessing run
+- THEN the acoustic change is not persisted as a distinct turn
+
+#### Scenario: confirmed_block_duration_seconds is never consulted
+
+- GIVEN any acoustic boundary regardless of its duration in seconds
+- WHEN signal fusion evaluates the boundary
+- THEN the acceptance or rejection decision is made without consulting
+  `confirmed_block_duration_seconds`
+
+---
+
+### Requirement: Postprocessing Pipeline
+
+The system MUST apply four postprocessing steps in order after raw acoustic
+boundaries are produced and before persistence:
+
+1. **Gap merge.** Adjacent segments attributed to the same speaker label with a
+   gap of less than 1.0 s MUST be merged into one turn.
+2. **Ping-pong collapse.** An A → B → A pattern where the total B duration falls
+   within a short window (to be specified in design, derived from Fase 0 data)
+   MUST be collapsed into a single A turn.
+3. **Text gate.** Each surviving acoustic change MUST be evaluated against the
+   SRT announcement window as specified in the Text Gate requirement above.
+4. **Same-name merge.** After name resolution, adjacent turns whose `resolved_name`
+   values are identical MUST be merged into one turn.
+
+#### Scenario: Sub-second gap between same-speaker segments is merged
+
+- GIVEN two consecutive acoustic segments attributed to speaker label "SPEAKER_01"
+  separated by a 0.7 s gap
+- WHEN the gap-merge step runs
+- THEN the two segments are merged into one turn
+- AND no turn boundary is recorded at the 0.7 s gap
+
+#### Scenario: Ping-pong A→B→A is collapsed
+
+- GIVEN three consecutive turns: A (60 s), B (4 s), A (90 s)
+  where B's duration falls within the ping-pong collapse window
+- WHEN the ping-pong collapse step runs
+- THEN the three segments are collapsed into one A turn
+- AND the B segment is not persisted
+
+#### Scenario: Adjacent turns with the same resolved name are merged
+
+- GIVEN two consecutive acoustic segments attributed to different speaker labels
+  ("SPEAKER_00" and "SPEAKER_02") that both resolve to the same
+  `resolved_name` "María Luisa García"
+- WHEN the same-name merge step runs
+- THEN the two segments are merged into one turn with
+  `resolved_name = "María Luisa García"`
+
+---
+
+### Requirement: Idempotent Persistence in speaker_turns Table
+
+The system MUST store each detected sub-turn in a new `speaker_turns` table
+with columns `turn_id` (PK), `chapter_id` (FK → `video_chapters`),
+`start_seconds` (numeric), `end_seconds` (numeric), `speaker_label` (text),
+`resolved_name` (text, nullable), `confidence` (numeric 0–1), and
+`source` (enum: `acoustic`, `text_confirmed`, `text_named`). The table MUST
+enforce `UNIQUE(chapter_id, start_seconds)`. Every upsert MUST use
+`ON CONFLICT (chapter_id, start_seconds) DO UPDATE` so that re-running the
+pipeline updates existing rows and never creates duplicates.
+
+The migration file MUST be the next sequential number above the current highest
+migration on the integration branch at the time of tasks execution (highest + 1,
+**≥ 021**). The exact number MUST be re-verified during the tasks phase against
+`congress_videos/sql/migrations/` on the `dev` branch before the file is created.
+
+#### Scenario: Idempotent re-run updates without duplicating rows
+
+- GIVEN a chapter has already been processed and its turns are in `speaker_turns`
+- WHEN the pipeline runs again for the same chapter
+- THEN the row count for that `chapter_id` is unchanged
+- AND `start_seconds`, `end_seconds`, `speaker_label`, `resolved_name`,
+  `confidence`, and `source` values are updated to reflect the latest run
+
+#### Scenario: source values are constrained to the declared enum
+
+- GIVEN a turn row is about to be persisted
+- WHEN `source` is set
+- THEN its value is exactly one of: `acoustic`, `text_confirmed`, `text_named`
+- AND no other value is accepted by the database constraint
+
+---
+
+### Requirement: Graceful Degradation
+
+The system MUST handle missing inputs without failing the DAG run.
+
+**Missing source video.** When `_find_source_video` returns no result for a
+chapter, the system MUST log a warning, skip that chapter, and continue
+processing remaining chapters. The DAG run MUST succeed.
+
+**Missing SRT.** When `find_srt_for_chapter` returns no SRT path for a chapter,
+the system MUST run acoustic-only processing. Persisted turns MUST have
+`source = acoustic` and a lower confidence value than text-confirmed turns.
+The DAG run MUST succeed.
+
+#### Scenario: Missing source video — chapter skipped, DAG succeeds
+
+- GIVEN a chapter references a `video_id` for which no source video file exists
+  on the worker's storage
+- WHEN the pipeline processes that chapter
+- THEN a warning is logged identifying the chapter
+- AND no `speaker_turns` rows are written for that chapter
+- AND the DAG task succeeds and continues to the next chapter
+
+#### Scenario: Missing SRT — acoustic-only rows with lower confidence
+
+- GIVEN a chapter has a locatable source video
+- AND `find_srt_for_chapter` returns no SRT path for that chapter
+- WHEN the pipeline processes that chapter
+- THEN speaker-turn rows are persisted with `source = acoustic`
+- AND each row's `confidence` value is below the threshold used for
+  text-confirmed turns
+- AND `resolved_name` is nullable (may be null when fuzzy lookup also fails)
+- AND the DAG task succeeds
+
+---
+
+### Requirement: On-Demand Standalone DAG
+
+A DAG named `speaker_turns_dag` with `schedule=None` MUST be created as an
+independent, triggerable pipeline following the `generic_thumbnail_generator_dag`
+pattern. Each DAG run MUST process at most a configured LIMIT of
+publication-intended chapters (from the `uploadable_chapters` view or equivalent
+query) and MUST NOT self-trigger subsequent batches. Re-queuing is handled
+externally by the operator re-triggering the DAG. The DAG MUST NOT be chained
+into `youtube_upload_dag` or any other existing DAG.
+
+#### Scenario: DAG loads without import errors
+
+- GIVEN the `speaker_turns_dag.py` file is present in the DAGs folder
+- WHEN Airflow loads all DAGs
+- THEN `speaker_turns_dag` is registered with no import errors
+- AND no existing DAG is modified
+
+#### Scenario: DAG run processes at most LIMIT chapters
+
+- GIVEN the `uploadable_chapters` view returns 50 eligible chapters
+  and the configured LIMIT is 10
+- WHEN the DAG is triggered without additional conf overrides
+- THEN exactly 10 chapters are processed in the run
+- AND the remaining 40 chapters are not processed in that run
+
+#### Scenario: DAG is not chained into youtube_upload_dag
+
+- GIVEN `youtube_upload_dag.py` in its post-change state
+- WHEN the DAG file is inspected
+- THEN it contains no reference to `speaker_turns_dag` or `speaker_turns`
+  tasks as upstream or downstream dependencies
+
+---
+
+### Requirement: Reuse of Existing Helpers Without Modification
+
+The system MUST reuse the following existing components without changing their
+signatures, behavior, or test coverage:
+
+- `extract_audio_wav(video_path, wav_path, start_secs, duration_secs)` from
+  `congress_videos/modules/vad_helpers.py`
+- `_find_source_video(target_date, video_id)` from
+  `congress_videos/modules/vad_helpers.py`
+- `find_srt_for_chapter(video_id, chapter_id, session_date)` from
+  `congress_videos/srt_helpers.py`
+- `_parse_srt_blocks(path)` from `congress_videos/srt_helpers.py`
+- `lookup_participant_fuzzy(name)` from
+  `congress_videos/modules/participants_db.py`
+
+The new `speaker_turns` module MUST call these functions through their existing
+public interfaces. No new parameter, return-type change, or behavioral change to
+these functions is permitted as part of this change.
+
+#### Scenario: Helper functions are called unchanged
+
+- GIVEN the post-change versions of `vad_helpers.py`, `srt_helpers.py`, and
+  `participants_db.py`
+- WHEN their test suites run
+- THEN all pre-existing tests pass without modification
+- AND no new parameter or return-type change is introduced by this change
+
+---
+
+### Requirement: Test Coverage with Injectable Boundaries
+
+The system MUST provide unit tests for the `speaker_turns` module that exercise
+turn detection, signal fusion, each postprocessing step, persistence, and
+graceful degradation using a stub `diarize_fn`. Tests MUST run without Docker,
+without network access, and without a live database. A DAG-load test MUST verify
+that `speaker_turns_dag` registers without import errors.
+
+#### Scenario: All postprocessing scenarios are covered by unit tests
+
+- GIVEN stub `diarize_fn` returning controlled boundary sequences
+- WHEN the unit-test suite runs
+- THEN tests assert correct output for: gap merge (gap < 1.0 s), gap non-merge
+  (gap ≥ 1.0 s), ping-pong collapse, same-name merge, missing-video skip,
+  missing-SRT acoustic-only output, text-gate acceptance, and text-gate
+  rejection (noise)
+
+---
+
+### Requirement: Scope Boundaries
+
+The system SHALL NOT implement video cutting, clip materialization (#88), silence
+or applause trimming (#87), recall measurement, best-moment selection (#17), or
+diarization confidence recall tuning. The `youtube_upload_dag` DAG MUST remain
+unchanged in structure and dependency graph. No existing table schema or module
+public interface is permitted to change as part of this delivery.
+
+#### Scenario: Deferred scope remains excluded
+
+- GIVEN implementation planning for this change
+- WHEN work is selected
+- THEN it excludes video cutting, clip materialization, silence trimming,
+  applause detection, recall measurement, `youtube_upload_dag` modifications,
+  and any schema or interface change to existing modules

--- a/openspec/changes/speaker-turns-detection/tasks.md
+++ b/openspec/changes/speaker-turns-detection/tasks.md
@@ -1,0 +1,129 @@
+# Implementation Tasks: Speaker-Turn Detection Inside video_chapters
+
+## Review Workload Forecast
+
+| Field | Value |
+|-------|-------|
+| Estimated changed lines | 700–950 (module ~300, DAG ~150, migration ~30, tests ~300+) |
+| 400-line budget risk | High |
+| Chained PRs recommended | Yes |
+| Suggested split | PR 1 = migration + pure module + module tests; PR 2 = Docker wrapper + DAG + DAG-load test + persistence upsert |
+| Delivery strategy | auto-chain |
+| Chain strategy | feature-branch-chain |
+
+Decision needed before apply: No
+Chained PRs recommended: Yes
+Chain strategy: feature-branch-chain
+400-line budget risk: High
+
+## Delivery Boundaries
+
+- Use a dedicated clean worktree before any implementation mutation; the dirty primary workspace is never a mutation target.
+- Deliver as a feature-branch chain: PR 1 targets the feature/tracker branch; PR 2 targets PR 1. Keep each PR below 400 changed lines.
+- Do not modify `vad_helpers.py`, `srt_helpers.py`, `participants_db.py`, `youtube_upload_dag.py`, or any existing migration file. Import only.
+- `confirmed_block_duration_seconds` MUST NOT appear as a threshold predicate anywhere in production code.
+
+## Task 0 — Migration Number Verification (pre-work, blocking)
+
+- [x] **VERIFY:** Before creating any file, list `congress_videos/sql/migrations/` on the `dev` branch (`git show dev:congress_videos/sql/migrations/ --name-only` or equivalent) to find the current highest migration number. The new file MUST be named `{highest+1}_create_speaker_turns.sql`. The spec states the number is **≥ 021**; confirm or adjust. Record the resolved number; all subsequent migration tasks use it. **Verification:** the filename matches highest+1 and is unique across both the working branch and `dev`. **Rollback:** no files created yet; no action needed. <!-- sdd-owner: implementation -->
+<!-- VERIFIED: dev branch contains 020 and 021; highest+1 = 022. File named 022_create_speaker_turns.sql. -->
+
+---
+
+## PR 1 — Migration + Pure Module
+
+### Phase 1: Migration DDL
+
+- [x] **RED:** add `tests/congress_videos/test_speaker_turns_migration.py` with a test that parses the SQL file for the new migration and asserts: `CREATE TABLE IF NOT EXISTS speaker_turns` is present; `REFERENCES video_chapters(chapter_id)` FK is present; `UNIQUE (chapter_id, start_seconds)` constraint is present; `CHECK (confidence >= 0 AND confidence <= 1)` is present; `CHECK (source IN ('acoustic','text_confirmed','text_named'))` is present; both indexes (`idx_speaker_turns_chapter`, `idx_speaker_turns_name`) are present; `ON DELETE CASCADE` is present on the FK. **Verification:** `uv run pytest tests/congress_videos/test_speaker_turns_migration.py -o addopts=` fails (file does not exist). **Rollback:** remove the new test file. <!-- sdd-owner: implementation -->
+<!-- NOTE: Test placed at tests/congress_videos/sql/test_migration_022.py (following existing convention). RED confirmed: 10 failed. -->
+- [x] **GREEN:** create `congress_videos/sql/migrations/{resolved_number}_create_speaker_turns.sql` with the DDL from the design: `speaker_turns` table (`turn_id SERIAL PK`, `chapter_id INTEGER NOT NULL REFERENCES video_chapters(chapter_id) ON DELETE CASCADE`, `start_seconds NUMERIC NOT NULL`, `end_seconds NUMERIC NOT NULL`, `speaker_label TEXT NOT NULL`, `resolved_name TEXT`, `confidence NUMERIC NOT NULL CHECK (confidence >= 0 AND confidence <= 1)`, `source TEXT NOT NULL CHECK (source IN ('acoustic','text_confirmed','text_named'))`, `created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()`, `UNIQUE (chapter_id, start_seconds)`), plus `idx_speaker_turns_chapter` and `idx_speaker_turns_name` indexes. **Verification:** `uv run pytest tests/congress_videos/test_speaker_turns_migration.py -o addopts=` passes green. **Rollback:** delete the migration file; revert the test. <!-- sdd-owner: implementation -->
+<!-- GREEN: 10/10 passed. File: congress_videos/sql/migrations/022_create_speaker_turns.sql -->
+
+### Phase 2: `Turn` Dataclass and Module Skeleton
+
+- [x] **RED:** add `tests/congress_videos/modules/test_speaker_turns.py`; import `Turn` from `congress_videos.modules.speaker_turns` and assert it is a frozen dataclass with fields `start_seconds: float`, `end_seconds: float`, `speaker_label: str`, `resolved_name: str | None`, `confidence: float`, `source: str`. Also assert module-level constants `GAP_MERGE_SECONDS = 1.0`, `PINGPONG_B_MAX_SECONDS = 5.0`, `PINGPONG_RETURN_SECONDS = 10.0` exist. **Verification:** test fails (module does not exist). **Rollback:** remove the test file. <!-- sdd-owner: implementation -->
+<!-- RED confirmed: 42 tests failed. Tests for all phases (2–7) written together in one file. -->
+- [x] **GREEN:** create `congress_videos/modules/speaker_turns.py` with the `Turn` frozen dataclass, `DiarizeFn` type alias, and the three named constants. No logic yet. **Verification:** the dataclass/constants assertions pass green. **Rollback:** delete the module. <!-- sdd-owner: implementation -->
+<!-- GREEN: Full module implemented; 42/42 passed. -->
+
+### Phase 3: President-Announcement Extractor (pure)
+
+Satisfies: Text Gate and Name Resolution requirement; scenarios "Announcement phrase confirms and names", "Announcement phrase is absent — fuzzy fallback fires", "Announcement phrase rejects a noisy acoustic change", "confirmed_block_duration_seconds is never consulted".
+
+- [x] **RED:** in `tests/congress_videos/modules/test_speaker_turns.py` add `extract_announcement` tests covering: (a) block containing `"Tiene la palabra el señor García"` in the `[t-30, t+30]` window returns `("García", True)`; (b) block containing `"Tiene la palabra la señora Martínez"` returns `("Martínez", True)`; (c) block containing `"Tiene la palabra su señoría"` returns `(None, True)`; (d) block containing `"Gracias, señoría"` returns `(None, True)`; (e) no matching block in window returns `(None, False)`; (f) matching block outside the window is ignored; (g) accent-tolerant match (`señor` with varied accents); (h) closest preceding block (within 15–30 s before `t`) is preferred when multiple blocks match. All use SRT-block list fixtures — no file I/O. **Verification:** run focused test and observe failures. **Rollback:** remove the new test cases. <!-- sdd-owner: implementation -->
+- [x] **GREEN:** implement `extract_announcement(srt_blocks: list[dict], t: float, window: float = 30.0) -> tuple[str | None, bool]` in `speaker_turns.py`. Compile three regex patterns once at module level (case-insensitive, accent-tolerant via `unicodedata.normalize`): `tiene la palabra (?:el señor|la señora)\s+(?P<name>[\wÁÉÍÓÚÑáéíóúñ.\- ]+?)(?:[.,]|$)`, `tiene la palabra su señoría`, `gracias,?\s+señoría`. Scan blocks intersecting `[t − window, t + window]`; prefer the closest preceding block within 15–30 s before `t` for name capture. Return `(raw_name_or_None, phrase_found)`. **Verification:** all `extract_announcement` tests pass. **Rollback:** revert only the extractor function. <!-- sdd-owner: implementation -->
+- [x] **REFACTOR:** extract compiled regex patterns to module-level constants; ensure the window scanning and preference logic is a single cohesive function with no side effects. Re-run extractor tests. **Rollback:** revert only this refactor unit. <!-- sdd-owner: implementation -->
+<!-- REFACTOR: Regex constants _RE_NAMED, _RE_SU_SENORIA, _RE_GRACIAS_SENORIA at module level. All 8 extractor tests pass. -->
+
+### Phase 4: Postprocessing Pipeline (pure)
+
+Satisfies: Postprocessing Pipeline requirement; scenarios "Sub-second gap merged", "Ping-pong A→B→A collapsed", "Adjacent turns with same resolved name merged".
+
+- [x] **RED:** add postprocessing tests in `test_speaker_turns.py` for each step as standalone functions: (a) `_merge_gaps`: two consecutive same-label segments with gap `0.7 s` → merged into one; two with gap `1.1 s` → not merged; (b) `_collapse_pingpong`: `A(60 s)→B(4 s)→A(90 s)` where B duration `< PINGPONG_B_MAX_SECONDS` and return gap `< PINGPONG_RETURN_SECONDS` → collapsed to one A; `A(60 s)→B(6 s)→A(90 s)` (B exceeds max) → not collapsed; (c) `_merge_same_name`: two adjacent segments with different `speaker_label` but same non-null `resolved_name` "María Luisa García" → merged; two with `resolved_name=None` → not merged. Use plain dicts/`Turn` instances as fixtures. **Verification:** tests fail (functions not implemented). **Rollback:** remove the new test cases. <!-- sdd-owner: implementation -->
+- [x] **GREEN:** implement `_merge_gaps(segments: list[dict]) -> list[dict]`, `_collapse_pingpong(segments: list[dict]) -> list[dict]`, and `_merge_same_name(turns: list[Turn]) -> list[Turn]` as pure functions in `speaker_turns.py`. Constants `GAP_MERGE_SECONDS`, `PINGPONG_B_MAX_SECONDS`, `PINGPONG_RETURN_SECONDS` are already defined. **Verification:** all three postprocessing tests pass green. **Rollback:** revert only these three functions. <!-- sdd-owner: implementation -->
+<!-- GREEN: 12 postprocessing tests pass (4 per function). -->
+
+### Phase 5: Text Gate Integration
+
+Satisfies: Text Gate requirement; "confirmed_block_duration_seconds is never consulted"; source/confidence routing table from design.
+
+- [x] **RED:** add text-gate tests in `test_speaker_turns.py` for `_apply_text_gate(segments, srt_blocks, name_resolver)`: (a) acoustic change with announcement phrase naming a resolvable participant → `source="text_named"`, `confidence=0.95`, `resolved_name` set; (b) phrase found but name not resolvable → `source="text_confirmed"`, `confidence=0.80`, `resolved_name=None`; (c) no phrase in window AND segments on both sides resolve to same speaker label → segment dropped (noise rejection); (d) no phrase in window but different labels → `source="acoustic"`, `confidence=0.50`; (e) `confirmed_block_duration_seconds` field present in segment dict but NEVER read as a threshold (assert it has no effect on outcome). Inject a fake `name_resolver` callable. **Verification:** tests fail (function not implemented). **Rollback:** remove these test cases. <!-- sdd-owner: implementation -->
+- [x] **GREEN:** implement `_apply_text_gate(segments: list[dict], srt_blocks: list[dict], name_resolver: Callable) -> list[Turn]` in `speaker_turns.py`. For each segment call `extract_announcement`; route `source`/`confidence` per the design table; drop same-speaker noise (both sides same label + no phrase); build `Turn` instances. Never read `confirmed_block_duration_seconds` as a threshold. **Verification:** text-gate tests pass green. **Rollback:** revert only this function. <!-- sdd-owner: implementation -->
+<!-- GREEN: 5 text-gate tests pass. confirmed_block_duration_seconds never consulted. -->
+
+### Phase 6: `detect_turns` Orchestrator
+
+Satisfies: Chapter-Bounded Turn Detection; Injectable Diarization Backend; all postprocessing scenarios end-to-end; graceful degradation (missing-video, missing-SRT).
+
+- [x] **RED:** add `detect_turns` integration tests in `test_speaker_turns.py`: (a) stub `diarize_fn` returning fixed change dicts → pipeline completes, returns `Turn[]` without launching Docker; (b) missing-video: `diarize_fn` raises/returns empty when `wav_path=None` or `chapter` has no source video → returns `[]`, no exception; (c) missing-SRT: `srt_blocks=[]` → acoustic-only turns with `source="acoustic"` and `confidence <= 0.50`, `resolved_name` nullable; (d) empty `diarize_fn` output (no changes) → returns `[]`; (e) end-to-end: gap-merge + ping-pong + text-gate + same-name all applied in order. All with stubbed `diarize_fn` and `name_resolver`. **Verification:** tests fail (function not implemented). **Rollback:** remove these test cases. <!-- sdd-owner: implementation -->
+- [x] **GREEN:** implement `detect_turns(chapter: dict, srt_blocks: list[dict], diarize_fn: DiarizeFn, name_resolver: Callable = lookup_participant_fuzzy) -> list[Turn]` in `speaker_turns.py`. Orchestrate: call `diarize_fn(wav_path, chapter_offset_seconds)` → acoustic changes; convert to candidate segments; run `_merge_gaps` → `_collapse_pingpong` → `_apply_text_gate` → `_merge_same_name`; return `Turn[]`. Never touches Airflow context, DB, or Docker. Import `lookup_participant_fuzzy` from `participants_db` for the default `name_resolver`; import `find_srt_for_chapter`, `_parse_srt_blocks`, `extract_audio_wav`, `_find_source_video` for use by the DAG layer (not inside this function). **Verification:** all `detect_turns` tests pass green. **Rollback:** revert only this function. <!-- sdd-owner: implementation -->
+- [x] **REFACTOR:** confirm no mutation of input dicts, all thresholds accessed through named constants, no `shell=True` in any call, and no import of pyannote/torch. Re-run full `test_speaker_turns.py`. **Rollback:** revert only this refactor unit. <!-- sdd-owner: implementation -->
+<!-- REFACTOR: Verified — no shell=True, no pyannote/torch, no dict mutation (uses dict() / {**seg,...}), constants used throughout. 42/42 pass. -->
+
+### Phase 7: Persistence Upsert (pure helper)
+
+Satisfies: Idempotent Persistence requirement; scenarios "Idempotent re-run updates without duplicating rows", "source values are constrained to the declared enum".
+
+- [x] **RED:** add `_upsert_turns` tests in `test_speaker_turns.py` using a fake DB cursor (a mock with `execute` and `fetchall`): (a) first call inserts `N` rows; (b) second call with same `chapter_id`/`start_seconds` → row count unchanged; (c) assert the SQL string passed to `cursor.execute` contains `ON CONFLICT (chapter_id, start_seconds) DO UPDATE SET`; (d) assert `updated_at = NOW()` or equivalent is in the update clause. No live DB required. **Verification:** tests fail. **Rollback:** remove test cases. <!-- sdd-owner: implementation -->
+- [x] **GREEN:** implement `_upsert_turns(cursor, chapter_id: int, turns: list[Turn]) -> None` in `speaker_turns.py`. For each `Turn` execute `INSERT INTO speaker_turns (...) VALUES (...) ON CONFLICT (chapter_id, start_seconds) DO UPDATE SET end_seconds=EXCLUDED.end_seconds, speaker_label=EXCLUDED.speaker_label, resolved_name=EXCLUDED.resolved_name, confidence=EXCLUDED.confidence, source=EXCLUDED.source, updated_at=NOW()`. Never call `cursor.commit()` (the DAG controls transactions). **Verification:** upsert tests pass green. **Rollback:** revert only this function. <!-- sdd-owner: implementation -->
+<!-- GREEN: 5 upsert tests pass. ON CONFLICT present, updated_at set, commit never called. -->
+
+---
+
+## PR 2 — Docker Wrapper + DAG + DAG-Load Test
+
+### Phase 8: Diarization Docker Subprocess Wrapper
+
+Satisfies: Injectable Diarization Backend requirement; scenarios "Production diarizer runs isolated", "Test stub replaces Docker diarizer"; threat matrix rows (shell injection, network egress, resource caps).
+
+- [ ] **RED:** add `tests/congress_videos/modules/test_speaker_turns_docker.py` testing `docker_diarize_fn(wav_path, chapter_offset_seconds)` with `subprocess.run` mocked: (a) assert arg vector contains `docker`, `run`, `--rm`, `--network`, `none`, `--memory`, `4g`, `--cpuset-cpus`; (b) assert `--network none` is present; (c) assert `--memory 4g` is present; (d) assert `shell=True` is NOT passed to `subprocess.run`; (e) assert wav path is mounted read-only (`-v {wav_dir}:/in:ro`); (f) assert output dir is mounted writable (`-v {out_dir}:/out`); (g) assert non-int / path-traversal chapter_ids are rejected before any subprocess call; (h) subprocess timeout is adaptive (proportional to audio duration). Mock `subprocess.run` to return a fake `changes.json`. **Verification:** tests fail (function not implemented). **Rollback:** remove this test file. <!-- sdd-owner: implementation -->
+- [ ] **GREEN:** implement `docker_diarize_fn(wav_path: str, chapter_offset_seconds: float) -> list[dict]` in `congress_videos/modules/speaker_turns.py` (or a dedicated `speaker_turns_docker.py` if cleaner). Build arg list for `subprocess.run` (no `shell=True`): `docker run --rm --network none --memory 4g --cpuset-cpus 0-1 -v {wav_dir}:/in:ro -v {out_dir}:/out pyannote/speaker-diarization-community-1 --input /in/{wav_name} --output /out/changes.json`. Derive adaptive timeout (`base + factor * audio_duration`). Parse `/out/changes.json` into the wire format; never import pyannote or torch. **Verification:** subprocess-mock tests pass green. **Rollback:** revert only this function. <!-- sdd-owner: implementation -->
+- [ ] **REFACTOR:** confirm arg vector is built from module-derived path constants (not user text), timeout is bounded, and the output temp directory is cleaned up after parsing. Re-run docker tests. **Rollback:** revert only this refactor unit. <!-- sdd-owner: implementation -->
+
+### Phase 9: Thin DAG `speaker_turns_dag.py`
+
+Satisfies: On-Demand Standalone DAG requirement; scenarios "DAG loads without import errors", "DAG run processes at most LIMIT chapters", "DAG is not chained into youtube_upload_dag"; graceful degradation per-chapter.
+
+- [ ] **RED:** add `tests/congress_videos/test_speaker_turns_dag.py` — DAG-load smoke test: import `speaker_turns_dag` and assert `speaker_turns_dag` is registered in the DagBag with no import errors; assert `schedule_interval` is `None`; assert `youtube_upload_dag.py` contains no reference to `speaker_turns_dag` or `speaker_turns` as a task dependency. **Verification:** tests fail (DAG file does not exist). **Rollback:** remove this test file. <!-- sdd-owner: implementation -->
+- [ ] **GREEN:** create `congress_videos/speaker_turns_dag.py` as a thin on-demand DAG following the `generic_thumbnail_generator_dag` pattern. `schedule=None`. Conf keys: `limit` (default 10), optional `chapter_ids` list. Task graph: `select_chapters` (xcom_task, query `uploadable_chapters` view up to LIMIT or filter by `chapter_ids`) → `process_chapters` (per chapter: call `_find_source_video` + `extract_audio_wav` to produce a transient WAV scoped to the chapter window; call `find_srt_for_chapter` + `_parse_srt_blocks` + filter blocks to chapter window; call `detect_turns(chapter, srt_blocks, docker_diarize_fn)`; call `_upsert_turns`). Per-chapter exception handling: missing source video → log warning + skip (DAG succeeds); missing SRT → pass `srt_blocks=[]` for acoustic-only. Use `xcom_task` from `utils.airflow_helpers`. Never self-triggers; never references `youtube_upload_dag`. **Verification:** DAG-load smoke test passes green; `uv run pytest tests/congress_videos/test_speaker_turns_dag.py -o addopts=` is green. **Rollback:** delete `speaker_turns_dag.py` and revert the DAG-load test. <!-- sdd-owner: implementation -->
+- [ ] **REFACTOR:** confirm the DAG contains no business logic (all logic in `speaker_turns.py`), no hard-coded paths, and no `youtube_upload_dag` references. Re-run DAG-load test and inspect `git diff -- congress_videos/youtube_upload_dag.py` is empty. **Rollback:** revert only this DAG refactor unit. <!-- sdd-owner: implementation -->
+
+### Phase 10: Reuse Verification (no-change assertion)
+
+Satisfies: Reuse of Existing Helpers Without Modification requirement; scenario "Helper functions are called unchanged".
+
+- [ ] **VERIFY (no new code):** run `uv run pytest tests/congress_videos/modules/test_vad_helpers.py tests/congress_videos/modules/test_srt_helpers.py tests/congress_videos/ -k "participant" -o addopts=` and confirm all pre-existing tests pass without modification. Run `git diff -- congress_videos/modules/vad_helpers.py congress_videos/srt_helpers.py congress_videos/modules/participants_db.py` and confirm all three files are unmodified. Record pass/fail. **Rollback:** if any existing test broke, revert the offending import or call site in `speaker_turns.py`/`speaker_turns_dag.py`; no change to helper files is permitted. <!-- sdd-owner: implementation -->
+
+---
+
+## Final Verification and Handoff
+
+- [ ] Run `uv run pytest` from the dedicated worktree; record the exact pass/fail count and distinguish any pre-existing environment/collection failure from change-caused failures. Confirm the test suite covers: all postprocessing steps (gap merge, ping-pong, same-name merge), text gate (named, confirmed, noise-rejected, acoustic fallback), `detect_turns` orchestrator (stub `diarize_fn`, missing-video, missing-SRT), persistence upsert (idempotency), Docker subprocess arg vector (security + resource caps), and the DAG-load smoke test. **Rollback:** revert PRs in reverse chain order (PR 2 → PR 1); fuzzy/upload behavior is unaffected; drop `speaker_turns` table if migration was applied. <!-- sdd-owner: implementation -->
+- [ ] Run `bash scripts/test-airflow-e2e.sh` once (this change touches `congress_videos/**`); record pass/fail/unavailable. If Docker is unavailable on the CI host, record `unavailable` (not a failure) and note that it must be run manually before merge. **Rollback:** no additional action; e2e is read-only with respect to this change's rollback path. <!-- sdd-owner: implementation -->
+- [ ] Confirm the final diff is limited to: `congress_videos/sql/migrations/{resolved_number}_create_speaker_turns.sql`, `congress_videos/modules/speaker_turns.py` (optionally `speaker_turns_docker.py` if extracted), `congress_videos/speaker_turns_dag.py`, `tests/congress_videos/test_speaker_turns_migration.py`, `tests/congress_videos/modules/test_speaker_turns.py`, `tests/congress_videos/modules/test_speaker_turns_docker.py`, `tests/congress_videos/test_speaker_turns_dag.py`. No existing DAG, migration, or module signature changed. `git diff -- congress_videos/youtube_upload_dag.py` is empty. <!-- sdd-owner: implementation -->
+
+## Parent Lifecycle Actions
+
+- [ ] Start or reuse bounded review for each frozen PR slice after its source-mutating work and tests are complete; review PR 1 before PR 2. <!-- sdd-owner: parent -->
+- [ ] Confirm PR 1 targets the feature/tracker branch and PR 2 targets PR 1; confirm neither slice exceeds the 400-line budget; split test fixtures into a data-only child if needed. <!-- sdd-owner: parent -->
+- [ ] After both PRs merge to `dev`, close GitHub issue #86 and confirm issues #17 and #88 reference the new `speaker_turns` table as an available input. <!-- sdd-owner: parent -->

--- a/tests/congress_videos/modules/test_speaker_turns.py
+++ b/tests/congress_videos/modules/test_speaker_turns.py
@@ -1,0 +1,647 @@
+"""Tests for congress_videos.modules.speaker_turns.
+
+Strict TDD: tests written first. No real Docker, pyannote, OpenAI,
+network, or live DB. diarize_fn, name_resolver, and DB cursor are
+all injected/faked.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+from typing import get_type_hints
+from unittest.mock import MagicMock, call
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Phase 2 — Turn dataclass and module constants
+# ---------------------------------------------------------------------------
+
+class TestTurnDataclass:
+
+    def test_turn_is_importable(self):
+        from congress_videos.modules.speaker_turns import Turn
+        assert Turn is not None
+
+    def test_turn_is_frozen_dataclass(self):
+        from congress_videos.modules.speaker_turns import Turn
+        assert dataclasses.is_dataclass(Turn)
+        assert Turn.__dataclass_params__.frozen is True
+
+    def test_turn_fields(self):
+        from congress_videos.modules.speaker_turns import Turn
+        fields = {f.name: f for f in dataclasses.fields(Turn)}
+        assert "start_seconds" in fields
+        assert "end_seconds" in fields
+        assert "speaker_label" in fields
+        assert "resolved_name" in fields
+        assert "confidence" in fields
+        assert "source" in fields
+
+    def test_turn_is_immutable(self):
+        from congress_videos.modules.speaker_turns import Turn
+        t = Turn(
+            start_seconds=0.0,
+            end_seconds=10.0,
+            speaker_label="SPEAKER_01",
+            resolved_name=None,
+            confidence=0.5,
+            source="acoustic",
+        )
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            t.start_seconds = 99.0  # type: ignore[misc]
+
+
+class TestModuleConstants:
+
+    def test_gap_merge_seconds(self):
+        from congress_videos.modules.speaker_turns import GAP_MERGE_SECONDS
+        assert GAP_MERGE_SECONDS == 1.0
+
+    def test_pingpong_b_max_seconds(self):
+        from congress_videos.modules.speaker_turns import PINGPONG_B_MAX_SECONDS
+        assert PINGPONG_B_MAX_SECONDS == 5.0
+
+    def test_pingpong_return_seconds(self):
+        from congress_videos.modules.speaker_turns import PINGPONG_RETURN_SECONDS
+        assert PINGPONG_RETURN_SECONDS == 10.0
+
+
+# ---------------------------------------------------------------------------
+# Fixtures shared across phases
+# ---------------------------------------------------------------------------
+
+def _make_srt_blocks(*entries):
+    """Build a list of SRT-block dicts from (start_secs, end_secs, text) tuples."""
+    return [
+        {"start_secs": s, "end_secs": e, "text": t}
+        for s, e, t in entries
+    ]
+
+
+def _identity_resolver(name: str):
+    """Fake name_resolver that returns the name as-is in a result dict."""
+    if not name:
+        return None
+    return {"display_name": name, "normalized_name": name.lower()}
+
+
+def _null_resolver(name: str):
+    """Fake name_resolver that always returns None (unresolvable)."""
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Phase 3 — extract_announcement
+# ---------------------------------------------------------------------------
+
+class TestExtractAnnouncement:
+
+    def test_announces_senor_returns_name_and_true(self):
+        """'Tiene la palabra el señor García' → ('García', True)"""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        blocks = _make_srt_blocks(
+            (75.0, 85.0, "Tiene la palabra el señor García"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is True
+        assert name is not None
+        assert "García" in name or "garcia" in name.lower()
+
+    def test_announces_senora_returns_name_and_true(self):
+        """'Tiene la palabra la señora Martínez' → ('Martínez', True)"""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        blocks = _make_srt_blocks(
+            (78.0, 88.0, "Tiene la palabra la señora Martínez"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is True
+        assert name is not None
+        assert "Martínez" in name or "Martinez" in name.lower() or "martínez" in name.lower()
+
+    def test_su_senoria_no_name_returns_none_true(self):
+        """'Tiene la palabra su señoría' → (None, True)"""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        blocks = _make_srt_blocks(
+            (80.0, 90.0, "Tiene la palabra su señoría"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is True
+        assert name is None
+
+    def test_gracias_senoria_returns_none_true(self):
+        """'Gracias, señoría' → (None, True)"""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        blocks = _make_srt_blocks(
+            (80.0, 90.0, "Gracias, señoría"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is True
+        assert name is None
+
+    def test_no_matching_block_returns_none_false(self):
+        """No relevant phrase anywhere → (None, False)"""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        blocks = _make_srt_blocks(
+            (80.0, 90.0, "El debate sobre el presupuesto continúa"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is False
+        assert name is None
+
+    def test_block_outside_window_is_ignored(self):
+        """A matching block more than 30 s before t is outside the default window."""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        # 100 - 31 = 69 → outside [70, 130] window
+        blocks = _make_srt_blocks(
+            (60.0, 68.0, "Tiene la palabra el señor Fuera de ventana"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is False
+        assert name is None
+
+    def test_accent_tolerant_match(self):
+        """'señor' written without accents (senor) still matches (accent-tolerant)."""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        blocks = _make_srt_blocks(
+            (80.0, 90.0, "Tiene la palabra el senor Lopez"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is True
+        assert name is not None
+
+    def test_closest_preceding_block_preferred(self):
+        """When multiple blocks match, the closest preceding block within 15–30 s is preferred."""
+        from congress_videos.modules.speaker_turns import extract_announcement
+        t = 100.0
+        # Two matching blocks before t; the one at 82s is closest
+        blocks = _make_srt_blocks(
+            (72.0, 74.0, "Tiene la palabra el señor Primero"),
+            (82.0, 84.0, "Tiene la palabra el señor Segundo"),
+        )
+        name, found = extract_announcement(blocks, t)
+        assert found is True
+        # Should prefer the closer one (at 82s)
+        assert name is not None
+        assert "Segundo" in name or "segundo" in name.lower()
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — Postprocessing helpers
+# ---------------------------------------------------------------------------
+
+def _seg(start, end, label, resolved_name=None):
+    """Build a minimal segment dict for postprocessing tests."""
+    return {
+        "start_seconds": start,
+        "end_seconds": end,
+        "speaker_label": label,
+        "resolved_name": resolved_name,
+        "confirmed_block_duration_seconds": end - start,  # present but NEVER threshold
+    }
+
+
+class TestMergeGaps:
+
+    def test_gap_under_threshold_merged(self):
+        """Two same-label segments with 0.7 s gap → merged into one."""
+        from congress_videos.modules.speaker_turns import _merge_gaps
+        segs = [
+            _seg(0.0, 10.0, "SPEAKER_01"),
+            _seg(10.7, 20.0, "SPEAKER_01"),
+        ]
+        result = _merge_gaps(segs)
+        assert len(result) == 1
+        assert result[0]["start_seconds"] == 0.0
+        assert result[0]["end_seconds"] == 20.0
+
+    def test_gap_over_threshold_not_merged(self):
+        """Two same-label segments with 1.1 s gap → not merged."""
+        from congress_videos.modules.speaker_turns import _merge_gaps
+        segs = [
+            _seg(0.0, 10.0, "SPEAKER_01"),
+            _seg(11.1, 20.0, "SPEAKER_01"),
+        ]
+        result = _merge_gaps(segs)
+        assert len(result) == 2
+
+    def test_different_labels_not_merged(self):
+        """Different labels even with small gap → not merged."""
+        from congress_videos.modules.speaker_turns import _merge_gaps
+        segs = [
+            _seg(0.0, 10.0, "SPEAKER_01"),
+            _seg(10.5, 20.0, "SPEAKER_02"),
+        ]
+        result = _merge_gaps(segs)
+        assert len(result) == 2
+
+    def test_empty_input(self):
+        """Empty list → empty list."""
+        from congress_videos.modules.speaker_turns import _merge_gaps
+        assert _merge_gaps([]) == []
+
+
+class TestCollapsePingpong:
+
+    def test_short_b_segment_collapsed(self):
+        """A(60s)→B(4s)→A(90s) where B < PINGPONG_B_MAX_SECONDS → single A."""
+        from congress_videos.modules.speaker_turns import _collapse_pingpong
+        segs = [
+            _seg(0.0, 60.0, "A"),
+            _seg(60.0, 64.0, "B"),    # 4 s < 5.0
+            _seg(64.0, 154.0, "A"),   # return gap 0s < 10.0
+        ]
+        result = _collapse_pingpong(segs)
+        assert len(result) == 1
+        assert result[0]["speaker_label"] == "A"
+        assert result[0]["start_seconds"] == 0.0
+        assert result[0]["end_seconds"] == 154.0
+
+    def test_b_over_max_not_collapsed(self):
+        """A(60s)→B(6s)→A where B >= PINGPONG_B_MAX_SECONDS → not collapsed."""
+        from congress_videos.modules.speaker_turns import _collapse_pingpong
+        segs = [
+            _seg(0.0, 60.0, "A"),
+            _seg(60.0, 66.0, "B"),    # 6 s >= 5.0
+            _seg(66.0, 156.0, "A"),
+        ]
+        result = _collapse_pingpong(segs)
+        assert len(result) == 3
+
+    def test_empty_input(self):
+        """Empty list → empty list."""
+        from congress_videos.modules.speaker_turns import _collapse_pingpong
+        assert _collapse_pingpong([]) == []
+
+    def test_single_segment_unchanged(self):
+        """Single segment → returned unchanged."""
+        from congress_videos.modules.speaker_turns import _collapse_pingpong
+        segs = [_seg(0.0, 60.0, "A")]
+        result = _collapse_pingpong(segs)
+        assert len(result) == 1
+
+
+class TestMergeSameName:
+
+    def test_adjacent_same_resolved_name_merged(self):
+        """Two adjacent turns with different labels but same non-null resolved_name → merged."""
+        from congress_videos.modules.speaker_turns import Turn, _merge_same_name
+        turns = [
+            Turn(0.0, 60.0, "SPEAKER_00", "María Luisa García", 0.95, "text_named"),
+            Turn(60.0, 120.0, "SPEAKER_02", "María Luisa García", 0.80, "text_confirmed"),
+        ]
+        result = _merge_same_name(turns)
+        assert len(result) == 1
+        assert result[0].resolved_name == "María Luisa García"
+        assert result[0].start_seconds == 0.0
+        assert result[0].end_seconds == 120.0
+
+    def test_none_resolved_name_not_merged(self):
+        """Two adjacent turns with resolved_name=None → not merged on name."""
+        from congress_videos.modules.speaker_turns import Turn, _merge_same_name
+        turns = [
+            Turn(0.0, 60.0, "SPEAKER_00", None, 0.50, "acoustic"),
+            Turn(60.0, 120.0, "SPEAKER_02", None, 0.50, "acoustic"),
+        ]
+        result = _merge_same_name(turns)
+        assert len(result) == 2
+
+    def test_empty_input(self):
+        """Empty list → empty list."""
+        from congress_videos.modules.speaker_turns import _merge_same_name
+        assert _merge_same_name([]) == []
+
+    def test_different_resolved_names_not_merged(self):
+        """Different resolved names → not merged."""
+        from congress_videos.modules.speaker_turns import Turn, _merge_same_name
+        turns = [
+            Turn(0.0, 60.0, "SPEAKER_00", "Ana García", 0.95, "text_named"),
+            Turn(60.0, 120.0, "SPEAKER_01", "Pedro López", 0.95, "text_named"),
+        ]
+        result = _merge_same_name(turns)
+        assert len(result) == 2
+
+
+# ---------------------------------------------------------------------------
+# Phase 5 — Text gate (_apply_text_gate)
+# ---------------------------------------------------------------------------
+
+class TestApplyTextGate:
+
+    def test_phrase_with_name_resolves_to_text_named(self):
+        """Phrase + resolvable name → text_named, confidence=0.95, resolved_name set."""
+        from congress_videos.modules.speaker_turns import _apply_text_gate
+        t = 100.0
+        segments = [
+            {
+                "start_seconds": t,
+                "end_seconds": t + 30.0,
+                "speaker_label": "SPEAKER_01",
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 30.0,
+            }
+        ]
+        srt_blocks = _make_srt_blocks(
+            (80.0, 90.0, "Tiene la palabra el señor García"),
+        )
+
+        def resolver(name):
+            return {"display_name": "Pedro García", "normalized_name": "garcia, pedro"}
+
+        turns = _apply_text_gate(segments, srt_blocks, resolver)
+        assert len(turns) == 1
+        assert turns[0].source == "text_named"
+        assert turns[0].confidence == pytest.approx(0.95)
+        assert turns[0].resolved_name is not None
+
+    def test_phrase_without_resolvable_name_gives_text_confirmed(self):
+        """Phrase found but name not resolvable → text_confirmed, confidence=0.80."""
+        from congress_videos.modules.speaker_turns import _apply_text_gate
+        t = 100.0
+        segments = [
+            {
+                "start_seconds": t,
+                "end_seconds": t + 30.0,
+                "speaker_label": "SPEAKER_01",
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 30.0,
+            }
+        ]
+        srt_blocks = _make_srt_blocks(
+            (80.0, 90.0, "Tiene la palabra su señoría"),
+        )
+        turns = _apply_text_gate(segments, srt_blocks, _null_resolver)
+        assert len(turns) == 1
+        assert turns[0].source == "text_confirmed"
+        assert turns[0].confidence == pytest.approx(0.80)
+        assert turns[0].resolved_name is None
+
+    def test_no_phrase_same_speaker_noise_rejected(self):
+        """No phrase + same from/to speaker label → segment dropped (noise rejection)."""
+        from congress_videos.modules.speaker_turns import _apply_text_gate
+        t = 100.0
+        segments = [
+            {
+                "start_seconds": t,
+                "end_seconds": t + 30.0,
+                "speaker_label": "SPEAKER_01",
+                "from_speaker": "SPEAKER_01",  # same speaker on both sides
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 30.0,
+            }
+        ]
+        srt_blocks = _make_srt_blocks(
+            (80.0, 90.0, "El debate continúa"),
+        )
+        turns = _apply_text_gate(segments, srt_blocks, _null_resolver)
+        assert len(turns) == 0
+
+    def test_no_phrase_different_speakers_gives_acoustic(self):
+        """No phrase + different speakers → acoustic, confidence=0.50."""
+        from congress_videos.modules.speaker_turns import _apply_text_gate
+        t = 100.0
+        segments = [
+            {
+                "start_seconds": t,
+                "end_seconds": t + 30.0,
+                "speaker_label": "SPEAKER_01",
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 30.0,
+            }
+        ]
+        srt_blocks = _make_srt_blocks(
+            (80.0, 90.0, "El debate continúa"),
+        )
+        turns = _apply_text_gate(segments, srt_blocks, _null_resolver)
+        assert len(turns) == 1
+        assert turns[0].source == "acoustic"
+        assert turns[0].confidence == pytest.approx(0.50)
+
+    def test_confirmed_block_duration_not_used_as_threshold(self):
+        """confirmed_block_duration_seconds present but has NO effect on outcome."""
+        from congress_videos.modules.speaker_turns import _apply_text_gate
+        t = 100.0
+        # Two segments identical except for confirmed_block_duration_seconds
+        seg_short = {
+            "start_seconds": t,
+            "end_seconds": t + 30.0,
+            "speaker_label": "SPEAKER_01",
+            "from_speaker": "SPEAKER_00",
+            "to_speaker": "SPEAKER_01",
+            "confirmed_block_duration_seconds": 0.1,  # tiny — must NOT cause rejection
+        }
+        seg_long = {
+            "start_seconds": t,
+            "end_seconds": t + 30.0,
+            "speaker_label": "SPEAKER_01",
+            "from_speaker": "SPEAKER_00",
+            "to_speaker": "SPEAKER_01",
+            "confirmed_block_duration_seconds": 999.0,  # huge — must NOT change outcome
+        }
+        srt_blocks = _make_srt_blocks(
+            (80.0, 90.0, "El debate continúa"),
+        )
+        turns_short = _apply_text_gate([seg_short], srt_blocks, _null_resolver)
+        turns_long = _apply_text_gate([seg_long], srt_blocks, _null_resolver)
+        # Both must yield same result regardless of confirmed_block_duration_seconds
+        assert len(turns_short) == len(turns_long)
+        if turns_short:
+            assert turns_short[0].source == turns_long[0].source
+            assert turns_short[0].confidence == turns_long[0].confidence
+
+
+# ---------------------------------------------------------------------------
+# Phase 6 — detect_turns orchestrator
+# ---------------------------------------------------------------------------
+
+def _make_chapter(chapter_id: int = 1, video_id: str = "abc123", session_date: str = "2024-01-01"):
+    return {
+        "chapter_id": chapter_id,
+        "video_id": video_id,
+        "session_date": session_date,
+        "start_time": "00:30:00",
+        "end_time": "01:15:00",
+    }
+
+
+def _stub_diarize_fn_with_changes(changes):
+    """Return a stub diarize_fn that returns the given changes."""
+    def _fn(wav_path, offset):
+        return changes
+    return _fn
+
+
+def _empty_diarize_fn(wav_path, offset):
+    return []
+
+
+class TestDetectTurns:
+
+    def test_stub_diarize_returns_turns_no_docker(self):
+        """Stub diarize_fn returns fixed changes; pipeline completes without Docker."""
+        from congress_videos.modules.speaker_turns import detect_turns
+        chapter = _make_chapter()
+        changes = [
+            {
+                "start_seconds": 10.0,
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 20.0,
+            },
+        ]
+        diarize_fn = _stub_diarize_fn_with_changes(changes)
+        srt_blocks = []
+        result = detect_turns(chapter, srt_blocks, diarize_fn, _null_resolver)
+        assert isinstance(result, list)
+        # No exception means Docker was NOT called
+
+    def test_empty_diarize_output_returns_empty(self):
+        """Empty diarize_fn output → []."""
+        from congress_videos.modules.speaker_turns import detect_turns
+        chapter = _make_chapter()
+        result = detect_turns(chapter, [], _empty_diarize_fn, _null_resolver)
+        assert result == []
+
+    def test_missing_srt_acoustic_only(self):
+        """srt_blocks=[] → turns with source='acoustic' and confidence<=0.50."""
+        from congress_videos.modules.speaker_turns import detect_turns
+        chapter = _make_chapter()
+        changes = [
+            {
+                "start_seconds": 10.0,
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 20.0,
+            },
+        ]
+        diarize_fn = _stub_diarize_fn_with_changes(changes)
+        result = detect_turns(chapter, [], diarize_fn, _null_resolver)
+        assert isinstance(result, list)
+        for t in result:
+            assert t.source == "acoustic"
+            assert t.confidence <= 0.50
+
+    def test_gap_merge_applied(self):
+        """Two same-speaker changes with tiny gap → gap merge applied."""
+        from congress_videos.modules.speaker_turns import detect_turns, Turn
+        chapter = _make_chapter()
+        # Two consecutive changes to SPEAKER_01 with 0.5s gap between them
+        changes = [
+            {
+                "start_seconds": 5.0,
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 4.5,
+            },
+            {
+                "start_seconds": 10.0,  # gap 0.5 s (5.0+4.5 = 9.5 end, then 10.0 start)
+                "from_speaker": "SPEAKER_01",
+                "to_speaker": "SPEAKER_01",  # same speaker → noise → will be dropped by text gate
+                "confirmed_block_duration_seconds": 30.0,
+            },
+        ]
+        diarize_fn = _stub_diarize_fn_with_changes(changes)
+        result = detect_turns(chapter, [], diarize_fn, _null_resolver)
+        assert isinstance(result, list)
+        # No exceptions; pipeline ran end-to-end
+
+    def test_end_to_end_pipeline_runs(self):
+        """End-to-end: all postprocessing steps applied with srt_blocks."""
+        from congress_videos.modules.speaker_turns import detect_turns
+        chapter = _make_chapter()
+        t = 50.0
+        changes = [
+            {
+                "start_seconds": t,
+                "from_speaker": "SPEAKER_00",
+                "to_speaker": "SPEAKER_01",
+                "confirmed_block_duration_seconds": 30.0,
+            },
+        ]
+        diarize_fn = _stub_diarize_fn_with_changes(changes)
+        srt_blocks = _make_srt_blocks(
+            (30.0, 40.0, "Tiene la palabra el señor García"),
+        )
+
+        def resolver(name):
+            return {"display_name": "García", "normalized_name": "garcia"}
+
+        result = detect_turns(chapter, srt_blocks, diarize_fn, resolver)
+        assert isinstance(result, list)
+        if result:
+            assert result[0].source in ("text_named", "text_confirmed", "acoustic")
+
+
+# ---------------------------------------------------------------------------
+# Phase 7 — _upsert_turns (persistence)
+# ---------------------------------------------------------------------------
+
+class TestUpsertTurns:
+
+    def _make_turns(self, n: int = 2):
+        from congress_videos.modules.speaker_turns import Turn
+        return [
+            Turn(
+                start_seconds=float(i * 10),
+                end_seconds=float(i * 10 + 9),
+                speaker_label=f"SPEAKER_{i:02d}",
+                resolved_name=None,
+                confidence=0.50,
+                source="acoustic",
+            )
+            for i in range(n)
+        ]
+
+    def test_upsert_calls_execute_for_each_turn(self):
+        """_upsert_turns calls cursor.execute once per Turn."""
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        turns = self._make_turns(3)
+        _upsert_turns(cursor, chapter_id=42, turns=turns)
+        assert cursor.execute.call_count == 3
+
+    def test_upsert_sql_contains_on_conflict(self):
+        """SQL passed to cursor.execute must contain ON CONFLICT (chapter_id, start_seconds) DO UPDATE."""
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        turns = self._make_turns(1)
+        _upsert_turns(cursor, chapter_id=42, turns=turns)
+        sql_arg = cursor.execute.call_args[0][0]
+        assert "ON CONFLICT" in sql_arg.upper()
+        assert "chapter_id" in sql_arg
+        assert "start_seconds" in sql_arg
+        assert "DO UPDATE" in sql_arg.upper()
+
+    def test_upsert_sql_contains_updated_at(self):
+        """SQL update clause must set updated_at."""
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        turns = self._make_turns(1)
+        _upsert_turns(cursor, chapter_id=42, turns=turns)
+        sql_arg = cursor.execute.call_args[0][0]
+        assert "updated_at" in sql_arg.lower()
+
+    def test_upsert_never_calls_commit(self):
+        """_upsert_turns must NOT call cursor.commit (DAG controls transactions)."""
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        turns = self._make_turns(2)
+        _upsert_turns(cursor, chapter_id=42, turns=turns)
+        cursor.commit.assert_not_called()
+
+    def test_upsert_empty_turns_no_execute(self):
+        """Empty turns list → cursor.execute never called."""
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        _upsert_turns(cursor, chapter_id=42, turns=[])
+        cursor.execute.assert_not_called()

--- a/tests/congress_videos/sql/test_migration_022.py
+++ b/tests/congress_videos/sql/test_migration_022.py
@@ -1,0 +1,91 @@
+"""[RED] Test: migration 022 — create speaker_turns table.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, table creation is idempotent (IF NOT EXISTS), FK references
+video_chapters(chapter_id) with ON DELETE CASCADE, UNIQUE constraint, CHECK
+constraints for confidence and source, both required indexes, and correct
+cascade behaviour. No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "022_create_speaker_turns.sql"
+)
+
+
+class TestMigration022FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration022TableDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_creates_table_if_not_exists(self):
+        """Migration must use CREATE TABLE IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "CREATE TABLE IF NOT EXISTS SPEAKER_TURNS" in sql
+
+    def test_fk_references_video_chapters(self):
+        """chapter_id column must reference video_chapters(chapter_id)."""
+        sql = self._sql()
+        assert "REFERENCES video_chapters(chapter_id)" in sql
+
+    def test_fk_has_on_delete_cascade(self):
+        """FK must include ON DELETE CASCADE."""
+        sql = self._sql().upper()
+        assert "ON DELETE CASCADE" in sql
+
+    def test_unique_constraint_chapter_start(self):
+        """UNIQUE (chapter_id, start_seconds) constraint must be present."""
+        sql = self._sql().upper()
+        assert "UNIQUE" in sql
+        assert "CHAPTER_ID" in sql
+        assert "START_SECONDS" in sql
+        # Check that UNIQUE appears with both columns in proximity
+        assert re.search(r"UNIQUE\s*\(\s*CHAPTER_ID\s*,\s*START_SECONDS\s*\)", sql)
+
+    def test_confidence_check_constraint(self):
+        """confidence column must have CHECK (confidence >= 0 AND confidence <= 1)."""
+        sql = self._sql()
+        assert "CHECK" in sql.upper()
+        assert "confidence >= 0" in sql or "confidence>=0" in sql
+        assert "confidence <= 1" in sql or "confidence<=1" in sql
+
+    def test_source_check_constraint(self):
+        """source column must have CHECK (source IN ('acoustic','text_confirmed','text_named'))."""
+        sql = self._sql()
+        assert "'acoustic'" in sql
+        assert "'text_confirmed'" in sql
+        assert "'text_named'" in sql
+        assert re.search(r"source\s+IN\s*\(", sql) or re.search(
+            r"CHECK\s*\(.*source.*IN\s*\(", sql, re.DOTALL
+        )
+
+    def test_index_speaker_turns_chapter(self):
+        """idx_speaker_turns_chapter index must be created."""
+        sql = self._sql()
+        assert "idx_speaker_turns_chapter" in sql
+
+    def test_index_speaker_turns_name(self):
+        """idx_speaker_turns_name index on resolved_name must be created."""
+        sql = self._sql()
+        assert "idx_speaker_turns_name" in sql
+
+    def test_indexes_are_conditional(self):
+        """Both indexes must use CREATE INDEX IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert sql.count("CREATE INDEX IF NOT EXISTS") >= 2


### PR DESCRIPTION
Part of #16 · **PR1 of 2** for #86 (speaker-turns-detection).

## Resumen

Detección de turnos de orador **dentro** de los `video_chapters` temáticos — módulo puro + esquema de persistencia. **No corta vídeo** (eso es #88). Este PR es el módulo Airflow-free; PR2 añade el wrapper Docker de diarización y el DAG.

Contexto: la **Fase 0 (auditoría de oído)** ya está hecha ([AUDIT_REPORT](../blob/feat/issue-86-speaker-turns/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/AUDIT_REPORT.md) en la rama de benchmarks) y probó que `confirmed_block_duration_seconds` **no** sirve como umbral → el texto (anuncio del presidente) confirma/descarta cada cambio.

## Qué incluye

| Archivo | Qué |
|---|---|
| `congress_videos/modules/speaker_turns.py` | `Turn`; extractor del presidente (regex + fallback fuzzy); postprocesado (gap<1s, ping-pong A→B→A, merge por nombre); text gate (source/confidence); `detect_turns` con `diarize_fn`/`name_resolver` inyectables; `_upsert_turns` idempotente |
| `congress_videos/sql/migrations/022_create_speaker_turns.sql` | tabla `speaker_turns` (FK, `UNIQUE(chapter_id,start_seconds)`, CHECKs, índices). **022** porque dev ya tiene 020+021 |
| `tests/...` | 52 tests (módulo 93% cov), `diarize_fn` stubbeado, sin Docker/pyannote/OpenAI real |
| `openspec/changes/speaker-turns-detection/` | artefactos SDD (proposal/exploration/spec/design/tasks) |

Reusa sin tocar: `vad_helpers`, `srt_helpers`, `participants_db`.

## Test plan

- [x] `uv run pytest` — 2067 passed, 1 skipped, 86,87% cobertura global
- [x] Módulo nuevo al 93,19%
- [x] Archivos reusados intactos (diff vacío vs dev)
- [ ] e2e docker smoke — se corre al cerrar la cadena (PR2 toca el DAG)

## Fuera de scope

Cortar vídeo (#88), recortes silencio/aplausos (#87), el wrapper Docker + DAG (PR2), recall (Fase 0 fue precision-only).