### PR TITLE
feat(#88): PR1 — migraciones 024/025 + planner puro de materialización

### DIFF
--- a/congress_videos/config/paths.py
+++ b/congress_videos/config/paths.py
@@ -197,6 +197,27 @@ def get_short_file_path(chapter_id: int, clip_id: str) -> str:
     return f"{get_shorts_dir(chapter_id)}/{clip_id}.mp4"
 
 
+def get_turn_video_path(date: str, video_id: str, turn_id: int) -> str:
+    """Return the canonical output path for a materialized speaker-turn video.
+
+    The path follows the convention::
+
+        {DOWNLOADS_DIR}/{date}/{video_id}/turns/{turn_id}/turn_video.mp4
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        date:     Recording date in YYYY-MM-DD format (e.g. ``"2025-10-08"``).
+        video_id: YouTube video identifier (e.g. ``"hy1cnx-0Oww"``).
+        turn_id:  Database ``turn_id`` from ``speaker_turns``.
+
+    Returns:
+        Absolute path string to the turn video MP4 file.
+    """
+    return f"{get_download_video_path(date, video_id)}/turns/{turn_id}/turn_video.mp4"
+
+
 # -------------------------
 # Path Validation
 # -------------------------

--- a/congress_videos/modules/materialization.py
+++ b/congress_videos/modules/materialization.py
@@ -1,0 +1,254 @@
+"""Pure planning module for speaker-turn video materialization.
+
+Derives ``MaterializationPlan`` records from turn rows and pre-filtered
+approved trim proposals. Contains **no ffmpeg, no database, no Airflow
+imports** — all logic is deterministic and unit-testable with plain dicts.
+
+The planner decides *what* to cut; the execution layer (PR2) decides *how*
+to cut it using ffmpeg helpers.
+
+Usage::
+
+    plans = plan_turn_materialization(turn_rows, approved_trim_rows)
+    for plan in plans:
+        ...  # delegate to execution layer
+
+Where ``turn_rows`` are dicts with keys:
+    turn_id, chapter_id, start_seconds, end_seconds
+
+And ``approved_trim_rows`` are dicts with keys:
+    turn_id, start_seconds, end_seconds, is_approved, is_voice_free
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "KeepInterval",
+    "MaterializationPlan",
+    "MIN_LONG_INTERVENTION_SECS",
+    "GROUP_GAP_TOLERANCE_SECS",
+    "plan_turn_materialization",
+]
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+MIN_LONG_INTERVENTION_SECS: float = 300.0
+"""Minimum duration (seconds) for a speaker turn to be treated as a
+long intervention requiring its own individual output video."""
+
+GROUP_GAP_TOLERANCE_SECS: float = 0.5
+"""Maximum gap (seconds) between two consecutive short turns in the same
+chapter that still allows them to be grouped into a single continuous cut."""
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KeepInterval:
+    """A single continuous time window to retain in the output video.
+
+    Attributes:
+        start: Absolute start of the interval in seconds.
+        end:   Absolute end of the interval in seconds.
+    """
+
+    start: float
+    end: float
+
+
+@dataclass(frozen=True)
+class MaterializationPlan:
+    """Complete materialization recipe for one output video.
+
+    Attributes:
+        turn_ids:       Tuple of constituent turn_ids (>1 only for grouped
+                        short turns).
+        chapter_id:     chapter_id shared by all turns in this plan.
+        keep_intervals: Ordered, non-overlapping intervals to retain.
+                        A single element means stream-copy is safe (no excision).
+        output_turn_id: Naming key — always the first (lowest) turn_id in the plan.
+        needs_reencode: True when excision forces re-encoding (len(keep_intervals) > 1).
+                        AV1-forced re-encoding is determined at execution time.
+    """
+
+    turn_ids: tuple[int, ...]
+    chapter_id: int
+    keep_intervals: tuple[KeepInterval, ...]
+    output_turn_id: int
+    needs_reencode: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_keep_intervals(
+    turn_start: float,
+    turn_end: float,
+    approved_trims: list[dict],
+) -> tuple[KeepInterval, ...]:
+    """Invert approved trim intervals within [turn_start, turn_end].
+
+    Produces the ordered list of keeper windows by walking through the
+    sorted trim list and emitting the gaps. Zero-duration segments
+    (when a trim exactly touches a boundary) are dropped.
+
+    Args:
+        turn_start:     Absolute start of the turn in seconds.
+        turn_end:       Absolute end of the turn in seconds.
+        approved_trims: Already-filtered approved+voice-free trim dicts.
+
+    Returns:
+        Tuple of KeepInterval in chronological order.
+    """
+    if not approved_trims:
+        return (KeepInterval(turn_start, turn_end),)
+
+    # Sort trims by start_seconds; clamp to turn bounds
+    sorted_trims = sorted(approved_trims, key=lambda t: t["start_seconds"])
+
+    intervals: list[KeepInterval] = []
+    cursor = turn_start
+
+    for trim in sorted_trims:
+        t_start = max(trim["start_seconds"], turn_start)
+        t_end = min(trim["end_seconds"], turn_end)
+        if t_start >= t_end:
+            continue  # trim is outside turn bounds after clamping
+
+        if cursor < t_start:
+            # Emit the gap before this trim
+            intervals.append(KeepInterval(cursor, t_start))
+        cursor = max(cursor, t_end)
+
+    # Trailing segment after the last trim
+    if cursor < turn_end:
+        intervals.append(KeepInterval(cursor, turn_end))
+
+    return tuple(intervals)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def plan_turn_materialization(
+    turns: list[dict],
+    approved_trims: list[dict],
+    *,
+    min_long_secs: float = MIN_LONG_INTERVENTION_SECS,
+) -> list[MaterializationPlan]:
+    """Derive a list of materialization plans from turn rows and approved trims.
+
+    Segmentation rules:
+    1. Turns are sorted by (chapter_id, start_seconds).
+    2. A turn whose duration >= ``min_long_secs`` gets its own plan with
+       approved trim intervals excised.
+    3. Consecutive short turns (<``min_long_secs``) sharing the same
+       ``chapter_id`` are grouped while the gap between adjacent turns
+       is <= ``GROUP_GAP_TOLERANCE_SECS``. A long turn or chapter boundary
+       flushes the current group.
+    4. Only trim proposals with ``is_approved=True AND is_voice_free=True``
+       are applied; all others are silently ignored.
+
+    Args:
+        turns:          List of turn dicts (turn_id, chapter_id,
+                        start_seconds, end_seconds).
+        approved_trims: List of trim proposal dicts (turn_id, start_seconds,
+                        end_seconds, is_approved, is_voice_free). The function
+                        filters this set internally — callers may pass the full
+                        proposal list for a chapter.
+        min_long_secs:  Override for the long-turn threshold (defaults to
+                        ``MIN_LONG_INTERVENTION_SECS``).
+
+    Returns:
+        Ordered list of ``MaterializationPlan`` records, one per output video.
+    """
+    # Filter to only approved + voice-free proposals, indexed by turn_id
+    effective_trims: dict[int, list[dict]] = {}
+    for trim in approved_trims:
+        if trim.get("is_approved") and trim.get("is_voice_free"):
+            effective_trims.setdefault(trim["turn_id"], []).append(trim)
+
+    # Sort turns by (chapter_id, start_seconds)
+    sorted_turns = sorted(
+        turns,
+        key=lambda t: (t["chapter_id"], t["start_seconds"]),
+    )
+
+    plans: list[MaterializationPlan] = []
+
+    # Group accumulator for consecutive short turns
+    group: list[dict] = []
+
+    def _flush_group(g: list[dict]) -> None:
+        """Emit a single plan for the accumulated short-turn group."""
+        if not g:
+            return
+        group_start = g[0]["start_seconds"]
+        group_end = g[-1]["end_seconds"]
+        turn_ids = tuple(t["turn_id"] for t in g)
+        plans.append(
+            MaterializationPlan(
+                turn_ids=turn_ids,
+                chapter_id=g[0]["chapter_id"],
+                keep_intervals=(KeepInterval(group_start, group_end),),
+                output_turn_id=turn_ids[0],
+                needs_reencode=False,
+            )
+        )
+
+    for turn in sorted_turns:
+        duration = turn["end_seconds"] - turn["start_seconds"]
+        is_long = duration >= min_long_secs
+
+        if is_long:
+            # Long turn flushes any accumulated short group, then goes solo
+            _flush_group(group)
+            group = []
+
+            trims_for_turn = effective_trims.get(turn["turn_id"], [])
+            keep = _compute_keep_intervals(
+                turn["start_seconds"],
+                turn["end_seconds"],
+                trims_for_turn,
+            )
+            plans.append(
+                MaterializationPlan(
+                    turn_ids=(turn["turn_id"],),
+                    chapter_id=turn["chapter_id"],
+                    keep_intervals=keep,
+                    output_turn_id=turn["turn_id"],
+                    needs_reencode=len(keep) > 1,
+                )
+            )
+        else:
+            # Short turn: check if it belongs to the current group
+            if group:
+                prev = group[-1]
+                same_chapter = prev["chapter_id"] == turn["chapter_id"]
+                within_gap = (
+                    turn["start_seconds"] <= prev["end_seconds"] + GROUP_GAP_TOLERANCE_SECS
+                )
+                if same_chapter and within_gap:
+                    group.append(turn)
+                else:
+                    # Gap too large or different chapter — flush and start new group
+                    _flush_group(group)
+                    group = [turn]
+            else:
+                group.append(turn)
+
+    # Flush any remaining short-turn group
+    _flush_group(group)
+
+    return plans

--- a/congress_videos/sql/migrations/024_add_approval_to_trim_proposals.sql
+++ b/congress_videos/sql/migrations/024_add_approval_to_trim_proposals.sql
@@ -1,0 +1,17 @@
+-- Migration 024: Add approval columns to speaker_turn_trim_proposals
+--
+-- Adds operator-approval tracking to existing trim proposals.
+-- is_approved: the operator has reviewed and approved this proposal for execution.
+-- approved_at: timestamp when the approval was set (nullable; NULL = not yet approved).
+--
+-- All existing rows default to is_approved = FALSE (no proposal is implicitly approved).
+-- Migration is idempotent via ADD COLUMN IF NOT EXISTS.
+
+ALTER TABLE speaker_turn_trim_proposals
+    ADD COLUMN IF NOT EXISTS is_approved BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ;
+
+-- Down migration:
+-- ALTER TABLE speaker_turn_trim_proposals
+--     DROP COLUMN IF EXISTS is_approved,
+--     DROP COLUMN IF EXISTS approved_at;

--- a/congress_videos/sql/migrations/025_create_speaker_turn_videos.sql
+++ b/congress_videos/sql/migrations/025_create_speaker_turn_videos.sql
@@ -1,0 +1,23 @@
+-- Migration 025: Create speaker_turn_videos idempotency table
+--
+-- Records each successfully materialized speaker-turn video.
+-- Acts as an idempotency guard: turns already present are skipped on re-run.
+--
+-- One row per speaker turn (UNIQUE on turn_id). Grouped short-turn plans
+-- insert one row per constituent turn_id (each referencing the same output_path).
+--
+-- Migration is idempotent via CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS speaker_turn_videos (
+    video_id         SERIAL PRIMARY KEY,
+    turn_id          INTEGER     NOT NULL REFERENCES speaker_turns(turn_id) ON DELETE CASCADE,
+    output_path      TEXT        NOT NULL,
+    materialized_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_speaker_turn_videos_turn UNIQUE (turn_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_speaker_turn_videos_turn
+    ON speaker_turn_videos (turn_id);
+
+-- Down migration:
+-- DROP TABLE IF EXISTS speaker_turn_videos;

--- a/tests/congress_videos/config/test_paths_turn_video.py
+++ b/tests/congress_videos/config/test_paths_turn_video.py
@@ -1,0 +1,64 @@
+"""[RED] Tests for get_turn_video_path helper in congress_videos.config.paths.
+
+Asserts canonical path pattern:
+  {DOWNLOADS_DIR}/{date}/{video_id}/turns/{turn_id}/turn_video.mp4
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from congress_videos.config.paths import DOWNLOADS_DIR, get_turn_video_path
+
+
+class TestGetTurnVideoPath:
+
+    def test_returns_string(self):
+        """get_turn_video_path must return a str."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert isinstance(result, str)
+
+    def test_contains_date(self):
+        """Returned path must contain the date segment."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert "2025-10-08" in result
+
+    def test_contains_video_id(self):
+        """Returned path must contain the video_id segment."""
+        result = get_turn_video_path("2025-10-08", "abc123xyz", 7)
+        assert "abc123xyz" in result
+
+    def test_contains_turns_subdir(self):
+        """Returned path must contain a 'turns' directory segment."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert "/turns/" in result
+
+    def test_contains_turn_id(self):
+        """Returned path must contain the turn_id as a path segment."""
+        result = get_turn_video_path("2025-10-08", "abc123", 42)
+        assert "/42/" in result
+
+    def test_ends_with_turn_video_mp4(self):
+        """Returned path must end with 'turn_video.mp4'."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert result.endswith("turn_video.mp4")
+
+    def test_starts_with_downloads_dir(self):
+        """Returned path must be rooted under DOWNLOADS_DIR."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert result.startswith(DOWNLOADS_DIR)
+
+    def test_canonical_pattern(self):
+        """Returned path must match the full canonical pattern."""
+        date = "2025-10-08"
+        video_id = "hy1cnx-0Oww"
+        turn_id = 99
+        result = get_turn_video_path(date, video_id, turn_id)
+        expected = f"{DOWNLOADS_DIR}/{date}/{video_id}/turns/{turn_id}/turn_video.mp4"
+        assert result == expected
+
+    @pytest.mark.parametrize("turn_id", [1, 42, 999, 10_000])
+    def test_various_turn_ids(self, turn_id: int):
+        """Path must correctly embed any integer turn_id."""
+        result = get_turn_video_path("2026-01-01", "vid_abc", turn_id)
+        assert f"/turns/{turn_id}/turn_video.mp4" in result

--- a/tests/congress_videos/modules/test_materialization.py
+++ b/tests/congress_videos/modules/test_materialization.py
@@ -1,0 +1,405 @@
+"""[RED] Tests for congress_videos.modules.materialization — pure planning module.
+
+Covers:
+- KeepInterval frozen dataclass.
+- MaterializationPlan frozen dataclass.
+- plan_turn_materialization: long-turn/no-trims, long-turn/with-trims,
+  unapproved trims ignored, is_voice_free=False trims ignored,
+  short-turn grouping, cross-chapter isolation, gap-beyond-tolerance split,
+  long-turn interrupts group, trim at start boundary, trim at end boundary.
+
+All tests are pure: no ffmpeg, no DB, no Airflow imports.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from congress_videos.modules.materialization import (
+    GROUP_GAP_TOLERANCE_SECS,
+    MIN_LONG_INTERVENTION_SECS,
+    KeepInterval,
+    MaterializationPlan,
+    plan_turn_materialization,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _turn(
+    turn_id: int,
+    chapter_id: int,
+    start: float,
+    end: float,
+) -> dict:
+    """Minimal turn dict for plan_turn_materialization."""
+    return {
+        "turn_id": turn_id,
+        "chapter_id": chapter_id,
+        "start_seconds": start,
+        "end_seconds": end,
+    }
+
+
+def _trim(
+    turn_id: int,
+    start: float,
+    end: float,
+    is_approved: bool = True,
+    is_voice_free: bool = True,
+) -> dict:
+    """Minimal approved trim proposal dict."""
+    return {
+        "turn_id": turn_id,
+        "start_seconds": start,
+        "end_seconds": end,
+        "is_approved": is_approved,
+        "is_voice_free": is_voice_free,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dataclass sanity
+# ---------------------------------------------------------------------------
+
+
+class TestKeepInterval:
+
+    def test_frozen(self):
+        """KeepInterval must be immutable."""
+        ki = KeepInterval(start=0.0, end=10.0)
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            ki.start = 5.0  # type: ignore[misc]
+
+    def test_fields(self):
+        """KeepInterval must expose start and end floats."""
+        ki = KeepInterval(start=1.5, end=3.5)
+        assert ki.start == 1.5
+        assert ki.end == 3.5
+
+
+class TestMaterializationPlan:
+
+    def test_frozen(self):
+        """MaterializationPlan must be immutable."""
+        plan = MaterializationPlan(
+            turn_ids=(1,),
+            chapter_id=10,
+            keep_intervals=(KeepInterval(0.0, 300.0),),
+            output_turn_id=1,
+            needs_reencode=False,
+        )
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            plan.needs_reencode = True  # type: ignore[misc]
+
+    def test_fields(self):
+        """MaterializationPlan must expose all required fields."""
+        ki = KeepInterval(0.0, 300.0)
+        plan = MaterializationPlan(
+            turn_ids=(1,),
+            chapter_id=7,
+            keep_intervals=(ki,),
+            output_turn_id=1,
+            needs_reencode=False,
+        )
+        assert plan.turn_ids == (1,)
+        assert plan.chapter_id == 7
+        assert plan.keep_intervals == (ki,)
+        assert plan.output_turn_id == 1
+        assert plan.needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.8: Long turn, no trims → single keep = full window, needs_reencode=False
+# ---------------------------------------------------------------------------
+
+
+class TestLongTurnNoTrims:
+
+    def test_single_plan_returned(self):
+        """A lone long turn with no trims must produce exactly one plan."""
+        turn = _turn(turn_id=1, chapter_id=5, start=0.0, end=600.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert len(plans) == 1
+
+    def test_turn_ids_contains_the_turn(self):
+        """Plan turn_ids must contain the single long turn's id."""
+        turn = _turn(turn_id=1, chapter_id=5, start=0.0, end=600.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert plans[0].turn_ids == (1,)
+
+    def test_keep_interval_is_full_window(self):
+        """Single keep interval must span the full turn [start, end]."""
+        turn = _turn(turn_id=1, chapter_id=5, start=100.0, end=700.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert plans[0].keep_intervals == (KeepInterval(100.0, 700.0),)
+
+    def test_needs_reencode_false(self):
+        """No trims → no excision → needs_reencode must be False."""
+        turn = _turn(turn_id=1, chapter_id=5, start=0.0, end=600.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert plans[0].needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.9: Long turn with two approved trims → multiple keeps, needs_reencode=True
+# ---------------------------------------------------------------------------
+
+
+class TestLongTurnWithApprovedTrims:
+
+    def _make_plans(self):
+        # 600s turn, two non-overlapping trims at [120,150] and [300,360]
+        turn = _turn(turn_id=2, chapter_id=1, start=0.0, end=600.0)
+        trims = [
+            _trim(turn_id=2, start=120.0, end=150.0),
+            _trim(turn_id=2, start=300.0, end=360.0),
+        ]
+        return plan_turn_materialization([turn], approved_trims=trims)
+
+    def test_one_plan(self):
+        """Long turn with two trims produces exactly one plan."""
+        assert len(self._make_plans()) == 1
+
+    def test_three_keep_intervals(self):
+        """Two trims excise two intervals → three keeper segments."""
+        plan = self._make_plans()[0]
+        assert len(plan.keep_intervals) == 3
+
+    def test_keep_intervals_values(self):
+        """Keep intervals must be the gaps between trim regions."""
+        plan = self._make_plans()[0]
+        assert plan.keep_intervals[0] == KeepInterval(0.0, 120.0)
+        assert plan.keep_intervals[1] == KeepInterval(150.0, 300.0)
+        assert plan.keep_intervals[2] == KeepInterval(360.0, 600.0)
+
+    def test_needs_reencode_true(self):
+        """Multiple keep intervals (excision) forces needs_reencode=True."""
+        plan = self._make_plans()[0]
+        assert plan.needs_reencode is True
+
+
+# ---------------------------------------------------------------------------
+# Task 1.10: Unapproved trims are ignored (caller filters, but function treats
+#             passed trims as the approved set — unapproved trims in the list
+#             must NOT be applied)
+# ---------------------------------------------------------------------------
+
+
+class TestUnapprovedTrimsIgnored:
+
+    def test_unapproved_trim_produces_full_window(self):
+        """A trim with is_approved=False in the input list must not be applied."""
+        turn = _turn(turn_id=3, chapter_id=1, start=0.0, end=600.0)
+        trims = [_trim(turn_id=3, start=100.0, end=200.0, is_approved=False)]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        # Only the approved+voice_free subset counts; unapproved → full window
+        assert plans[0].keep_intervals == (KeepInterval(0.0, 600.0),)
+        assert plans[0].needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.11: is_voice_free=False trims are ignored
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceFreeFilterApplied:
+
+    def test_not_voice_free_trim_is_dropped(self):
+        """A trim with is_voice_free=False must not be excised even if approved."""
+        turn = _turn(turn_id=4, chapter_id=1, start=0.0, end=600.0)
+        trims = [
+            _trim(turn_id=4, start=100.0, end=200.0, is_approved=True, is_voice_free=False),
+            _trim(turn_id=4, start=300.0, end=400.0, is_approved=True, is_voice_free=True),
+        ]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        # Only the voice-free+approved one is applied → two keep intervals
+        assert len(plans[0].keep_intervals) == 2
+        assert plans[0].keep_intervals[0] == KeepInterval(0.0, 300.0)
+        assert plans[0].keep_intervals[1] == KeepInterval(400.0, 600.0)
+
+
+# ---------------------------------------------------------------------------
+# Task 1.12: Short-turn grouping (2 consecutive same-chapter turns)
+# ---------------------------------------------------------------------------
+
+
+class TestShortTurnGrouping:
+
+    def test_two_adjacent_short_turns_become_one_plan(self):
+        """Two consecutive short same-chapter turns must produce one plan."""
+        # Each turn is 60s, well below 300s threshold
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 1
+
+    def test_grouped_turn_ids(self):
+        """Grouped plan must contain both turn_ids."""
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert set(plans[0].turn_ids) == {10, 11}
+
+    def test_grouped_keep_interval_spans_both(self):
+        """Grouped keep interval must span [first.start, last.end]."""
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert plans[0].keep_intervals == (KeepInterval(0.0, 120.0),)
+
+    def test_grouped_needs_reencode_false(self):
+        """Grouped short-turn plan has no excision → needs_reencode=False."""
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert plans[0].needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.13: Cross-chapter short turns are NOT grouped
+# ---------------------------------------------------------------------------
+
+
+class TestCrossChapterNotGrouped:
+
+    def test_different_chapters_produce_separate_plans(self):
+        """Short turns in different chapters must each produce their own plan."""
+        t_a = _turn(turn_id=20, chapter_id=3, start=0.0, end=60.0)
+        t_b = _turn(turn_id=21, chapter_id=4, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 2
+
+    def test_each_plan_has_own_turn_id(self):
+        """Each separate-chapter plan must contain only its own turn_id."""
+        t_a = _turn(turn_id=20, chapter_id=3, start=0.0, end=60.0)
+        t_b = _turn(turn_id=21, chapter_id=4, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        turn_id_sets = [set(p.turn_ids) for p in plans]
+        assert {20} in turn_id_sets
+        assert {21} in turn_id_sets
+
+
+# ---------------------------------------------------------------------------
+# Task 1.14: Gap beyond tolerance breaks grouping (gap=0.6 > 0.5 → two plans)
+# ---------------------------------------------------------------------------
+
+
+class TestGapBeyondToleranceSplitsGroup:
+
+    def test_gap_exceeds_tolerance(self):
+        """Short turns with a gap > GROUP_GAP_TOLERANCE_SECS must not be grouped."""
+        t_a = _turn(turn_id=30, chapter_id=5, start=0.0, end=60.0)
+        # 0.6s gap > 0.5 tolerance
+        t_b = _turn(turn_id=31, chapter_id=5, start=60.6, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 2
+
+    def test_gap_within_tolerance_still_groups(self):
+        """Short turns with a gap <= GROUP_GAP_TOLERANCE_SECS must be grouped."""
+        t_a = _turn(turn_id=32, chapter_id=5, start=0.0, end=60.0)
+        # 0.4s gap < 0.5 tolerance → grouped
+        t_b = _turn(turn_id=33, chapter_id=5, start=60.4, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 1.15: Long turn interrupts a short-turn group (three separate plans)
+# ---------------------------------------------------------------------------
+
+
+class TestLongTurnInterruptsGroup:
+
+    def test_three_plans_for_short_long_short(self):
+        """[short_A, long_B, short_C] in same chapter → 3 separate plans."""
+        t_a = _turn(turn_id=40, chapter_id=6, start=0.0, end=60.0)     # short
+        t_b = _turn(turn_id=41, chapter_id=6, start=60.0, end=400.0)   # long (340s)
+        t_c = _turn(turn_id=42, chapter_id=6, start=400.0, end=460.0)  # short
+        plans = plan_turn_materialization([t_a, t_b, t_c], approved_trims=[])
+        assert len(plans) == 3
+
+    def test_each_plan_contains_single_turn_id(self):
+        """Each of the three plans must contain a single turn_id."""
+        t_a = _turn(turn_id=40, chapter_id=6, start=0.0, end=60.0)
+        t_b = _turn(turn_id=41, chapter_id=6, start=60.0, end=400.0)
+        t_c = _turn(turn_id=42, chapter_id=6, start=400.0, end=460.0)
+        plans = plan_turn_materialization([t_a, t_b, t_c], approved_trims=[])
+        for p in plans:
+            assert len(p.turn_ids) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 1.16: Approved trim at turn start boundary (trim.start == turn.start)
+# ---------------------------------------------------------------------------
+
+
+class TestTrimAtStartBoundary:
+
+    def test_no_zero_duration_leading_segment(self):
+        """Trim starting at turn start must not produce a [start, start] interval."""
+        turn = _turn(turn_id=50, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=50, start=0.0, end=60.0)]  # trim from very beginning
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        ki = plans[0].keep_intervals
+        # First keep must start at 60.0, not 0.0
+        assert all(interval.end > interval.start for interval in ki), (
+            "No zero-duration keep interval must be produced"
+        )
+        assert ki[0].start == 60.0
+
+    def test_single_keep_after_start_trim(self):
+        """Trim at turn start → one keep interval covering [trim.end, turn.end]."""
+        turn = _turn(turn_id=50, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=50, start=0.0, end=60.0)]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        assert len(plans[0].keep_intervals) == 1
+        assert plans[0].keep_intervals[0] == KeepInterval(60.0, 600.0)
+
+
+# ---------------------------------------------------------------------------
+# Task 1.17: Approved trim at turn end boundary (trim.end == turn.end)
+# ---------------------------------------------------------------------------
+
+
+class TestTrimAtEndBoundary:
+
+    def test_no_zero_duration_trailing_segment(self):
+        """Trim ending at turn end must not produce a [end, end] interval."""
+        turn = _turn(turn_id=51, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=51, start=540.0, end=600.0)]  # trim at very end
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        ki = plans[0].keep_intervals
+        assert all(interval.end > interval.start for interval in ki), (
+            "No zero-duration keep interval must be produced"
+        )
+        assert ki[-1].end == 540.0
+
+    def test_single_keep_before_end_trim(self):
+        """Trim at turn end → one keep interval covering [turn.start, trim.start]."""
+        turn = _turn(turn_id=51, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=51, start=540.0, end=600.0)]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        assert len(plans[0].keep_intervals) == 1
+        assert plans[0].keep_intervals[0] == KeepInterval(0.0, 540.0)
+
+
+# ---------------------------------------------------------------------------
+# Module constant assertions (triangulation guard)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+
+    def test_min_long_intervention_secs_value(self):
+        """MIN_LONG_INTERVENTION_SECS must be 300.0."""
+        assert MIN_LONG_INTERVENTION_SECS == 300.0
+
+    def test_group_gap_tolerance_secs_value(self):
+        """GROUP_GAP_TOLERANCE_SECS must be 0.5."""
+        assert GROUP_GAP_TOLERANCE_SECS == 0.5

--- a/tests/congress_videos/sql/test_migration_024.py
+++ b/tests/congress_videos/sql/test_migration_024.py
@@ -1,0 +1,136 @@
+"""[RED] Test: migration 024 — add approval columns to speaker_turn_trim_proposals.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, ALTER TABLE adds is_approved and approved_at idempotently
+(ADD COLUMN IF NOT EXISTS), DOWN block drops both columns, no DROP TABLE.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "024_add_approval_to_trim_proposals.sql"
+)
+
+
+class TestMigration024FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration024UpBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_alters_correct_table(self):
+        """Migration must ALTER TABLE speaker_turn_trim_proposals."""
+        sql = self._sql().upper()
+        assert "ALTER TABLE SPEAKER_TURN_TRIM_PROPOSALS" in sql
+
+    def test_adds_is_approved_idempotent(self):
+        """is_approved column must be added with ADD COLUMN IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS IS_APPROVED" in sql
+
+    def test_is_approved_type_boolean_not_null_default_false(self):
+        """is_approved must be BOOLEAN NOT NULL DEFAULT FALSE."""
+        sql = self._sql().upper()
+        assert re.search(
+            r"ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+IS_APPROVED\s+BOOLEAN\s+NOT\s+NULL\s+DEFAULT\s+FALSE",
+            sql,
+        ), "is_approved must be BOOLEAN NOT NULL DEFAULT FALSE"
+
+    def test_adds_approved_at_idempotent(self):
+        """approved_at column must be added with ADD COLUMN IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS APPROVED_AT" in sql
+
+    def test_approved_at_type_timestamptz(self):
+        """approved_at must be TIMESTAMPTZ (nullable — no NOT NULL)."""
+        sql = self._sql().upper()
+        assert re.search(
+            r"ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+APPROVED_AT\s+TIMESTAMPTZ",
+            sql,
+        ), "approved_at must be TIMESTAMPTZ"
+
+    def test_approved_at_is_nullable(self):
+        """approved_at must NOT have NOT NULL constraint (nullable column)."""
+        sql = self._sql().upper()
+        # Find the approved_at line and ensure NOT NULL is absent on that line
+        for line in sql.splitlines():
+            if "APPROVED_AT" in line and "ADD COLUMN" in line:
+                assert "NOT NULL" not in line, (
+                    "approved_at must be nullable (no NOT NULL)"
+                )
+                break
+
+    def test_no_schema_qualification(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        sql = self._sql()
+        assert not re.search(r"\bpublic\.speaker_turn_trim_proposals\b", sql)
+
+
+class TestMigration024Idempotency:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_up_uses_add_column_if_not_exists_for_is_approved(self):
+        """UP block must guard is_approved with IF NOT EXISTS to be re-runnable."""
+        sql = self._sql().upper()
+        count = sql.count("ADD COLUMN IF NOT EXISTS IS_APPROVED")
+        assert count >= 1, "is_approved must use ADD COLUMN IF NOT EXISTS"
+
+    def test_up_uses_add_column_if_not_exists_for_approved_at(self):
+        """UP block must guard approved_at with IF NOT EXISTS to be re-runnable."""
+        sql = self._sql().upper()
+        count = sql.count("ADD COLUMN IF NOT EXISTS APPROVED_AT")
+        assert count >= 1, "approved_at must use ADD COLUMN IF NOT EXISTS"
+
+
+class TestMigration024DownBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_down_block_present(self):
+        """Migration must include a down-migration block."""
+        sql = self._sql().upper()
+        assert "DROP COLUMN" in sql or "-- DOWN" in sql or "DOWN MIGRATION" in sql
+
+    def test_down_drops_is_approved(self):
+        """DOWN block must drop the is_approved column."""
+        sql = self._sql().upper()
+        assert "IS_APPROVED" in sql
+        # Both ADD (UP) and DROP (DOWN) must reference IS_APPROVED
+        assert sql.count("IS_APPROVED") >= 2, (
+            "is_approved must appear in both UP (ADD) and DOWN (DROP)"
+        )
+
+    def test_down_drops_approved_at(self):
+        """DOWN block must drop the approved_at column."""
+        sql = self._sql().upper()
+        assert "APPROVED_AT" in sql
+        assert sql.count("APPROVED_AT") >= 2, (
+            "approved_at must appear in both UP (ADD) and DOWN (DROP)"
+        )
+
+    def test_down_does_not_drop_table(self):
+        """DOWN block must NOT drop the entire table — only the two new columns."""
+        sql = self._sql().upper()
+        assert "DROP TABLE" not in sql, (
+            "DOWN migration must only drop columns, not the whole table"
+        )

--- a/tests/congress_videos/sql/test_migration_025.py
+++ b/tests/congress_videos/sql/test_migration_025.py
@@ -1,0 +1,112 @@
+"""[RED] Test: migration 025 — create speaker_turn_videos idempotency table.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, CREATE TABLE IF NOT EXISTS, required columns, FK to speaker_turns,
+UNIQUE constraint on turn_id, and DOWN block drops the table.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "025_create_speaker_turn_videos.sql"
+)
+
+
+class TestMigration025FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration025TableDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_creates_table_if_not_exists(self):
+        """Migration must use CREATE TABLE IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "CREATE TABLE IF NOT EXISTS SPEAKER_TURN_VIDEOS" in sql
+
+    def test_turn_id_column_integer_not_null(self):
+        """turn_id column must be INTEGER NOT NULL."""
+        sql = self._sql().upper()
+        assert re.search(r"TURN_ID\s+INTEGER\s+NOT\s+NULL", sql), (
+            "turn_id must be INTEGER NOT NULL"
+        )
+
+    def test_output_path_column_text_not_null(self):
+        """output_path column must be TEXT NOT NULL."""
+        sql = self._sql().upper()
+        assert re.search(r"OUTPUT_PATH\s+TEXT\s+NOT\s+NULL", sql), (
+            "output_path must be TEXT NOT NULL"
+        )
+
+    def test_materialized_at_column_timestamptz_not_null_default_now(self):
+        """materialized_at must be TIMESTAMPTZ NOT NULL DEFAULT NOW()."""
+        sql = self._sql().upper()
+        assert "MATERIALIZED_AT" in sql
+        assert re.search(
+            r"MATERIALIZED_AT\s+TIMESTAMPTZ\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)",
+            sql,
+        ), "materialized_at must be TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+
+    def test_fk_references_speaker_turns(self):
+        """turn_id must reference speaker_turns(turn_id)."""
+        sql = self._sql()
+        assert "REFERENCES speaker_turns(turn_id)" in sql
+
+    def test_fk_has_on_delete_cascade(self):
+        """FK must include ON DELETE CASCADE."""
+        sql = self._sql().upper()
+        assert "ON DELETE CASCADE" in sql
+
+    def test_unique_constraint_on_turn_id(self):
+        """UNIQUE constraint on turn_id must be present."""
+        sql = self._sql().upper()
+        assert "UNIQUE" in sql
+        # Could be inline UNIQUE or a named CONSTRAINT
+        assert re.search(
+            r"UNIQUE\s*\(\s*TURN_ID\s*\)|TURN_ID.*UNIQUE|UNIQUE.*TURN_ID",
+            sql,
+        ), "UNIQUE constraint on turn_id must be present"
+
+    def test_no_schema_qualification(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        sql = self._sql()
+        assert not re.search(r"\bpublic\.speaker_turn_videos\b", sql)
+        assert not re.search(r"\bpublic\.speaker_turns\b", sql)
+
+
+class TestMigration025DownBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_down_block_present(self):
+        """Migration must include a down-migration block."""
+        sql = self._sql().upper()
+        assert "DROP TABLE" in sql or "-- DOWN" in sql or "DOWN MIGRATION" in sql
+
+    def test_down_drops_speaker_turn_videos(self):
+        """DOWN block must reference DROP TABLE for speaker_turn_videos."""
+        sql = self._sql().upper()
+        # Table name must appear in context of drop
+        assert "SPEAKER_TURN_VIDEOS" in sql
+        # At minimum a drop comment or statement must exist alongside the table name
+        drop_lines = [
+            line for line in sql.splitlines()
+            if "SPEAKER_TURN_VIDEOS" in line and "DROP" in line
+        ]
+        assert drop_lines, "DOWN block must drop speaker_turn_videos table"


### PR DESCRIPTION
Parte de #16 · Cierra el pipeline de refinamiento junto a #86 (turnos) y #87 (recortes) · Slice **PR1/2** de #88

## Qué hace (PR1 — base, sin ffmpeg/DAG)
Capa de datos + planificación pura para materializar 1 orador = 1 vídeo aplicando **solo lo aprobado**. No ejecuta cortes (eso es PR2); todo es unit-testable sin I/O.

- **Migración 024** — añade `is_approved BOOLEAN NOT NULL DEFAULT FALSE` + `approved_at TIMESTAMPTZ` a `speaker_turn_trim_proposals`. La aprobación se marca con **SQL manual** (decisión de alcance: sin UI/DAG de aprobación en este cambio).
- **Migración 025** — tabla `speaker_turn_videos` `(turn_id UNIQUE, output_path, materialized_at)` para idempotencia y auditoría.
- **`congress_videos/modules/materialization.py`** (puro, sin ffmpeg/DB/Airflow) — dataclasses `MaterializationPlan`/`KeepInterval`, `MIN_LONG_INTERVENTION_SECS=300.0`, `GROUP_GAP_TOLERANCE_SECS=0.5`, `plan_turn_materialization(turns, approved_trims)`. Segmentación **solo por duración**: turno ≥umbral → plan propio; turnos cortos consecutivos del mismo capítulo → un corte continuo agrupado. Cálculo de keep-intervals = ventana del turno menos recortes aprobados.
- **`get_turn_video_path`** en `config/paths.py`.

## Alcance / no-goals
- Solo LEE lo aprobado y planifica. No decide qué cortar.
- Non-goal: UI/DAG de aprobación; concat cross-región tipo Q&A; aceleración GPU.

## Test plan
- [x] 67 tests nuevos (migraciones text-parse 024/025, planner puro, path helper), TDD RED→GREEN.
- [x] Suite completa verde, cobertura ≥80%.
- Es la base independiente de la cadena; PR2 (ejecutor ffmpeg + DAG) apunta a esta rama.