### PR TITLE
fix(title): anchor thumbnail titles to key_speakers, drop politician-name keywords

### DIFF
--- a/congress_videos/config/ai_prompts.py
+++ b/congress_videos/config/ai_prompts.py
@@ -223,12 +223,11 @@ ART_DIRECTION_RETRY_INSTRUCTION = (
 # Thumbnail Title Generation (Pikzels + OpenAI pipeline)
 
 # Editorial keyword lists — edit these to steer LLM word choice at the persona level.
-# Source: issue #60 verbatim.
+# Source: issue #60 verbatim. IMPORTANT: keep topic/register words only — NO proper
+# politician names. Proper names are constrained via key_speakers injection at
+# prompt time (see generate_title + THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION below).
 TITLE_PRIORITY_KEYWORDS: tuple[str, ...] = (
     "corrupción",
-    "Sánchez",
-    "Feijóo",
-    "Yolanda Díaz",
 )
 
 TITLE_WORDS_TO_AVOID: tuple[str, ...] = (
@@ -238,15 +237,33 @@ TITLE_WORDS_TO_AVOID: tuple[str, ...] = (
     "eutanasia",
 )
 
-# Soft speaker hint injected into the user prompt when key_speakers is truthy.
+# Known placeholder tokens for unidentified speakers. Match case-insensitively on
+# .strip().lower(). Extend this set if new tokens surface in production data.
+SPEAKER_PLACEHOLDERS: frozenset[str] = frozenset({
+    "interviniente no identificado",
+    "ponente desconocido",
+    "orador desconocido",
+})
+
+# Hard prohibition injected into the user prompt when real speakers (non-placeholder)
+# are present. ONLY names from this list may appear in the title.
 THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION = (
-    "Si es natural, menciona a alguno de estos protagonistas del debate:\n{speaker_list}"
+    "SOLO puedes nombrar a personas de esta lista de ponentes del debate. "
+    "No atribuyas la frase a nadie que no aparezca aquí:\n{speaker_list}"
+)
+
+# Injected into the user prompt when key_speakers is non-empty but ALL entries are
+# placeholder tokens (or key_speakers is falsy). The title must not name any person.
+THUMBNAIL_TITLE_NAMELESS_INSTRUCTION = (
+    "INSTRUCCIÓN CRÍTICA: no hay ponentes identificados en este debate. "
+    "El título NO puede empezar con el nombre de una persona; "
+    "usa formato sin nombre ([Verbo] + complemento)."
 )
 
 THUMBNAIL_TITLE_SYSTEM_PROMPT = (
     "Eres un redactor político experto en titulares de alto impacto para YouTube. "
     "Escribe titulares declarativos en formato de noticias: [Nombre] + verbo de acción + complemento o cita. "
-    "Ejemplos correctos: «Sánchez anuncia recortes en pensiones», «Feijóo acusa al Gobierno de corrupción». "
+    "Ejemplos correctos: «El portavoz anuncia recortes en pensiones», «El líder de la oposición acusa al Gobierno de corrupción». "
     "NUNCA uses signos de interrogación (¿?): ningún titular puede ser una pregunta. "
     "Los títulos deben generar urgencia y curiosidad sin perder rigor informativo. "
     "Varía el registro emocional entre títulos consecutivos: alterna entre urgencia, pérdida, "

--- a/congress_videos/modules/thumbnail_generation.py
+++ b/congress_videos/modules/thumbnail_generation.py
@@ -29,6 +29,8 @@ from congress_videos.config.ai_prompts import (
     ART_DIRECTION_USER_PROMPT_TEMPLATE,
     LAPIDARY_RANKING_SYSTEM_PROMPT,
     LAPIDARY_RANKING_USER_TEMPLATE,
+    SPEAKER_PLACEHOLDERS,
+    THUMBNAIL_TITLE_NAMELESS_INSTRUCTION,
     THUMBNAIL_TITLE_SIBLING_INSTRUCTION,
     THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION,
     THUMBNAIL_TITLE_SYSTEM_PROMPT,
@@ -200,6 +202,34 @@ def extract_lapidary_quote(
         return None
 
     return candidates[idx]
+
+
+def _real_speakers(key_speakers: list | None) -> list[str]:
+    """Return the subset of key_speakers that are real (non-placeholder) names.
+
+    Normalizes each entry (dict → name string), strips whitespace, drops empty
+    strings, and filters out any entry whose lowercased form appears in
+    SPEAKER_PLACEHOLDERS (case-insensitive comparison).
+
+    Args:
+        key_speakers: List of speaker entries (strings or dicts with a ``name`` key),
+            or None.
+
+    Returns:
+        A list of real speaker name strings; empty list when none survive.
+    """
+    if not key_speakers:
+        return []
+    result: list[str] = []
+    for entry in key_speakers:
+        name = entry.get("name", "") if isinstance(entry, dict) else str(entry)
+        name = name.strip()
+        if not name:
+            continue
+        if name.lower() in SPEAKER_PLACEHOLDERS:
+            continue
+        result.append(name)
+    return result
 
 
 # ---------------------------------------------------------------------------
@@ -482,14 +512,17 @@ def generate_title(
                 sibling_list=sibling_list
             )
             user_prompt += f"\n\n{sibling_block}"
-        if key_speakers:
-            speaker_list = ", ".join(
-                s["name"] if isinstance(s, dict) else s for s in key_speakers
+        real = _real_speakers(key_speakers)
+        if real:
+            user_prompt += "\n\n" + THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION.format(
+                speaker_list=", ".join(real)
             )
-            speaker_block = THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION.format(
-                speaker_list=speaker_list
-            )
-            user_prompt += f"\n\n{speaker_block}"
+        else:
+            # Falsy key_speakers (None / []) and all-placeholder lists both map
+            # to the nameless format — this is the hard guarantee that prevents
+            # the model from hallucinating politician names when no real speaker
+            # is identified.
+            user_prompt += f"\n\n{THUMBNAIL_TITLE_NAMELESS_INSTRUCTION}"
         if extra_instruction:
             user_prompt += f"\n\nINSTRUCCIÓN ADICIONAL: {extra_instruction}"
 

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -235,6 +235,7 @@ def trigger_thumbnail_generation(ti, **context) -> str | None:
         "youtube_video_id": str(chapter_id),
         **{key: thumbnail_config[key] for key in required_values},
         "slug": thumbnail_config.get("slug"),
+        "key_speakers": thumbnail_config.get("key_speakers") or [],
     }
     if "srt_fragment" in thumbnail_config:
         child_conf["srt_fragment"] = thumbnail_config["srt_fragment"]

--- a/tests/congress_videos/modules/test_thumbnail_generation.py
+++ b/tests/congress_videos/modules/test_thumbnail_generation.py
@@ -2949,3 +2949,239 @@ class TestArtDirectArchetypeWiring:
         assert result["archetype"] == "generico", (
             "Fallback brief archetype must be 'generico'"
         )
+
+
+# ---------------------------------------------------------------------------
+# issue #91: title-speaker-attribution Phase A — ai_prompts constants
+# ---------------------------------------------------------------------------
+
+
+class TestKeywordTupleContainsNoPoliticianNames:
+    """T-01 RED: TITLE_PRIORITY_KEYWORDS must not contain politician proper names."""
+
+    def test_keyword_tuple_contains_no_politician_names(self) -> None:
+        """TITLE_PRIORITY_KEYWORDS must not include Sánchez, Feijóo, or Yolanda Díaz."""
+        from congress_videos.config.ai_prompts import TITLE_PRIORITY_KEYWORDS
+
+        assert "Sánchez" not in TITLE_PRIORITY_KEYWORDS, (
+            "TITLE_PRIORITY_KEYWORDS must not contain 'Sánchez'"
+        )
+        assert "Feijóo" not in TITLE_PRIORITY_KEYWORDS, (
+            "TITLE_PRIORITY_KEYWORDS must not contain 'Feijóo'"
+        )
+        assert "Yolanda Díaz" not in TITLE_PRIORITY_KEYWORDS, (
+            "TITLE_PRIORITY_KEYWORDS must not contain 'Yolanda Díaz'"
+        )
+        assert "corrupción" in TITLE_PRIORITY_KEYWORDS, (
+            "TITLE_PRIORITY_KEYWORDS must still contain 'corrupción'"
+        )
+
+
+class TestSystemPromptPrizacausaClauseNoPoliticians:
+    """T-02 RED: THUMBNAIL_TITLE_SYSTEM_PROMPT PRIORIZA clause must name no politicians."""
+
+    def test_system_prompt_prioriza_clause_names_no_politicians(self) -> None:
+        """THUMBNAIL_TITLE_SYSTEM_PROMPT must not contain politician names Sánchez/Feijóo/Yolanda Díaz."""
+        from congress_videos.config.ai_prompts import THUMBNAIL_TITLE_SYSTEM_PROMPT
+
+        assert "Sánchez" not in THUMBNAIL_TITLE_SYSTEM_PROMPT, (
+            "THUMBNAIL_TITLE_SYSTEM_PROMPT must not contain 'Sánchez'"
+        )
+        assert "Feijóo" not in THUMBNAIL_TITLE_SYSTEM_PROMPT, (
+            "THUMBNAIL_TITLE_SYSTEM_PROMPT must not contain 'Feijóo'"
+        )
+        assert "Yolanda Díaz" not in THUMBNAIL_TITLE_SYSTEM_PROMPT, (
+            "THUMBNAIL_TITLE_SYSTEM_PROMPT must not contain 'Yolanda Díaz'"
+        )
+        assert any(
+            kw in THUMBNAIL_TITLE_SYSTEM_PROMPT
+            for kw in ("corrupción", "PRIORIZA", "prioriza")
+        ), (
+            "THUMBNAIL_TITLE_SYSTEM_PROMPT must still contain a retained topic word"
+        )
+
+
+class TestSpeakersInstructionIsProhibition:
+    """T-03 RED: THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION must be a hard prohibition."""
+
+    def test_speakers_instruction_is_hard_prohibition(self) -> None:
+        """THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION must contain hard-prohibition language, not soft hint."""
+        from congress_videos.config.ai_prompts import THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION
+
+        prohibition_phrases = ("SOLO puedes nombrar", "SOLO puedes", "solo puedes nombrar")
+        assert any(p in THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION for p in prohibition_phrases), (
+            "THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION must contain hard prohibition "
+            f"(one of {prohibition_phrases})"
+        )
+        soft_phrases = ("Si es natural", "menciona a alguno")
+        assert not any(p in THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION for p in soft_phrases), (
+            "THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION must NOT contain soft suggestion text"
+        )
+
+
+# ---------------------------------------------------------------------------
+# issue #91: title-speaker-attribution Phase C — _real_speakers helper
+# ---------------------------------------------------------------------------
+
+
+class TestRealSpeakersHelper:
+    """T-08 RED: _real_speakers pure helper — various input scenarios."""
+
+    def test_none_returns_empty_list(self) -> None:
+        """_real_speakers(None) must return []."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers(None) == []
+
+    def test_empty_list_returns_empty_list(self) -> None:
+        """_real_speakers([]) must return []."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers([]) == []
+
+    def test_empty_string_entry_dropped(self) -> None:
+        """_real_speakers(['']) must return [] (empty string is not a real name)."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers([""]) == []
+
+    def test_real_name_string_returned(self) -> None:
+        """_real_speakers(['Cervera Pinar']) must return ['Cervera Pinar']."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers(["Cervera Pinar"]) == ["Cervera Pinar"]
+
+    def test_dict_entry_extracts_name(self) -> None:
+        """_real_speakers([{'name': 'Ana Pastor'}]) must return ['Ana Pastor']."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers([{"name": "Ana Pastor"}]) == ["Ana Pastor"]
+
+    def test_placeholder_interviniente_no_identificado_filtered(self) -> None:
+        """_real_speakers(['Interviniente no identificado']) must return []."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers(["Interviniente no identificado"]) == []
+
+    def test_placeholder_uppercase_filtered(self) -> None:
+        """_real_speakers(['INTERVINIENTE NO IDENTIFICADO']) must return [] (case-insensitive)."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers(["INTERVINIENTE NO IDENTIFICADO"]) == []
+
+    def test_mixed_placeholder_and_real_returns_real_only(self) -> None:
+        """_real_speakers(['Interviniente no identificado', 'Cervera Pinar']) → ['Cervera Pinar']."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        result = _real_speakers(["Interviniente no identificado", "Cervera Pinar"])
+        assert result == ["Cervera Pinar"]
+
+    def test_ponente_desconocido_filtered(self) -> None:
+        """_real_speakers(['Ponente desconocido']) must return []."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers(["Ponente desconocido"]) == []
+
+    def test_orador_desconocido_filtered(self) -> None:
+        """_real_speakers(['Orador desconocido']) must return []."""
+        from congress_videos.modules.thumbnail_generation import _real_speakers
+
+        assert _real_speakers(["Orador desconocido"]) == []
+
+
+# ---------------------------------------------------------------------------
+# issue #91: title-speaker-attribution Phase C — generate_title 3-state branch
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateTitlePromptInjection:
+    """T-09 RED: generate_title injects correct speaker block based on 3-state logic."""
+
+    def _make_best(self) -> dict:
+        return {"style": "A", "prompt": "debate parlamentario"}
+
+    def _make_cfg(self) -> dict:
+        return {
+            "styles": [],
+            "participants_lookup": lambda slug: None,
+            "party_logo_map": None,
+        }
+
+    def _capture_prompt(self, mocker, key_speakers):
+        """Helper: call generate_title and return the first captured user_prompt."""
+        from congress_videos.modules.thumbnail_generation import generate_title
+
+        captured: list[str] = []
+
+        def _side(system_prompt, user_prompt, **kw):
+            captured.append(user_prompt)
+            return {"data": {"title": "Un título válido"}, "error": None}
+
+        mocker.patch(
+            "congress_videos.modules.thumbnail_generation.generate_json_completion",
+            side_effect=_side,
+        )
+        generate_title(
+            "Debate summary",
+            self._make_best(),
+            self._make_cfg(),
+            key_speakers=key_speakers,
+        )
+        return captured[0] if captured else ""
+
+    def test_real_speaker_injects_prohibition_not_nameless(self, mocker) -> None:
+        """key_speakers=['Cervera Pinar'] → user_prompt has prohibition + name, no nameless block."""
+        prompt = self._capture_prompt(mocker, ["Cervera Pinar"])
+
+        assert "SOLO puedes nombrar" in prompt or "solo puedes nombrar" in prompt.lower(), (
+            "Prompt must contain hard prohibition phrase when real speaker present"
+        )
+        assert "Cervera Pinar" in prompt, "Prompt must name the real speaker"
+        assert "no hay ponentes identificados" not in prompt.lower(), (
+            "Nameless instruction must NOT appear when real speaker is present"
+        )
+
+    def test_all_placeholder_injects_nameless_not_prohibition(self, mocker) -> None:
+        """key_speakers=['Interviniente no identificado'] → prompt has nameless instruction, no name."""
+        prompt = self._capture_prompt(mocker, ["Interviniente no identificado"])
+
+        assert "no hay ponentes identificados" in prompt.lower(), (
+            "Nameless instruction must appear when all speakers are placeholders"
+        )
+        assert "Interviniente no identificado" not in prompt or (
+            "SOLO puedes nombrar" not in prompt
+        ), (
+            "Placeholder name must not be listed in a speaker prohibition block"
+        )
+
+    def test_mixed_list_uses_real_name_prohibition(self, mocker) -> None:
+        """key_speakers=['Interviniente no identificado', 'Cervera Pinar'] → prohibition with real name only."""
+        prompt = self._capture_prompt(
+            mocker, ["Interviniente no identificado", "Cervera Pinar"]
+        )
+
+        assert "Cervera Pinar" in prompt, "Real name must appear in prohibition"
+        assert "no hay ponentes identificados" not in prompt.lower(), (
+            "Nameless instruction must NOT appear when real speaker exists"
+        )
+        assert "Interviniente no identificado" not in prompt or (
+            "SOLO puedes nombrar" in prompt
+        ), (
+            "Placeholder must not appear in the speaker list sent to the model"
+        )
+
+    def test_none_key_speakers_injects_nameless(self, mocker) -> None:
+        """key_speakers=None → user_prompt MUST contain nameless instruction (same as empty list)."""
+        prompt = self._capture_prompt(mocker, None)
+
+        assert "no hay ponentes identificados" in prompt.lower(), (
+            "Nameless instruction must appear when key_speakers=None"
+        )
+
+    def test_empty_key_speakers_injects_nameless(self, mocker) -> None:
+        """key_speakers=[] → user_prompt MUST contain nameless instruction (same as None)."""
+        prompt = self._capture_prompt(mocker, [])
+
+        assert "no hay ponentes identificados" in prompt.lower(), (
+            "Nameless instruction must appear when key_speakers=[]"
+        )

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -658,7 +658,7 @@ class TestTriggerThumbnailGeneration:
 
         trigger.assert_called_once_with(
             dag_id="generic_thumbnail_generator",
-            conf={"youtube_video_id": "42", **self.THUMBNAIL_CONFIG},
+            conf={"youtube_video_id": "42", **self.THUMBNAIL_CONFIG, "key_speakers": []},
             run_id="chapter_thumbnail_test_run",
         )
 
@@ -688,7 +688,7 @@ class TestTriggerThumbnailGeneration:
 
         trigger.assert_called_once_with(
             dag_id="generic_thumbnail_generator",
-            conf={"youtube_video_id": "42", **config_without_speaker},
+            conf={"youtube_video_id": "42", **config_without_speaker, "key_speakers": []},
             run_id="chapter_thumbnail_test_run",
         )
 
@@ -1097,3 +1097,89 @@ class TestTriggerThumbnailGenerationForwardsSrt:
         trigger_thumbnail_generation(ti, run_id="test_run")
 
         assert "srt_fragment" not in captured_confs[0]
+
+
+# ---------------------------------------------------------------------------
+# issue #91: title-speaker-attribution — key_speakers forwarding (T-05, T-06)
+# ---------------------------------------------------------------------------
+
+
+class TestTriggerThumbnailGenerationForwardsKeySpeakers:
+    """trigger_thumbnail_generation must forward key_speakers into child_conf."""
+
+    def _make_mock_run(self, mocker, captured_confs):
+        mock_run = MagicMock()
+        mock_run.run_id = "thumb_run_speakers"
+        mock_run.state = "success"
+        mock_run.refresh_from_db = MagicMock()
+
+        def _fake_trigger(dag_id, conf, run_id):
+            captured_confs.append(conf)
+            return mock_run
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api",
+            side_effect=_fake_trigger,
+        )
+        mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.XCom.get_one",
+            return_value={
+                "success": True,
+                "chapter_id": 42,
+                "output_path": "/some/path.png",
+                "title": "Un título",
+            },
+        )
+        return mock_run
+
+    def test_key_speakers_forwarded_when_present(self, mocker):
+        """When thumbnail_config has key_speakers, child_conf must include the list."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs = []
+        self._make_mock_run(mocker, captured_confs)
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    "key_speakers": ["Cervera Pinar"],
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert len(captured_confs) == 1
+        assert captured_confs[0].get("key_speakers") == ["Cervera Pinar"]
+
+    def test_key_speakers_forwarded_as_empty_list_when_absent(self, mocker):
+        """When thumbnail_config lacks key_speakers, child_conf must have key_speakers=[]."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs = []
+        self._make_mock_run(mocker, captured_confs)
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    # No key_speakers key
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert len(captured_confs) == 1
+        assert "key_speakers" in captured_confs[0]
+        assert captured_confs[0]["key_speakers"] == []


### PR DESCRIPTION
Closes #91

## Summary
- El generador de títulos de miniatura ya no atribuye citas a personas que **no intervinieron** en el debate (caso prod `1hTGHjydxVo`: título "Yolanda Díaz…" cuando la ponente real era Cervera Pinar/VOX).
- El nombre del título queda **anclado a `key_speakers`/`speakers`**; sin ponente identificado, formato **sin nombre**.
- Se saca de `TITLE_PRIORITY_KEYWORDS` los nombres propios de políticos, que inducían la alucinación de atribución.

## Root causes (todos corregidos)
1. `TITLE_PRIORITY_KEYWORDS` contenía nombres propios (Sánchez, Feijóo, Yolanda Díaz) inyectados como "PRIORIZA…".
2. `key_speakers` se guardaba en `thumbnail_config` pero se **caía** al armar `child_conf` → nunca llegaba al generador.
3. La instrucción de ponentes era un hint blando, no una prohibición.

## Changes
| File | Change |
|------|--------|
| `congress_videos/config/ai_prompts.py` | `TITLE_PRIORITY_KEYWORDS`→`("corrupción",)`; `SPEAKER_PLACEHOLDERS` frozenset; `THUMBNAIL_TITLE_SPEAKERS_INSTRUCTION` endurecida a prohibición; `THUMBNAIL_TITLE_NAMELESS_INSTRUCTION`; ejemplos del system prompt sin nombres propios |
| `congress_videos/youtube_upload_dag.py` | Forward `key_speakers` en `child_conf` |
| `congress_videos/modules/thumbnail_generation.py` | Helper puro `_real_speakers()` + branch con nombre / sin nombre en `generate_title` (None/[]/todo-placeholder → sin nombre) |
| tests | 20 tests nuevos (helper, prohibición, nameless, mixed-list, forwarding) |

## Interacción con #60
Se preserva el formato noticia `[Nombre]+verbo` cuando hay ponente real; sólo pasa a formato sin nombre cuando no hay ninguno identificado.

## Test plan
- [x] `uv run pytest` — 2233 passed, 1 skipped, 87.12% cobertura (gate ≥80% PASS)
- [x] Tests #91 en aislamiento: 20 nuevos GREEN (TDD RED→GREEN)
- [x] Rama basada directamente en `dev`; el diff es exclusivamente #91

## Notas
- SDD completo (explore→propose→spec→design→tasks→apply→verify) — artefactos en Engram.
- Issue #91 sigue con `needs-triage` (sin `status:approved`); ningún workflow de PR lo bloquea en este repo.