### PR TITLE
docs(benchmarks): commit Fase 0 ear-audit report + kit (#86)

### DIFF
--- a/benchmarks/pyannote_diarization/audit/.gitignore
+++ b/benchmarks/pyannote_diarization/audit/.gitignore
@@ -1,0 +1,4 @@
+# Heavy/binary audit artifacts — do not commit
+*.wav
+*.mp3
+clips/

--- a/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/AUDIT_REPORT.md
+++ b/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/AUDIT_REPORT.md
@@ -1,0 +1,48 @@
+# Ground-truth audit — speaker-change candidates (run.SC6R8Dgl)
+
+Source: `postprocessed-speaker-changes.json` (32 candidates) from
+`pyannote/speaker-diarization-community-1` on `calibration-1310s.wav`
+(1310 s ≈ fFpw1dIRcAI). Labelled by ear 2026-08-17. Clips: `clips/` (gitignored).
+
+## Results
+
+| Metric | Value |
+|--------|-------|
+| Total detections | 32 |
+| Noise (false positives) | 6 → idx 2, 3, 8, 16, 23, 31 |
+| Redundant duplicates | 7 (pairs 4/5, 9/10, 12/13, 18/19, 21/22, 27/28, 29/30) |
+| **Unique real changes** | **19** |
+| Crude precision (real/total) | 81.2% |
+| **Useful-detection rate (unique/total)** | **59.4%** |
+| Redundancy (dup/real) | 26.9% |
+
+## Key finding: `confirmed_block_duration_seconds` is NOT a usable threshold
+
+Score distributions overlap completely:
+- noise: 3.0, 6.4, 7.6, 8.1, 8.2, 8.4
+- unique real: 1.8, 2.1, 2.3×4, 2.7, 3.1, 3.2, 11.5, 15.7, 16.0, 17.1, 34.4, 40.3, 73.4, 86.1, 92.0, 108.7
+
+Removing all 6 noise requires T≥10.8, which also drops 9/19 real changes
+(keeps 53%). No threshold cleanly separates real from noise.
+
+## Why, and design implications for #86
+
+1. **Noise = same-speaker pitch/intonation shifts** (idx 2,3 confirmed by ear).
+   The diarization splits one speaker into two clusters; the "new" cluster then
+   talks long → high block duration. Block duration measures persistence, not
+   speaker-difference confidence — so it cannot discriminate.
+2. **Duplicates (27%) are a separate error**, not fixable by score (some dup
+   scores reach 133 s). They need temporal merging / A→B→A ping-pong handling in
+   postprocessing.
+3. **Confirms the #86 design**: acoustic diarization alone yields only ~59%
+   useful detections with no reliable threshold. The text layer (president
+   announcements) must **confirm/deny** each change, not just name it. The
+   text×audio cross-check is the cleanup mechanism.
+
+## Recommended next steps (feed #86 design)
+
+- Postprocessing: merge adjacent changes and collapse A→B→A returns within a
+  short window (kills the 27% redundancy).
+- Replace/augment the block-duration score with a genuine cluster-separation
+  signal (embedding distance) OR gate every acoustic change on a text signal.
+- Do NOT calibrate a block-duration threshold — this audit shows it is a dead end.

--- a/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/analyze_audit.py
+++ b/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/analyze_audit.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+"""Compute precision + a threshold suggestion from the filled-in audit sheet.
+
+Reads audit-sheet.csv (label column filled with real|ruido) and reports:
+- Overall precision of the detector at the current postprocessing settings.
+- How precision/retention move if we require score_block_seconds >= T, so a
+  threshold can be picked that drops low-confidence false changes.
+
+Note: this measures PRECISION only. Recall needs separately labelling the
+changes the detector MISSED, which this sheet does not capture.
+"""
+from __future__ import annotations
+
+import csv
+from pathlib import Path
+
+HERE = Path(__file__).parent
+SHEET = HERE / "audit-sheet.csv"
+
+
+def main() -> None:
+    rows = list(csv.DictReader(SHEET.open()))
+    labelled = [r for r in rows if r["label"].strip().lower() in {"real", "ruido"}]
+    missing = len(rows) - len(labelled)
+    if missing:
+        print(f"⚠ {missing}/{len(rows)} candidatos sin marcar — completá la columna label.")
+    if not labelled:
+        return
+
+    reals = [r for r in labelled if r["label"].strip().lower() == "real"]
+    precision = len(reals) / len(labelled)
+    print(f"Candidatos marcados : {len(labelled)}/{len(rows)}")
+    print(f"Reales / ruido      : {len(reals)} / {len(labelled) - len(reals)}")
+    print(f"Precisión global    : {precision:.1%}\n")
+
+    scored = sorted(labelled, key=lambda r: float(r["score_block_seconds"]))
+    thresholds = sorted({round(float(r["score_block_seconds"]), 1) for r in scored})
+    print("Umbral (score >= T) | quedan | precisión | reales conservados")
+    print("--------------------|--------|-----------|-------------------")
+    total_reals = len(reals)
+    for t in thresholds:
+        kept = [r for r in labelled if float(r["score_block_seconds"]) >= t]
+        kept_reals = [r for r in kept if r["label"].strip().lower() == "real"]
+        prec = len(kept_reals) / len(kept) if kept else 0.0
+        retain = len(kept_reals) / total_reals if total_reals else 0.0
+        print(f"{t:>19.1f} | {len(kept):>6} | {prec:>8.1%} | {retain:>16.1%}")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/audit-sheet.csv
+++ b/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/audit-sheet.csv
@@ -1,0 +1,33 @@
+idx,timestamp,start_seconds,transition,score_block_seconds,clip,label,notes
+1,00:03.473,3.473,SPEAKER_00->SPEAKER_01,17.129,clips/01_00m03.47s.mp3,real,
+2,00:20.973,20.973,SPEAKER_01->SPEAKER_02,3.004,clips/02_00m20.97s.mp3,ruido,subida de tono del mismo orador
+3,00:24.567,24.567,SPEAKER_02->SPEAKER_01,8.066,clips/03_00m24.57s.mp3,ruido,subida de tono del mismo orador
+4,02:32.429,152.429,SPEAKER_01->SPEAKER_00,2.312,clips/04_02m32.43s.mp3,real,duplicado del cambio 4/5
+5,02:35.078,155.078,SPEAKER_00->SPEAKER_02,10.75,clips/05_02m35.08s.mp3,real,duplicado del cambio 4/5
+6,02:59.682,179.682,SPEAKER_02->SPEAKER_00,2.261,clips/06_02m59.68s.mp3,real,
+7,03:01.943,181.943,SPEAKER_00->SPEAKER_01,11.509,clips/07_03m01.94s.mp3,real,
+8,03:21.907,201.907,SPEAKER_01->SPEAKER_00,6.378,clips/08_03m21.91s.mp3,ruido,
+9,03:31.846,211.846,SPEAKER_00->SPEAKER_03,1.822,clips/09_03m31.85s.mp3,real,duplicado del cambio 9/10
+10,03:35.423,215.423,SPEAKER_03->SPEAKER_00,3.055,clips/10_03m35.42s.mp3,real,duplicado del cambio 9/10
+11,03:39.490,219.490,SPEAKER_00->SPEAKER_01,15.66,clips/11_03m39.49s.mp3,real,
+12,04:02.812,242.812,SPEAKER_01->SPEAKER_00,2.666,clips/12_04m02.81s.mp3,real,duplicado del cambio 12/13
+13,04:05.680,245.680,SPEAKER_00->SPEAKER_03,133.33,clips/13_04m05.68s.mp3,real,duplicado del cambio 12/13
+14,06:35.986,395.986,SPEAKER_03->SPEAKER_00,16.014,clips/14_06m35.99s.mp3,real,
+15,06:52.810,412.810,SPEAKER_00->SPEAKER_01,73.44,clips/15_06m52.81s.mp3,real,
+16,09:23.825,563.825,SPEAKER_01->SPEAKER_00,7.593,clips/16_09m23.83s.mp3,ruido,
+17,09:32.971,572.971,SPEAKER_00->SPEAKER_04,34.408,clips/17_09m32.97s.mp3,real,
+18,10:14.146,614.146,SPEAKER_04->SPEAKER_00,3.156,clips/18_10m14.15s.mp3,real,duplicado del cambio 18/19
+19,10:17.504,617.504,SPEAKER_00->SPEAKER_01,87.986,clips/19_10m17.50s.mp3,real,duplicado del cambio 18/19
+20,11:46.368,706.368,SPEAKER_01->SPEAKER_04,92.019,clips/20_11m46.37s.mp3,real,
+21,13:25.002,805.002,SPEAKER_04->SPEAKER_00,3.139,clips/21_13m25.00s.mp3,real,duplicado del cambio 21/22
+22,13:28.225,808.225,SPEAKER_00->SPEAKER_01,73.407,clips/22_13m28.23s.mp3,real,duplicado del cambio 21/22
+23,14:50.322,890.322,SPEAKER_01->SPEAKER_00,8.218,clips/23_14m50.32s.mp3,ruido,
+24,15:01.190,901.190,SPEAKER_00->SPEAKER_05,40.348,clips/24_15m01.19s.mp3,real,
+25,15:43.478,943.478,SPEAKER_05->SPEAKER_00,2.11,clips/25_15m43.48s.mp3,real,
+26,15:48.322,948.322,SPEAKER_00->SPEAKER_06,108.675,clips/26_15m48.32s.mp3,real,
+27,17:45.063,1065.063,SPEAKER_06->SPEAKER_00,2.329,clips/27_17m45.06s.mp3,real,duplicado del cambio 27/28
+28,17:48.202,1068.202,SPEAKER_00->SPEAKER_05,64.614,clips/28_17m48.20s.mp3,real,duplicado del cambio 27/28
+29,18:58.418,1138.418,SPEAKER_05->SPEAKER_00,2.346,clips/29_18m58.42s.mp3,real,duplicado del cambio 29/30
+30,19:00.764,1140.764,SPEAKER_00->SPEAKER_06,44.668,clips/30_19m00.76s.mp3,real,duplicado del cambio 29/30
+31,19:55.608,1195.608,SPEAKER_06->SPEAKER_00,8.42,clips/31_19m55.61s.mp3,ruido,
+32,20:04.484,1204.484,SPEAKER_00->SPEAKER_07,86.113,clips/32_20m04.48s.mp3,real,

--- a/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/audit-sheet.md
+++ b/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/audit-sheet.md
@@ -1,0 +1,40 @@
+# Auditoría de oído — 32 candidatos de cambio de orador (run.SC6R8Dgl)
+
+Escuchá cada clip (el cambio está en el segundo ~4). Marcá en la columna
+**label**: `real` si de verdad cambia el orador, `ruido` si no (mismo
+orador, solape, silencio, aplauso, corte falso).
+
+| # | ts | transición | score (s) | clip | label | notas |
+|---|----|-----------|-----------|------|-------|-------|
+| 1 | 00:03.473 | SPEAKER_00->SPEAKER_01 | 17.129 | clips/01_00m03.47s.mp3 |  |  |
+| 2 | 00:20.973 | SPEAKER_01->SPEAKER_02 | 3.004 | clips/02_00m20.97s.mp3 |  |  |
+| 3 | 00:24.567 | SPEAKER_02->SPEAKER_01 | 8.066 | clips/03_00m24.57s.mp3 |  |  |
+| 4 | 02:32.429 | SPEAKER_01->SPEAKER_00 | 2.312 | clips/04_02m32.43s.mp3 |  |  |
+| 5 | 02:35.078 | SPEAKER_00->SPEAKER_02 | 10.75 | clips/05_02m35.08s.mp3 |  |  |
+| 6 | 02:59.682 | SPEAKER_02->SPEAKER_00 | 2.261 | clips/06_02m59.68s.mp3 |  |  |
+| 7 | 03:01.943 | SPEAKER_00->SPEAKER_01 | 11.509 | clips/07_03m01.94s.mp3 |  |  |
+| 8 | 03:21.907 | SPEAKER_01->SPEAKER_00 | 6.378 | clips/08_03m21.91s.mp3 |  |  |
+| 9 | 03:31.846 | SPEAKER_00->SPEAKER_03 | 1.822 | clips/09_03m31.85s.mp3 |  |  |
+| 10 | 03:35.423 | SPEAKER_03->SPEAKER_00 | 3.055 | clips/10_03m35.42s.mp3 |  |  |
+| 11 | 03:39.490 | SPEAKER_00->SPEAKER_01 | 15.66 | clips/11_03m39.49s.mp3 |  |  |
+| 12 | 04:02.812 | SPEAKER_01->SPEAKER_00 | 2.666 | clips/12_04m02.81s.mp3 |  |  |
+| 13 | 04:05.680 | SPEAKER_00->SPEAKER_03 | 133.33 | clips/13_04m05.68s.mp3 |  |  |
+| 14 | 06:35.986 | SPEAKER_03->SPEAKER_00 | 16.014 | clips/14_06m35.99s.mp3 |  |  |
+| 15 | 06:52.810 | SPEAKER_00->SPEAKER_01 | 73.44 | clips/15_06m52.81s.mp3 |  |  |
+| 16 | 09:23.825 | SPEAKER_01->SPEAKER_00 | 7.593 | clips/16_09m23.83s.mp3 |  |  |
+| 17 | 09:32.971 | SPEAKER_00->SPEAKER_04 | 34.408 | clips/17_09m32.97s.mp3 |  |  |
+| 18 | 10:14.146 | SPEAKER_04->SPEAKER_00 | 3.156 | clips/18_10m14.15s.mp3 |  |  |
+| 19 | 10:17.504 | SPEAKER_00->SPEAKER_01 | 87.986 | clips/19_10m17.50s.mp3 |  |  |
+| 20 | 11:46.368 | SPEAKER_01->SPEAKER_04 | 92.019 | clips/20_11m46.37s.mp3 |  |  |
+| 21 | 13:25.002 | SPEAKER_04->SPEAKER_00 | 3.139 | clips/21_13m25.00s.mp3 |  |  |
+| 22 | 13:28.225 | SPEAKER_00->SPEAKER_01 | 73.407 | clips/22_13m28.23s.mp3 |  |  |
+| 23 | 14:50.322 | SPEAKER_01->SPEAKER_00 | 8.218 | clips/23_14m50.32s.mp3 |  |  |
+| 24 | 15:01.190 | SPEAKER_00->SPEAKER_05 | 40.348 | clips/24_15m01.19s.mp3 |  |  |
+| 25 | 15:43.478 | SPEAKER_05->SPEAKER_00 | 2.11 | clips/25_15m43.48s.mp3 |  |  |
+| 26 | 15:48.322 | SPEAKER_00->SPEAKER_06 | 108.675 | clips/26_15m48.32s.mp3 |  |  |
+| 27 | 17:45.063 | SPEAKER_06->SPEAKER_00 | 2.329 | clips/27_17m45.06s.mp3 |  |  |
+| 28 | 17:48.202 | SPEAKER_00->SPEAKER_05 | 64.614 | clips/28_17m48.20s.mp3 |  |  |
+| 29 | 18:58.418 | SPEAKER_05->SPEAKER_00 | 2.346 | clips/29_18m58.42s.mp3 |  |  |
+| 30 | 19:00.764 | SPEAKER_00->SPEAKER_06 | 44.668 | clips/30_19m00.76s.mp3 |  |  |
+| 31 | 19:55.608 | SPEAKER_06->SPEAKER_00 | 8.42 | clips/31_19m55.61s.mp3 |  |  |
+| 32 | 20:04.484 | SPEAKER_00->SPEAKER_07 | 86.113 | clips/32_20m04.48s.mp3 |  |  |

--- a/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/build_audit.py
+++ b/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/build_audit.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+"""Build a ground-truth audit kit for the pyannote speaker-change candidates.
+
+Reads postprocessed-speaker-changes.json, cuts a short mp3 clip centred on each
+candidate change point, and emits a labelling sheet (CSV + Markdown) for a human
+to mark each change as real / noise. Precision and a threshold suggestion are
+computed later from the filled-in labels.
+"""
+from __future__ import annotations
+
+import csv
+import json
+import subprocess
+from pathlib import Path
+
+HERE = Path(__file__).parent
+WAV = HERE / "calibration-1310s.wav"
+CHANGES = HERE / "postprocessed-speaker-changes.json"
+CLIPS = HERE / "clips"
+PAD_SECONDS = 4.0  # audio before and after the change point
+WAV_DURATION = 1309.9935
+
+CLIPS.mkdir(exist_ok=True)
+
+
+def fmt_mmss(seconds: float) -> str:
+    m, s = divmod(seconds, 60)
+    return f"{int(m):02d}m{s:05.2f}s"
+
+
+def main() -> None:
+    data = json.loads(CHANGES.read_text())
+    changes = data["speaker_changes"]
+    rows = []
+    for i, ch in enumerate(changes, start=1):
+        start = float(ch["start_seconds"])
+        clip_start = max(0.0, start - PAD_SECONDS)
+        clip_len = min(WAV_DURATION, start + PAD_SECONDS) - clip_start
+        clip_name = f"{i:02d}_{fmt_mmss(start)}.mp3"
+        clip_path = CLIPS / clip_name
+        subprocess.run(
+            [
+                "ffmpeg", "-y", "-loglevel", "error",
+                "-ss", f"{clip_start:.3f}", "-i", str(WAV),
+                "-t", f"{clip_len:.3f}",
+                "-ac", "1", "-ar", "16000", "-q:a", "4",
+                str(clip_path),
+            ],
+            check=True,
+        )
+        rows.append(
+            {
+                "idx": i,
+                "timestamp": ch["timestamp"],
+                "start_seconds": f"{start:.3f}",
+                "transition": f'{ch["from_speaker"]}->{ch["to_speaker"]}',
+                "score_block_seconds": ch["confirmed_block_duration_seconds"],
+                "clip": f"clips/{clip_name}",
+                "label": "",  # fill: real | ruido
+                "notes": "",
+            }
+        )
+
+    fields = [
+        "idx", "timestamp", "start_seconds", "transition",
+        "score_block_seconds", "clip", "label", "notes",
+    ]
+    with (HERE / "audit-sheet.csv").open("w", newline="") as fh:
+        writer = csv.DictWriter(fh, fieldnames=fields)
+        writer.writeheader()
+        writer.writerows(rows)
+
+    lines = [
+        "# Auditoría de oído — 32 candidatos de cambio de orador (run.SC6R8Dgl)",
+        "",
+        "Escuchá cada clip (el cambio está en el segundo ~4). Marcá en la columna",
+        "**label**: `real` si de verdad cambia el orador, `ruido` si no (mismo",
+        "orador, solape, silencio, aplauso, corte falso).",
+        "",
+        "| # | ts | transición | score (s) | clip | label | notas |",
+        "|---|----|-----------|-----------|------|-------|-------|",
+    ]
+    for r in rows:
+        lines.append(
+            f'| {r["idx"]} | {r["timestamp"]} | {r["transition"]} | '
+            f'{r["score_block_seconds"]} | {r["clip"]} |  |  |'
+        )
+    (HERE / "audit-sheet.md").write_text("\n".join(lines) + "\n")
+    print(f"OK: {len(rows)} clips + audit-sheet.csv + audit-sheet.md")
+
+
+if __name__ == "__main__":
+    main()

--- a/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/postprocessed-speaker-changes.json
+++ b/benchmarks/pyannote_diarization/audit/run.SC6R8Dgl/postprocessed-speaker-changes.json
@@ -1,0 +1,238 @@
+{
+  "source": "/volume1/docker/airflow/pyannote_diarization_benchmark/output/run.SC6R8Dgl/summary.json",
+  "rules": {
+    "min_track_seconds": 0.5,
+    "same_speaker_gap_seconds": 1.0,
+    "min_change_block_seconds": 1.5,
+    "overlap_policy": "preserve the currently active speaker; otherwise choose the longest active track"
+  },
+  "raw_turn_count": 125,
+  "tracks_after_min_duration_filter": 117,
+  "speaker_change_count": 32,
+  "speaker_changes": [
+    {
+      "timestamp": "00:03.473",
+      "start_seconds": 3.473,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 17.129
+    },
+    {
+      "timestamp": "00:20.973",
+      "start_seconds": 20.973,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_02",
+      "confirmed_block_duration_seconds": 3.004
+    },
+    {
+      "timestamp": "00:24.567",
+      "start_seconds": 24.567,
+      "from_speaker": "SPEAKER_02",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 8.066
+    },
+    {
+      "timestamp": "02:32.429",
+      "start_seconds": 152.429,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 2.312
+    },
+    {
+      "timestamp": "02:35.078",
+      "start_seconds": 155.078,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_02",
+      "confirmed_block_duration_seconds": 10.75
+    },
+    {
+      "timestamp": "02:59.682",
+      "start_seconds": 179.682,
+      "from_speaker": "SPEAKER_02",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 2.261
+    },
+    {
+      "timestamp": "03:01.943",
+      "start_seconds": 181.943,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 11.509
+    },
+    {
+      "timestamp": "03:21.907",
+      "start_seconds": 201.907,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 6.378
+    },
+    {
+      "timestamp": "03:31.846",
+      "start_seconds": 211.846,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_03",
+      "confirmed_block_duration_seconds": 1.822
+    },
+    {
+      "timestamp": "03:35.423",
+      "start_seconds": 215.423,
+      "from_speaker": "SPEAKER_03",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 3.055
+    },
+    {
+      "timestamp": "03:39.490",
+      "start_seconds": 219.49,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 15.66
+    },
+    {
+      "timestamp": "04:02.812",
+      "start_seconds": 242.812,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 2.666
+    },
+    {
+      "timestamp": "04:05.680",
+      "start_seconds": 245.68,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_03",
+      "confirmed_block_duration_seconds": 133.33
+    },
+    {
+      "timestamp": "06:35.986",
+      "start_seconds": 395.986,
+      "from_speaker": "SPEAKER_03",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 16.014
+    },
+    {
+      "timestamp": "06:52.810",
+      "start_seconds": 412.81,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 73.44
+    },
+    {
+      "timestamp": "09:23.825",
+      "start_seconds": 563.825,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 7.593
+    },
+    {
+      "timestamp": "09:32.971",
+      "start_seconds": 572.971,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_04",
+      "confirmed_block_duration_seconds": 34.408
+    },
+    {
+      "timestamp": "10:14.146",
+      "start_seconds": 614.146,
+      "from_speaker": "SPEAKER_04",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 3.156
+    },
+    {
+      "timestamp": "10:17.504",
+      "start_seconds": 617.504,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 87.986
+    },
+    {
+      "timestamp": "11:46.368",
+      "start_seconds": 706.368,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_04",
+      "confirmed_block_duration_seconds": 92.019
+    },
+    {
+      "timestamp": "13:25.002",
+      "start_seconds": 805.002,
+      "from_speaker": "SPEAKER_04",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 3.139
+    },
+    {
+      "timestamp": "13:28.225",
+      "start_seconds": 808.225,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_01",
+      "confirmed_block_duration_seconds": 73.407
+    },
+    {
+      "timestamp": "14:50.322",
+      "start_seconds": 890.322,
+      "from_speaker": "SPEAKER_01",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 8.218
+    },
+    {
+      "timestamp": "15:01.190",
+      "start_seconds": 901.19,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_05",
+      "confirmed_block_duration_seconds": 40.348
+    },
+    {
+      "timestamp": "15:43.478",
+      "start_seconds": 943.478,
+      "from_speaker": "SPEAKER_05",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 2.11
+    },
+    {
+      "timestamp": "15:48.322",
+      "start_seconds": 948.322,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_06",
+      "confirmed_block_duration_seconds": 108.675
+    },
+    {
+      "timestamp": "17:45.063",
+      "start_seconds": 1065.063,
+      "from_speaker": "SPEAKER_06",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 2.329
+    },
+    {
+      "timestamp": "17:48.202",
+      "start_seconds": 1068.202,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_05",
+      "confirmed_block_duration_seconds": 64.614
+    },
+    {
+      "timestamp": "18:58.418",
+      "start_seconds": 1138.418,
+      "from_speaker": "SPEAKER_05",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 2.346
+    },
+    {
+      "timestamp": "19:00.764",
+      "start_seconds": 1140.764,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_06",
+      "confirmed_block_duration_seconds": 44.668
+    },
+    {
+      "timestamp": "19:55.608",
+      "start_seconds": 1195.608,
+      "from_speaker": "SPEAKER_06",
+      "to_speaker": "SPEAKER_00",
+      "confirmed_block_duration_seconds": 8.42
+    },
+    {
+      "timestamp": "20:04.484",
+      "start_seconds": 1204.484,
+      "from_speaker": "SPEAKER_00",
+      "to_speaker": "SPEAKER_07",
+      "confirmed_block_duration_seconds": 86.113
+    }
+  ]
+}


### PR DESCRIPTION
Sube el `AUDIT_REPORT.md` de la Fase 0 (y planilla + scripts + los 32 candidatos JSON) que el archive de #86 referencia. El WAV/mp3 quedan gitignoreados (reproducibles desde el run del NAS). Solo evidencia; no toca código.