### PR TITLE
feat(#88): PR2 — ejecutor concat-demuxer AV1-safe + DAG speaker_turn_videos

### DIFF
--- a/congress_videos/config/paths.py
+++ b/congress_videos/config/paths.py
@@ -197,6 +197,27 @@ def get_short_file_path(chapter_id: int, clip_id: str) -> str:
     return f"{get_shorts_dir(chapter_id)}/{clip_id}.mp4"
 
 
+def get_turn_video_path(date: str, video_id: str, turn_id: int) -> str:
+    """Return the canonical output path for a materialized speaker-turn video.
+
+    The path follows the convention::
+
+        {DOWNLOADS_DIR}/{date}/{video_id}/turns/{turn_id}/turn_video.mp4
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        date:     Recording date in YYYY-MM-DD format (e.g. ``"2025-10-08"``).
+        video_id: YouTube video identifier (e.g. ``"hy1cnx-0Oww"``).
+        turn_id:  Database ``turn_id`` from ``speaker_turns``.
+
+    Returns:
+        Absolute path string to the turn video MP4 file.
+    """
+    return f"{get_download_video_path(date, video_id)}/turns/{turn_id}/turn_video.mp4"
+
+
 # -------------------------
 # Path Validation
 # -------------------------

--- a/congress_videos/modules/materialization.py
+++ b/congress_videos/modules/materialization.py
@@ -1,0 +1,254 @@
+"""Pure planning module for speaker-turn video materialization.
+
+Derives ``MaterializationPlan`` records from turn rows and pre-filtered
+approved trim proposals. Contains **no ffmpeg, no database, no Airflow
+imports** — all logic is deterministic and unit-testable with plain dicts.
+
+The planner decides *what* to cut; the execution layer (PR2) decides *how*
+to cut it using ffmpeg helpers.
+
+Usage::
+
+    plans = plan_turn_materialization(turn_rows, approved_trim_rows)
+    for plan in plans:
+        ...  # delegate to execution layer
+
+Where ``turn_rows`` are dicts with keys:
+    turn_id, chapter_id, start_seconds, end_seconds
+
+And ``approved_trim_rows`` are dicts with keys:
+    turn_id, start_seconds, end_seconds, is_approved, is_voice_free
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+__all__ = [
+    "KeepInterval",
+    "MaterializationPlan",
+    "MIN_LONG_INTERVENTION_SECS",
+    "GROUP_GAP_TOLERANCE_SECS",
+    "plan_turn_materialization",
+]
+
+# ---------------------------------------------------------------------------
+# Module-level constants
+# ---------------------------------------------------------------------------
+
+MIN_LONG_INTERVENTION_SECS: float = 300.0
+"""Minimum duration (seconds) for a speaker turn to be treated as a
+long intervention requiring its own individual output video."""
+
+GROUP_GAP_TOLERANCE_SECS: float = 0.5
+"""Maximum gap (seconds) between two consecutive short turns in the same
+chapter that still allows them to be grouped into a single continuous cut."""
+
+
+# ---------------------------------------------------------------------------
+# Frozen dataclasses
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class KeepInterval:
+    """A single continuous time window to retain in the output video.
+
+    Attributes:
+        start: Absolute start of the interval in seconds.
+        end:   Absolute end of the interval in seconds.
+    """
+
+    start: float
+    end: float
+
+
+@dataclass(frozen=True)
+class MaterializationPlan:
+    """Complete materialization recipe for one output video.
+
+    Attributes:
+        turn_ids:       Tuple of constituent turn_ids (>1 only for grouped
+                        short turns).
+        chapter_id:     chapter_id shared by all turns in this plan.
+        keep_intervals: Ordered, non-overlapping intervals to retain.
+                        A single element means stream-copy is safe (no excision).
+        output_turn_id: Naming key — always the first (lowest) turn_id in the plan.
+        needs_reencode: True when excision forces re-encoding (len(keep_intervals) > 1).
+                        AV1-forced re-encoding is determined at execution time.
+    """
+
+    turn_ids: tuple[int, ...]
+    chapter_id: int
+    keep_intervals: tuple[KeepInterval, ...]
+    output_turn_id: int
+    needs_reencode: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _compute_keep_intervals(
+    turn_start: float,
+    turn_end: float,
+    approved_trims: list[dict],
+) -> tuple[KeepInterval, ...]:
+    """Invert approved trim intervals within [turn_start, turn_end].
+
+    Produces the ordered list of keeper windows by walking through the
+    sorted trim list and emitting the gaps. Zero-duration segments
+    (when a trim exactly touches a boundary) are dropped.
+
+    Args:
+        turn_start:     Absolute start of the turn in seconds.
+        turn_end:       Absolute end of the turn in seconds.
+        approved_trims: Already-filtered approved+voice-free trim dicts.
+
+    Returns:
+        Tuple of KeepInterval in chronological order.
+    """
+    if not approved_trims:
+        return (KeepInterval(turn_start, turn_end),)
+
+    # Sort trims by start_seconds; clamp to turn bounds
+    sorted_trims = sorted(approved_trims, key=lambda t: t["start_seconds"])
+
+    intervals: list[KeepInterval] = []
+    cursor = turn_start
+
+    for trim in sorted_trims:
+        t_start = max(trim["start_seconds"], turn_start)
+        t_end = min(trim["end_seconds"], turn_end)
+        if t_start >= t_end:
+            continue  # trim is outside turn bounds after clamping
+
+        if cursor < t_start:
+            # Emit the gap before this trim
+            intervals.append(KeepInterval(cursor, t_start))
+        cursor = max(cursor, t_end)
+
+    # Trailing segment after the last trim
+    if cursor < turn_end:
+        intervals.append(KeepInterval(cursor, turn_end))
+
+    return tuple(intervals)
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def plan_turn_materialization(
+    turns: list[dict],
+    approved_trims: list[dict],
+    *,
+    min_long_secs: float = MIN_LONG_INTERVENTION_SECS,
+) -> list[MaterializationPlan]:
+    """Derive a list of materialization plans from turn rows and approved trims.
+
+    Segmentation rules:
+    1. Turns are sorted by (chapter_id, start_seconds).
+    2. A turn whose duration >= ``min_long_secs`` gets its own plan with
+       approved trim intervals excised.
+    3. Consecutive short turns (<``min_long_secs``) sharing the same
+       ``chapter_id`` are grouped while the gap between adjacent turns
+       is <= ``GROUP_GAP_TOLERANCE_SECS``. A long turn or chapter boundary
+       flushes the current group.
+    4. Only trim proposals with ``is_approved=True AND is_voice_free=True``
+       are applied; all others are silently ignored.
+
+    Args:
+        turns:          List of turn dicts (turn_id, chapter_id,
+                        start_seconds, end_seconds).
+        approved_trims: List of trim proposal dicts (turn_id, start_seconds,
+                        end_seconds, is_approved, is_voice_free). The function
+                        filters this set internally — callers may pass the full
+                        proposal list for a chapter.
+        min_long_secs:  Override for the long-turn threshold (defaults to
+                        ``MIN_LONG_INTERVENTION_SECS``).
+
+    Returns:
+        Ordered list of ``MaterializationPlan`` records, one per output video.
+    """
+    # Filter to only approved + voice-free proposals, indexed by turn_id
+    effective_trims: dict[int, list[dict]] = {}
+    for trim in approved_trims:
+        if trim.get("is_approved") and trim.get("is_voice_free"):
+            effective_trims.setdefault(trim["turn_id"], []).append(trim)
+
+    # Sort turns by (chapter_id, start_seconds)
+    sorted_turns = sorted(
+        turns,
+        key=lambda t: (t["chapter_id"], t["start_seconds"]),
+    )
+
+    plans: list[MaterializationPlan] = []
+
+    # Group accumulator for consecutive short turns
+    group: list[dict] = []
+
+    def _flush_group(g: list[dict]) -> None:
+        """Emit a single plan for the accumulated short-turn group."""
+        if not g:
+            return
+        group_start = g[0]["start_seconds"]
+        group_end = g[-1]["end_seconds"]
+        turn_ids = tuple(t["turn_id"] for t in g)
+        plans.append(
+            MaterializationPlan(
+                turn_ids=turn_ids,
+                chapter_id=g[0]["chapter_id"],
+                keep_intervals=(KeepInterval(group_start, group_end),),
+                output_turn_id=turn_ids[0],
+                needs_reencode=False,
+            )
+        )
+
+    for turn in sorted_turns:
+        duration = turn["end_seconds"] - turn["start_seconds"]
+        is_long = duration >= min_long_secs
+
+        if is_long:
+            # Long turn flushes any accumulated short group, then goes solo
+            _flush_group(group)
+            group = []
+
+            trims_for_turn = effective_trims.get(turn["turn_id"], [])
+            keep = _compute_keep_intervals(
+                turn["start_seconds"],
+                turn["end_seconds"],
+                trims_for_turn,
+            )
+            plans.append(
+                MaterializationPlan(
+                    turn_ids=(turn["turn_id"],),
+                    chapter_id=turn["chapter_id"],
+                    keep_intervals=keep,
+                    output_turn_id=turn["turn_id"],
+                    needs_reencode=len(keep) > 1,
+                )
+            )
+        else:
+            # Short turn: check if it belongs to the current group
+            if group:
+                prev = group[-1]
+                same_chapter = prev["chapter_id"] == turn["chapter_id"]
+                within_gap = (
+                    turn["start_seconds"] <= prev["end_seconds"] + GROUP_GAP_TOLERANCE_SECS
+                )
+                if same_chapter and within_gap:
+                    group.append(turn)
+                else:
+                    # Gap too large or different chapter — flush and start new group
+                    _flush_group(group)
+                    group = [turn]
+            else:
+                group.append(turn)
+
+    # Flush any remaining short-turn group
+    _flush_group(group)
+
+    return plans

--- a/congress_videos/modules/materialization_executor.py
+++ b/congress_videos/modules/materialization_executor.py
@@ -1,0 +1,251 @@
+"""Execution layer for speaker-turn video materialization.
+
+Consumes a :class:`~congress_videos.modules.materialization.MaterializationPlan`
+(from the pure planning module) together with a resolved source-video path and
+executes the necessary ffmpeg commands to produce a single output MP4.
+
+Three execution paths:
+
+1. **Single keep-interval, non-AV1** — plain stream-copy cut via
+   :func:`build_ffmpeg_cut_cmd` with ``reencode=False``.
+
+2. **Single keep-interval, AV1 source** — re-encode via
+   :func:`build_ffmpeg_cut_cmd` with ``reencode=True`` (AV1 + stream-copy
+   produces an unplayable moov atom).
+
+3. **Multiple keep-intervals (excision, ``needs_reencode=True``)** — concat-
+   demuxer pipeline: each keeper segment is cut with re-encode (libx264/aac),
+   written to a temporary file, a concat-list file is written, and ffmpeg
+   joins all segments with a final ``-c copy`` pass into the output path.
+   Temporary files are removed on both success and failure.
+
+All subprocess calls use list-form arguments (no shell interpolation).
+Timeouts are computed from the total kept duration via
+:func:`compute_ffmpeg_timeout`.
+
+Usage::
+
+    from congress_videos.modules.materialization import plan_turn_materialization
+    from congress_videos.modules.materialization_executor import execute_plan
+
+    plans = plan_turn_materialization(turns, approved_trims)
+    for plan in plans:
+        execute_plan(plan, source_path, output_path, codec=codec)
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+
+from congress_videos.modules.materialization import MaterializationPlan
+from congress_videos.modules.video_splitter import (
+    build_ffmpeg_cut_cmd,
+    compute_ffmpeg_timeout,
+)
+from utils.codec_detection import get_cached_codec, reencode_for_codec
+
+__all__ = [
+    "execute_plan",
+]
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Private helpers
+# ---------------------------------------------------------------------------
+
+
+def _write_concat_list(segment_paths: list[str], tmpdir: str) -> str:
+    """Write an ffmpeg concat-demuxer list file and return its path.
+
+    Each line is ``file '<absolute_path>'`` as required by the demuxer.
+    ``-safe 0`` is set at call-site so absolute paths are accepted.
+
+    Args:
+        segment_paths: Ordered list of absolute paths to segment MP4 files.
+        tmpdir:        Directory where the list file is written.
+
+    Returns:
+        Absolute path to the written ``concat_list.txt`` file.
+    """
+    list_path = os.path.join(tmpdir, "concat_list.txt")
+    with open(list_path, "w", encoding="utf-8") as fh:
+        for seg in segment_paths:
+            fh.write(f"file '{seg}'\n")
+    return list_path
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def execute_plan(
+    plan: MaterializationPlan,
+    source_path: str,
+    output_path: str,
+    *,
+    codec: str | None = None,
+    codec_cache: dict | None = None,
+) -> None:
+    """Execute a :class:`~congress_videos.modules.materialization.MaterializationPlan`.
+
+    Creates the output directory if needed, then follows one of three ffmpeg
+    strategies depending on the number of keep-intervals and the source codec:
+
+    - **1 interval, non-AV1** → ``build_ffmpeg_cut_cmd(reencode=False)`` (stream copy).
+    - **1 interval, AV1/unknown** → ``build_ffmpeg_cut_cmd(reencode=True)`` (re-encode).
+    - **N > 1 intervals** → concat-demuxer: N segment cuts (always re-encode)
+      written to temp files, joined into ``output_path`` via ``-c copy``.
+
+    Temp files (multi-interval path only) are cleaned up in a ``finally`` block
+    on both success and failure, so the NAS never accumulates orphan segments.
+
+    Args:
+        plan:         Materialization plan produced by
+                      :func:`~congress_videos.modules.materialization.plan_turn_materialization`.
+        source_path:  Absolute path to the downloaded source video.
+        output_path:  Absolute path where the output MP4 is written.
+        codec:        Pre-detected source codec string (``"h264"`` | ``"av1"`` |
+                      ``"unknown"``). When ``None``, the codec is probed via
+                      :func:`~utils.codec_detection.get_cached_codec` using
+                      ``codec_cache``.
+        codec_cache:  Optional shared dict for memoizing codec probes across
+                      multiple :func:`execute_plan` calls within the same DAG run.
+
+    Raises:
+        RuntimeError: When any ffmpeg invocation exits with a non-zero code.
+    """
+    # Resolve codec if not supplied
+    if codec is None:
+        codec = get_cached_codec(source_path, codec_cache)
+
+    keep = plan.keep_intervals
+
+    # Ensure output directory exists
+    os.makedirs(os.path.dirname(output_path), exist_ok=True)
+
+    if len(keep) == 1:
+        _execute_single_interval(source_path, output_path, keep[0], codec)
+    else:
+        _execute_multi_interval(source_path, output_path, keep, codec)
+
+
+def _execute_single_interval(
+    source_path: str,
+    output_path: str,
+    interval,
+    codec: str,
+) -> None:
+    """Run a single-interval cut (stream-copy or re-encode depending on codec).
+
+    Design rule: only h264 sources use stream-copy (``-c copy``); AV1 and
+    unknown sources must re-encode via libx264/aac to produce a valid moov atom.
+    ``reencode_for_codec`` returns ``True`` only for h264; we invert that to
+    decide the ``reencode`` flag for ``build_ffmpeg_cut_cmd``:
+    - h264, no trims → ``reencode=False`` → stream-copy (fast, keyframe-snapped).
+    - AV1/unknown    → ``reencode=True``  → libx264/aac (safe, frame-accurate).
+    """
+    force_reencode = (codec != "h264")
+
+    duration = interval.end - interval.start
+    cmd = build_ffmpeg_cut_cmd(
+        src=source_path,
+        out=output_path,
+        start=interval.start,
+        duration=duration,
+        reencode=force_reencode,
+    )
+    timeout = compute_ffmpeg_timeout(duration)
+    log.info(
+        "executor.single_interval src=%s out=%s start=%.2f duration=%.2f codec=%s reencode=%s",
+        source_path, output_path, interval.start, duration, codec, force_reencode,
+    )
+    result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"ffmpeg single-interval cut failed (exit {result.returncode}): {result.stderr}"
+        )
+
+
+def _execute_multi_interval(
+    source_path: str,
+    output_path: str,
+    keep_intervals,
+    codec: str,
+) -> None:
+    """Run the concat-demuxer pipeline for multiple keep intervals.
+
+    Each keeper segment is re-encoded (libx264/aac) and written to a temp
+    file. All temp files are removed in a ``finally`` block on both success
+    and failure.
+    """
+    tmpdir = tempfile.mkdtemp(prefix="mat_exec_")
+    segment_paths: list[str] = []
+
+    try:
+        total_kept = sum(ki.end - ki.start for ki in keep_intervals)
+        seg_timeout = compute_ffmpeg_timeout(total_kept / len(keep_intervals))
+
+        for idx, ki in enumerate(keep_intervals):
+            seg_path = os.path.join(tmpdir, f"seg_{idx:03d}.mp4")
+            segment_paths.append(seg_path)
+            duration = ki.end - ki.start
+            cmd = build_ffmpeg_cut_cmd(
+                src=source_path,
+                out=seg_path,
+                start=ki.start,
+                duration=duration,
+                reencode=True,  # excision always re-encodes
+            )
+            log.info(
+                "executor.segment idx=%d start=%.2f duration=%.2f -> %s",
+                idx, ki.start, duration, seg_path,
+            )
+            result = subprocess.run(cmd, capture_output=True, text=True, timeout=seg_timeout)
+            if result.returncode != 0:
+                raise RuntimeError(
+                    f"ffmpeg segment cut {idx} failed (exit {result.returncode}): {result.stderr}"
+                )
+
+        # Write concat list and join
+        list_path = _write_concat_list(segment_paths, tmpdir)
+        concat_cmd = [
+            "ffmpeg",
+            "-y",
+            "-f", "concat",
+            "-safe", "0",
+            "-i", list_path,
+            "-c", "copy",
+            output_path,
+        ]
+        concat_timeout = compute_ffmpeg_timeout(total_kept)
+        log.info(
+            "executor.concat n_segments=%d output=%s timeout=%ds",
+            len(segment_paths), output_path, concat_timeout,
+        )
+        concat_result = subprocess.run(
+            concat_cmd, capture_output=True, text=True, timeout=concat_timeout
+        )
+        if concat_result.returncode != 0:
+            raise RuntimeError(
+                f"ffmpeg concat failed (exit {concat_result.returncode}): {concat_result.stderr}"
+            )
+
+    finally:
+        # Clean up all temp segment files and the list file
+        for seg in segment_paths:
+            if os.path.exists(seg):
+                os.remove(seg)
+        list_file = os.path.join(tmpdir, "concat_list.txt")
+        if os.path.exists(list_file):
+            os.remove(list_file)
+        try:
+            os.rmdir(tmpdir)
+        except OSError:
+            pass  # non-empty directory; leave it (shouldn't happen)

--- a/congress_videos/modules/materialization_executor.py
+++ b/congress_videos/modules/materialization_executor.py
@@ -46,7 +46,7 @@ from congress_videos.modules.video_splitter import (
     build_ffmpeg_cut_cmd,
     compute_ffmpeg_timeout,
 )
-from utils.codec_detection import get_cached_codec, reencode_for_codec
+from utils.codec_detection import get_cached_codec
 
 __all__ = [
     "execute_plan",
@@ -144,12 +144,13 @@ def _execute_single_interval(
 ) -> None:
     """Run a single-interval cut (stream-copy or re-encode depending on codec).
 
-    Design rule: only h264 sources use stream-copy (``-c copy``); AV1 and
-    unknown sources must re-encode via libx264/aac to produce a valid moov atom.
-    ``reencode_for_codec`` returns ``True`` only for h264; we invert that to
-    decide the ``reencode`` flag for ``build_ffmpeg_cut_cmd``:
+    Design rule: only h264 sources use stream-copy (``-c copy``). AV1, unknown,
+    and every other codec (h265, vp9, …) re-encode via libx264/aac. This is a
+    deliberately conservative policy: stream-copy is enabled only for the codec
+    proven safe in this pipeline, so a valid moov atom is always produced. The
+    ``reencode`` flag passed to ``build_ffmpeg_cut_cmd`` is therefore:
     - h264, no trims → ``reencode=False`` → stream-copy (fast, keyframe-snapped).
-    - AV1/unknown    → ``reencode=True``  → libx264/aac (safe, frame-accurate).
+    - anything else  → ``reencode=True``  → libx264/aac (safe, frame-accurate).
     """
     force_reencode = (codec != "h264")
 

--- a/congress_videos/speaker_turn_videos_dag.py
+++ b/congress_videos/speaker_turn_videos_dag.py
@@ -1,0 +1,258 @@
+"""Speaker Turn Videos DAG.
+
+On-demand DAG that materializes one output MP4 per speaker turn (or per
+group of consecutive short turns) by executing operator-approved trim cuts.
+Nothing is cut automatically — only turns with ``is_approved=TRUE``
+proposals in ``speaker_turn_trim_proposals`` are excised; the rest receive a
+full-window stream-copy (or re-encode when the source is AV1).
+
+Idempotent: turns already present in ``speaker_turn_videos`` are skipped
+before any ffmpeg invocation, so re-running the DAG on the same chapter
+produces no duplicates.
+
+**Airflow pool prerequisite (ops, outside DAG code)**::
+
+    airflow pools set nas_ffmpeg 1 "NAS ffmpeg execution slot"
+
+The ``nas_ffmpeg`` pool MUST be created by an admin before the DAG runs.
+The DAG declares ``pool="nas_ffmpeg"`` on the ffmpeg-invoking task; without
+the pool the task will queue indefinitely. The pool is NOT created in code.
+
+Usage::
+
+    airflow dags trigger speaker_turn_videos \\
+        --conf '{"chapter_id": 42}'
+
+    airflow dags trigger speaker_turn_videos \\
+        --conf '{"video_id": "hy1cnx-0Oww"}'
+
+Pipeline::
+
+    select_turns  (speaker_turns + idempotency filter)
+      → materialize_turns  (plan → execute → INSERT speaker_turn_videos)
+          → collect_results  (summary XCom)
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timedelta, timezone
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator
+
+from congress_videos.config.paths import get_turn_video_path
+from congress_videos.modules.materialization import plan_turn_materialization
+from congress_videos.modules.materialization_executor import execute_plan
+from congress_videos.modules.vad_helpers import _find_source_video
+from utils.codec_detection import get_cached_codec
+from utils.postgres_helpers import PostgresConnection
+
+logger = logging.getLogger(__name__)
+
+DAG_ID = "speaker_turn_videos"
+
+
+# ---------------------------------------------------------------------------
+# Airflow task callables
+# ---------------------------------------------------------------------------
+
+
+def _select_task(**context) -> list[dict]:
+    """Fetch speaker turns in scope and filter out already-materialized ones.
+
+    Reads turns by ``chapter_id`` or ``video_id`` from DAG conf, then
+    cross-checks ``speaker_turn_videos`` and drops any turn_id already present.
+    The filtered list is pushed to XCom under key ``"turns"``.
+    """
+    dag_run = context.get("dag_run")
+    conf = (dag_run.conf or {}) if dag_run else {}
+    chapter_id = conf.get("chapter_id")
+    video_id = conf.get("video_id")
+
+    pg = PostgresConnection()
+    turns_table = pg.get_qualified_table("speaker_turns")
+    stv_table = pg.get_qualified_table("speaker_turn_videos")
+    cols = "turn_id, chapter_id, video_id, session_date, start_seconds, end_seconds"
+
+    with pg.get_connection() as conn:
+        with conn.cursor() as cur:
+            if chapter_id is not None:
+                cur.execute(
+                    f"SELECT {cols} FROM {turns_table} WHERE chapter_id = %s ORDER BY turn_id",
+                    (chapter_id,),
+                )
+            elif video_id is not None:
+                cur.execute(
+                    f"SELECT {cols} FROM {turns_table} WHERE video_id = %s ORDER BY turn_id",
+                    (str(video_id),),
+                )
+            else:
+                cur.execute(
+                    f"SELECT {cols} FROM {turns_table} ORDER BY turn_id LIMIT 10"
+                )
+            names = [d[0] for d in cur.description]
+            turns = [dict(zip(names, row)) for row in cur.fetchall()]
+
+            # Idempotency: exclude turns already in speaker_turn_videos
+            if turns:
+                cur.execute(
+                    f"SELECT turn_id FROM {stv_table} WHERE turn_id = ANY(%s)",
+                    ([t["turn_id"] for t in turns],),
+                )
+                already_done = {row[0] for row in cur.fetchall()}
+                turns = [t for t in turns if t["turn_id"] not in already_done]
+
+    logger.info("speaker_turn_videos: selected %d turn(s) for materialization", len(turns))
+    context["ti"].xcom_push(key="turns", value=turns)
+    return turns
+
+
+def _materialize_task(**context) -> dict:
+    """Plan and execute materialization for each pending turn.
+
+    For each turn in the XCom list:
+    1. Locate the source video on disk (skip gracefully if absent).
+    2. Fetch approved+voice-free trim proposals for the turn.
+    3. Call ``plan_turn_materialization`` to derive keep intervals.
+    4. For each plan: probe codec, run ``execute_plan``, INSERT into
+       ``speaker_turn_videos``. A failed ``execute_plan`` is caught; the turn
+       is logged as skipped and processing continues.
+
+    Returns a summary dict ``{materialized: int, skipped: int}``.
+    """
+    turns = context["ti"].xcom_pull(key="turns", task_ids="select_turns") or []
+    summary = {"materialized": 0, "skipped": 0}
+
+    if not turns:
+        logger.info("speaker_turn_videos: no turns to materialize")
+        context["ti"].xcom_push(key="summary", value=summary)
+        return summary
+
+    pg = PostgresConnection()
+    trims_table = pg.get_qualified_table("speaker_turn_trim_proposals")
+    stv_table = pg.get_qualified_table("speaker_turn_videos")
+    codec_cache: dict = {}
+
+    with pg.get_connection() as conn:
+        with conn.cursor() as cur:
+            # Fetch all approved+voice-free trims for the selected turns
+            turn_ids = [t["turn_id"] for t in turns]
+            cur.execute(
+                f"SELECT turn_id, start_seconds, end_seconds, is_approved, is_voice_free "
+                f"FROM {trims_table} "
+                f"WHERE turn_id = ANY(%s) AND is_approved = TRUE AND is_voice_free = TRUE",
+                (turn_ids,),
+            )
+            trim_names = [d[0] for d in cur.description]
+            approved_trims = [dict(zip(trim_names, row)) for row in cur.fetchall()]
+
+        plans = plan_turn_materialization(turns, approved_trims)
+
+        for plan in plans:
+            # Use first turn in plan to locate source video
+            first_turn = next(
+                t for t in turns if t["turn_id"] == plan.turn_ids[0]
+            )
+            session_date = str(first_turn.get("session_date"))
+            video_id = str(first_turn["video_id"])
+
+            source_path = _find_source_video(session_date, video_id)
+            if not source_path:
+                logger.warning(
+                    "speaker_turn_videos: no source video for date=%s video_id=%s — skipping plan turn_ids=%s",
+                    session_date, video_id, plan.turn_ids,
+                )
+                summary["skipped"] += len(plan.turn_ids)
+                continue
+
+            # Derive output path using first (naming) turn_id
+            output_path = get_turn_video_path(
+                session_date, video_id, plan.output_turn_id
+            )
+
+            try:
+                codec = get_cached_codec(source_path, codec_cache)
+                execute_plan(plan, source_path, output_path, codec=codec, codec_cache=codec_cache)
+            except Exception:  # noqa: BLE001 — one bad plan must not sink the run
+                logger.exception(
+                    "speaker_turn_videos: execute_plan failed for turn_ids=%s — skipping",
+                    plan.turn_ids,
+                )
+                summary["skipped"] += len(plan.turn_ids)
+                continue
+
+            # INSERT idempotency rows (one per turn_id in plan)
+            with conn.cursor() as cur:
+                for tid in plan.turn_ids:
+                    cur.execute(
+                        f"INSERT INTO {stv_table} (turn_id, output_path) "
+                        f"VALUES (%s, %s) "
+                        f"ON CONFLICT (turn_id) DO NOTHING",
+                        (tid, output_path),
+                    )
+            conn.commit()
+            summary["materialized"] += len(plan.turn_ids)
+            logger.info(
+                "speaker_turn_videos: materialized turn_ids=%s -> %s",
+                plan.turn_ids, output_path,
+            )
+
+    context["ti"].xcom_push(key="summary", value=summary)
+    logger.info("speaker_turn_videos: run complete summary=%s", summary)
+    return summary
+
+
+def _collect_task(**context) -> dict:
+    """Collect the materialization summary from XCom and return it.
+
+    This task is a lightweight terminal node that surfaces the final
+    ``{materialized, skipped}`` counts for operator visibility in the Airflow
+    UI without requiring the caller to dig into _materialize_task's XCom.
+    """
+    summary = context["ti"].xcom_pull(key="summary", task_ids="materialize_turns") or {}
+    logger.info("speaker_turn_videos.collect: %s", summary)
+    return summary
+
+
+# ---------------------------------------------------------------------------
+# DAG definition
+# ---------------------------------------------------------------------------
+
+default_args = {
+    "owner": "airflow",
+    "retries": 0,
+    "retry_delay": timedelta(minutes=5),
+}
+
+dag = DAG(
+    dag_id=DAG_ID,
+    description=(
+        "On-demand DAG that materializes speaker-turn MP4 files from approved "
+        "trim proposals (issue #88). Requires nas_ffmpeg Airflow pool (pool_slots=1)."
+    ),
+    schedule=None,
+    start_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+    catchup=False,
+    max_active_tasks=1,
+    default_args=default_args,
+    tags=["congress_videos", "materialization", "on-demand"],
+)
+
+with dag:
+    select_turns_task = PythonOperator(
+        task_id="select_turns",
+        python_callable=_select_task,
+    )
+    materialize_turns_task = PythonOperator(
+        task_id="materialize_turns",
+        python_callable=_materialize_task,
+        pool="nas_ffmpeg",
+        pool_slots=1,
+    )
+    collect_results_task = PythonOperator(
+        task_id="collect_results",
+        python_callable=_collect_task,
+    )
+
+    select_turns_task >> materialize_turns_task >> collect_results_task

--- a/congress_videos/sql/migrations/024_add_approval_to_trim_proposals.sql
+++ b/congress_videos/sql/migrations/024_add_approval_to_trim_proposals.sql
@@ -1,0 +1,17 @@
+-- Migration 024: Add approval columns to speaker_turn_trim_proposals
+--
+-- Adds operator-approval tracking to existing trim proposals.
+-- is_approved: the operator has reviewed and approved this proposal for execution.
+-- approved_at: timestamp when the approval was set (nullable; NULL = not yet approved).
+--
+-- All existing rows default to is_approved = FALSE (no proposal is implicitly approved).
+-- Migration is idempotent via ADD COLUMN IF NOT EXISTS.
+
+ALTER TABLE speaker_turn_trim_proposals
+    ADD COLUMN IF NOT EXISTS is_approved BOOLEAN NOT NULL DEFAULT FALSE,
+    ADD COLUMN IF NOT EXISTS approved_at TIMESTAMPTZ;
+
+-- Down migration:
+-- ALTER TABLE speaker_turn_trim_proposals
+--     DROP COLUMN IF EXISTS is_approved,
+--     DROP COLUMN IF EXISTS approved_at;

--- a/congress_videos/sql/migrations/025_create_speaker_turn_videos.sql
+++ b/congress_videos/sql/migrations/025_create_speaker_turn_videos.sql
@@ -1,0 +1,23 @@
+-- Migration 025: Create speaker_turn_videos idempotency table
+--
+-- Records each successfully materialized speaker-turn video.
+-- Acts as an idempotency guard: turns already present are skipped on re-run.
+--
+-- One row per speaker turn (UNIQUE on turn_id). Grouped short-turn plans
+-- insert one row per constituent turn_id (each referencing the same output_path).
+--
+-- Migration is idempotent via CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS speaker_turn_videos (
+    video_id         SERIAL PRIMARY KEY,
+    turn_id          INTEGER     NOT NULL REFERENCES speaker_turns(turn_id) ON DELETE CASCADE,
+    output_path      TEXT        NOT NULL,
+    materialized_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_speaker_turn_videos_turn UNIQUE (turn_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_speaker_turn_videos_turn
+    ON speaker_turn_videos (turn_id);
+
+-- Down migration:
+-- DROP TABLE IF EXISTS speaker_turn_videos;

--- a/docs/DEPLOYMENT_NAS.md
+++ b/docs/DEPLOYMENT_NAS.md
@@ -557,4 +557,29 @@ docker exec airflow-scheduler-prod airflow dags list-import-errors
 
 # Generar Fernet Key
 python -c "from cryptography.fernet import Fernet; print(Fernet.generate_key().decode())"
+
+---
+
+## Airflow Pools — prerequisitos de operaciones
+
+Algunos DAGs requieren pools de Airflow preconfigurados. Los pools **no** se
+crean automáticamente en código; deben ser provistos por un administrador antes
+de la primera ejecución del DAG correspondiente.
+
+### `nas_ffmpeg` — pool para `speaker_turn_videos` (issue #88)
+
+Limita la concurrencia de tareas ffmpeg a 1 proceso simultáneo para proteger
+el I/O del NAS.
+
+```bash
+# Crear el pool (ejecutar una sola vez)
+docker exec airflow-scheduler-prod \
+  airflow pools set nas_ffmpeg 1 "NAS ffmpeg execution slot"
+
+# Verificar
+docker exec airflow-scheduler-prod airflow pools list
+```
+
+Sin este pool el DAG `speaker_turn_videos` encola indefinidamente.
+Ver también el docstring del DAG en `congress_videos/speaker_turn_videos_dag.py`.
 ```

--- a/tests/congress_videos/config/test_paths_turn_video.py
+++ b/tests/congress_videos/config/test_paths_turn_video.py
@@ -1,0 +1,64 @@
+"""[RED] Tests for get_turn_video_path helper in congress_videos.config.paths.
+
+Asserts canonical path pattern:
+  {DOWNLOADS_DIR}/{date}/{video_id}/turns/{turn_id}/turn_video.mp4
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from congress_videos.config.paths import DOWNLOADS_DIR, get_turn_video_path
+
+
+class TestGetTurnVideoPath:
+
+    def test_returns_string(self):
+        """get_turn_video_path must return a str."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert isinstance(result, str)
+
+    def test_contains_date(self):
+        """Returned path must contain the date segment."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert "2025-10-08" in result
+
+    def test_contains_video_id(self):
+        """Returned path must contain the video_id segment."""
+        result = get_turn_video_path("2025-10-08", "abc123xyz", 7)
+        assert "abc123xyz" in result
+
+    def test_contains_turns_subdir(self):
+        """Returned path must contain a 'turns' directory segment."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert "/turns/" in result
+
+    def test_contains_turn_id(self):
+        """Returned path must contain the turn_id as a path segment."""
+        result = get_turn_video_path("2025-10-08", "abc123", 42)
+        assert "/42/" in result
+
+    def test_ends_with_turn_video_mp4(self):
+        """Returned path must end with 'turn_video.mp4'."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert result.endswith("turn_video.mp4")
+
+    def test_starts_with_downloads_dir(self):
+        """Returned path must be rooted under DOWNLOADS_DIR."""
+        result = get_turn_video_path("2025-10-08", "abc123", 7)
+        assert result.startswith(DOWNLOADS_DIR)
+
+    def test_canonical_pattern(self):
+        """Returned path must match the full canonical pattern."""
+        date = "2025-10-08"
+        video_id = "hy1cnx-0Oww"
+        turn_id = 99
+        result = get_turn_video_path(date, video_id, turn_id)
+        expected = f"{DOWNLOADS_DIR}/{date}/{video_id}/turns/{turn_id}/turn_video.mp4"
+        assert result == expected
+
+    @pytest.mark.parametrize("turn_id", [1, 42, 999, 10_000])
+    def test_various_turn_ids(self, turn_id: int):
+        """Path must correctly embed any integer turn_id."""
+        result = get_turn_video_path("2026-01-01", "vid_abc", turn_id)
+        assert f"/turns/{turn_id}/turn_video.mp4" in result

--- a/tests/congress_videos/modules/test_materialization.py
+++ b/tests/congress_videos/modules/test_materialization.py
@@ -1,0 +1,405 @@
+"""[RED] Tests for congress_videos.modules.materialization — pure planning module.
+
+Covers:
+- KeepInterval frozen dataclass.
+- MaterializationPlan frozen dataclass.
+- plan_turn_materialization: long-turn/no-trims, long-turn/with-trims,
+  unapproved trims ignored, is_voice_free=False trims ignored,
+  short-turn grouping, cross-chapter isolation, gap-beyond-tolerance split,
+  long-turn interrupts group, trim at start boundary, trim at end boundary.
+
+All tests are pure: no ffmpeg, no DB, no Airflow imports.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from congress_videos.modules.materialization import (
+    GROUP_GAP_TOLERANCE_SECS,
+    MIN_LONG_INTERVENTION_SECS,
+    KeepInterval,
+    MaterializationPlan,
+    plan_turn_materialization,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _turn(
+    turn_id: int,
+    chapter_id: int,
+    start: float,
+    end: float,
+) -> dict:
+    """Minimal turn dict for plan_turn_materialization."""
+    return {
+        "turn_id": turn_id,
+        "chapter_id": chapter_id,
+        "start_seconds": start,
+        "end_seconds": end,
+    }
+
+
+def _trim(
+    turn_id: int,
+    start: float,
+    end: float,
+    is_approved: bool = True,
+    is_voice_free: bool = True,
+) -> dict:
+    """Minimal approved trim proposal dict."""
+    return {
+        "turn_id": turn_id,
+        "start_seconds": start,
+        "end_seconds": end,
+        "is_approved": is_approved,
+        "is_voice_free": is_voice_free,
+    }
+
+
+# ---------------------------------------------------------------------------
+# Dataclass sanity
+# ---------------------------------------------------------------------------
+
+
+class TestKeepInterval:
+
+    def test_frozen(self):
+        """KeepInterval must be immutable."""
+        ki = KeepInterval(start=0.0, end=10.0)
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            ki.start = 5.0  # type: ignore[misc]
+
+    def test_fields(self):
+        """KeepInterval must expose start and end floats."""
+        ki = KeepInterval(start=1.5, end=3.5)
+        assert ki.start == 1.5
+        assert ki.end == 3.5
+
+
+class TestMaterializationPlan:
+
+    def test_frozen(self):
+        """MaterializationPlan must be immutable."""
+        plan = MaterializationPlan(
+            turn_ids=(1,),
+            chapter_id=10,
+            keep_intervals=(KeepInterval(0.0, 300.0),),
+            output_turn_id=1,
+            needs_reencode=False,
+        )
+        with pytest.raises((dataclasses.FrozenInstanceError, AttributeError)):
+            plan.needs_reencode = True  # type: ignore[misc]
+
+    def test_fields(self):
+        """MaterializationPlan must expose all required fields."""
+        ki = KeepInterval(0.0, 300.0)
+        plan = MaterializationPlan(
+            turn_ids=(1,),
+            chapter_id=7,
+            keep_intervals=(ki,),
+            output_turn_id=1,
+            needs_reencode=False,
+        )
+        assert plan.turn_ids == (1,)
+        assert plan.chapter_id == 7
+        assert plan.keep_intervals == (ki,)
+        assert plan.output_turn_id == 1
+        assert plan.needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.8: Long turn, no trims → single keep = full window, needs_reencode=False
+# ---------------------------------------------------------------------------
+
+
+class TestLongTurnNoTrims:
+
+    def test_single_plan_returned(self):
+        """A lone long turn with no trims must produce exactly one plan."""
+        turn = _turn(turn_id=1, chapter_id=5, start=0.0, end=600.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert len(plans) == 1
+
+    def test_turn_ids_contains_the_turn(self):
+        """Plan turn_ids must contain the single long turn's id."""
+        turn = _turn(turn_id=1, chapter_id=5, start=0.0, end=600.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert plans[0].turn_ids == (1,)
+
+    def test_keep_interval_is_full_window(self):
+        """Single keep interval must span the full turn [start, end]."""
+        turn = _turn(turn_id=1, chapter_id=5, start=100.0, end=700.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert plans[0].keep_intervals == (KeepInterval(100.0, 700.0),)
+
+    def test_needs_reencode_false(self):
+        """No trims → no excision → needs_reencode must be False."""
+        turn = _turn(turn_id=1, chapter_id=5, start=0.0, end=600.0)
+        plans = plan_turn_materialization([turn], approved_trims=[])
+        assert plans[0].needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.9: Long turn with two approved trims → multiple keeps, needs_reencode=True
+# ---------------------------------------------------------------------------
+
+
+class TestLongTurnWithApprovedTrims:
+
+    def _make_plans(self):
+        # 600s turn, two non-overlapping trims at [120,150] and [300,360]
+        turn = _turn(turn_id=2, chapter_id=1, start=0.0, end=600.0)
+        trims = [
+            _trim(turn_id=2, start=120.0, end=150.0),
+            _trim(turn_id=2, start=300.0, end=360.0),
+        ]
+        return plan_turn_materialization([turn], approved_trims=trims)
+
+    def test_one_plan(self):
+        """Long turn with two trims produces exactly one plan."""
+        assert len(self._make_plans()) == 1
+
+    def test_three_keep_intervals(self):
+        """Two trims excise two intervals → three keeper segments."""
+        plan = self._make_plans()[0]
+        assert len(plan.keep_intervals) == 3
+
+    def test_keep_intervals_values(self):
+        """Keep intervals must be the gaps between trim regions."""
+        plan = self._make_plans()[0]
+        assert plan.keep_intervals[0] == KeepInterval(0.0, 120.0)
+        assert plan.keep_intervals[1] == KeepInterval(150.0, 300.0)
+        assert plan.keep_intervals[2] == KeepInterval(360.0, 600.0)
+
+    def test_needs_reencode_true(self):
+        """Multiple keep intervals (excision) forces needs_reencode=True."""
+        plan = self._make_plans()[0]
+        assert plan.needs_reencode is True
+
+
+# ---------------------------------------------------------------------------
+# Task 1.10: Unapproved trims are ignored (caller filters, but function treats
+#             passed trims as the approved set — unapproved trims in the list
+#             must NOT be applied)
+# ---------------------------------------------------------------------------
+
+
+class TestUnapprovedTrimsIgnored:
+
+    def test_unapproved_trim_produces_full_window(self):
+        """A trim with is_approved=False in the input list must not be applied."""
+        turn = _turn(turn_id=3, chapter_id=1, start=0.0, end=600.0)
+        trims = [_trim(turn_id=3, start=100.0, end=200.0, is_approved=False)]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        # Only the approved+voice_free subset counts; unapproved → full window
+        assert plans[0].keep_intervals == (KeepInterval(0.0, 600.0),)
+        assert plans[0].needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.11: is_voice_free=False trims are ignored
+# ---------------------------------------------------------------------------
+
+
+class TestVoiceFreeFilterApplied:
+
+    def test_not_voice_free_trim_is_dropped(self):
+        """A trim with is_voice_free=False must not be excised even if approved."""
+        turn = _turn(turn_id=4, chapter_id=1, start=0.0, end=600.0)
+        trims = [
+            _trim(turn_id=4, start=100.0, end=200.0, is_approved=True, is_voice_free=False),
+            _trim(turn_id=4, start=300.0, end=400.0, is_approved=True, is_voice_free=True),
+        ]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        # Only the voice-free+approved one is applied → two keep intervals
+        assert len(plans[0].keep_intervals) == 2
+        assert plans[0].keep_intervals[0] == KeepInterval(0.0, 300.0)
+        assert plans[0].keep_intervals[1] == KeepInterval(400.0, 600.0)
+
+
+# ---------------------------------------------------------------------------
+# Task 1.12: Short-turn grouping (2 consecutive same-chapter turns)
+# ---------------------------------------------------------------------------
+
+
+class TestShortTurnGrouping:
+
+    def test_two_adjacent_short_turns_become_one_plan(self):
+        """Two consecutive short same-chapter turns must produce one plan."""
+        # Each turn is 60s, well below 300s threshold
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 1
+
+    def test_grouped_turn_ids(self):
+        """Grouped plan must contain both turn_ids."""
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert set(plans[0].turn_ids) == {10, 11}
+
+    def test_grouped_keep_interval_spans_both(self):
+        """Grouped keep interval must span [first.start, last.end]."""
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert plans[0].keep_intervals == (KeepInterval(0.0, 120.0),)
+
+    def test_grouped_needs_reencode_false(self):
+        """Grouped short-turn plan has no excision → needs_reencode=False."""
+        t_a = _turn(turn_id=10, chapter_id=2, start=0.0, end=60.0)
+        t_b = _turn(turn_id=11, chapter_id=2, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert plans[0].needs_reencode is False
+
+
+# ---------------------------------------------------------------------------
+# Task 1.13: Cross-chapter short turns are NOT grouped
+# ---------------------------------------------------------------------------
+
+
+class TestCrossChapterNotGrouped:
+
+    def test_different_chapters_produce_separate_plans(self):
+        """Short turns in different chapters must each produce their own plan."""
+        t_a = _turn(turn_id=20, chapter_id=3, start=0.0, end=60.0)
+        t_b = _turn(turn_id=21, chapter_id=4, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 2
+
+    def test_each_plan_has_own_turn_id(self):
+        """Each separate-chapter plan must contain only its own turn_id."""
+        t_a = _turn(turn_id=20, chapter_id=3, start=0.0, end=60.0)
+        t_b = _turn(turn_id=21, chapter_id=4, start=60.0, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        turn_id_sets = [set(p.turn_ids) for p in plans]
+        assert {20} in turn_id_sets
+        assert {21} in turn_id_sets
+
+
+# ---------------------------------------------------------------------------
+# Task 1.14: Gap beyond tolerance breaks grouping (gap=0.6 > 0.5 → two plans)
+# ---------------------------------------------------------------------------
+
+
+class TestGapBeyondToleranceSplitsGroup:
+
+    def test_gap_exceeds_tolerance(self):
+        """Short turns with a gap > GROUP_GAP_TOLERANCE_SECS must not be grouped."""
+        t_a = _turn(turn_id=30, chapter_id=5, start=0.0, end=60.0)
+        # 0.6s gap > 0.5 tolerance
+        t_b = _turn(turn_id=31, chapter_id=5, start=60.6, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 2
+
+    def test_gap_within_tolerance_still_groups(self):
+        """Short turns with a gap <= GROUP_GAP_TOLERANCE_SECS must be grouped."""
+        t_a = _turn(turn_id=32, chapter_id=5, start=0.0, end=60.0)
+        # 0.4s gap < 0.5 tolerance → grouped
+        t_b = _turn(turn_id=33, chapter_id=5, start=60.4, end=120.0)
+        plans = plan_turn_materialization([t_a, t_b], approved_trims=[])
+        assert len(plans) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 1.15: Long turn interrupts a short-turn group (three separate plans)
+# ---------------------------------------------------------------------------
+
+
+class TestLongTurnInterruptsGroup:
+
+    def test_three_plans_for_short_long_short(self):
+        """[short_A, long_B, short_C] in same chapter → 3 separate plans."""
+        t_a = _turn(turn_id=40, chapter_id=6, start=0.0, end=60.0)     # short
+        t_b = _turn(turn_id=41, chapter_id=6, start=60.0, end=400.0)   # long (340s)
+        t_c = _turn(turn_id=42, chapter_id=6, start=400.0, end=460.0)  # short
+        plans = plan_turn_materialization([t_a, t_b, t_c], approved_trims=[])
+        assert len(plans) == 3
+
+    def test_each_plan_contains_single_turn_id(self):
+        """Each of the three plans must contain a single turn_id."""
+        t_a = _turn(turn_id=40, chapter_id=6, start=0.0, end=60.0)
+        t_b = _turn(turn_id=41, chapter_id=6, start=60.0, end=400.0)
+        t_c = _turn(turn_id=42, chapter_id=6, start=400.0, end=460.0)
+        plans = plan_turn_materialization([t_a, t_b, t_c], approved_trims=[])
+        for p in plans:
+            assert len(p.turn_ids) == 1
+
+
+# ---------------------------------------------------------------------------
+# Task 1.16: Approved trim at turn start boundary (trim.start == turn.start)
+# ---------------------------------------------------------------------------
+
+
+class TestTrimAtStartBoundary:
+
+    def test_no_zero_duration_leading_segment(self):
+        """Trim starting at turn start must not produce a [start, start] interval."""
+        turn = _turn(turn_id=50, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=50, start=0.0, end=60.0)]  # trim from very beginning
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        ki = plans[0].keep_intervals
+        # First keep must start at 60.0, not 0.0
+        assert all(interval.end > interval.start for interval in ki), (
+            "No zero-duration keep interval must be produced"
+        )
+        assert ki[0].start == 60.0
+
+    def test_single_keep_after_start_trim(self):
+        """Trim at turn start → one keep interval covering [trim.end, turn.end]."""
+        turn = _turn(turn_id=50, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=50, start=0.0, end=60.0)]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        assert len(plans[0].keep_intervals) == 1
+        assert plans[0].keep_intervals[0] == KeepInterval(60.0, 600.0)
+
+
+# ---------------------------------------------------------------------------
+# Task 1.17: Approved trim at turn end boundary (trim.end == turn.end)
+# ---------------------------------------------------------------------------
+
+
+class TestTrimAtEndBoundary:
+
+    def test_no_zero_duration_trailing_segment(self):
+        """Trim ending at turn end must not produce a [end, end] interval."""
+        turn = _turn(turn_id=51, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=51, start=540.0, end=600.0)]  # trim at very end
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        ki = plans[0].keep_intervals
+        assert all(interval.end > interval.start for interval in ki), (
+            "No zero-duration keep interval must be produced"
+        )
+        assert ki[-1].end == 540.0
+
+    def test_single_keep_before_end_trim(self):
+        """Trim at turn end → one keep interval covering [turn.start, trim.start]."""
+        turn = _turn(turn_id=51, chapter_id=7, start=0.0, end=600.0)
+        trims = [_trim(turn_id=51, start=540.0, end=600.0)]
+        plans = plan_turn_materialization([turn], approved_trims=trims)
+        assert len(plans[0].keep_intervals) == 1
+        assert plans[0].keep_intervals[0] == KeepInterval(0.0, 540.0)
+
+
+# ---------------------------------------------------------------------------
+# Module constant assertions (triangulation guard)
+# ---------------------------------------------------------------------------
+
+
+class TestModuleConstants:
+
+    def test_min_long_intervention_secs_value(self):
+        """MIN_LONG_INTERVENTION_SECS must be 300.0."""
+        assert MIN_LONG_INTERVENTION_SECS == 300.0
+
+    def test_group_gap_tolerance_secs_value(self):
+        """GROUP_GAP_TOLERANCE_SECS must be 0.5."""
+        assert GROUP_GAP_TOLERANCE_SECS == 0.5

--- a/tests/congress_videos/modules/test_materialization_executor.py
+++ b/tests/congress_videos/modules/test_materialization_executor.py
@@ -188,6 +188,37 @@ class TestSingleIntervalAV1Reencode:
             assert cmd[c_idx + 1] != "copy"
 
 
+class TestSingleIntervalNonH264Reencode:
+    """Conservative policy: only h264 stream-copies; every other non-AV1 codec
+    (e.g. h265) still re-encodes rather than risking an invalid stream copy."""
+
+    def test_h265_forces_reencode_not_copy(self, monkeypatch):
+        plan = _plan([_ki(0.0, 600.0)], needs_reencode=False)
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h265",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h265")
+
+        cmd = captured_cmds[0]
+        # Re-encode path: libx264 present, no bare -c copy.
+        assert "libx264" in cmd
+        if "-c" in cmd:
+            c_idx = cmd.index("-c")
+            assert cmd[c_idx + 1] != "copy"
+
+
 # ---------------------------------------------------------------------------
 # 2.3 Multi-interval (excision): N segments + 1 concat join
 # ---------------------------------------------------------------------------

--- a/tests/congress_videos/modules/test_materialization_executor.py
+++ b/tests/congress_videos/modules/test_materialization_executor.py
@@ -1,0 +1,519 @@
+"""Tests for congress_videos.modules.materialization_executor (PR2).
+
+All I/O collaborators are mocked — no real ffmpeg, no filesystem side effects.
+
+Test organisation:
+  TestSingleIntervalStreamCopy     — non-AV1, one keep interval → -c copy
+  TestSingleIntervalAV1Reencode    — AV1 source, one interval → re-encode
+  TestMultiIntervalExcision        — N intervals → N segment cuts + concat join
+  TestTempFileCleanup              — temp segments deleted on failure
+  TestGroupedContinuousInterval    — grouped short turns (one interval, non-AV1) → stream copy, no concat
+  TestTimeoutComputation           — timeout computed from total kept duration
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from congress_videos.modules.materialization import KeepInterval, MaterializationPlan
+from congress_videos.modules.materialization_executor import execute_plan
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_SRC = "/data/downloads/2026-01-01/vid1/source.mp4"
+_OUT = "/data/downloads/2026-01-01/vid1/turns/1/turn_video.mp4"
+
+# Common fixture: monkeypatch os.makedirs so tests never try to create /data
+def _patch_makedirs(monkeypatch):
+    monkeypatch.setattr(
+        "congress_videos.modules.materialization_executor.os.makedirs",
+        lambda path, **kw: None,
+    )
+
+
+def _plan(keep_intervals, needs_reencode=False, turn_ids=(1,), chapter_id=10):
+    """Factory: build a MaterializationPlan with the given keep_intervals."""
+    return MaterializationPlan(
+        turn_ids=tuple(turn_ids),
+        chapter_id=chapter_id,
+        keep_intervals=tuple(keep_intervals),
+        output_turn_id=turn_ids[0],
+        needs_reencode=needs_reencode,
+    )
+
+
+def _ki(start, end):
+    return KeepInterval(start=start, end=end)
+
+
+# ---------------------------------------------------------------------------
+# 2.1 Single keep interval, non-AV1 → stream copy (-c copy)
+# ---------------------------------------------------------------------------
+
+class TestSingleIntervalStreamCopy:
+    """Single keep interval + h264 source → build_ffmpeg_cut_cmd(reencode=False)."""
+
+    def test_uses_stream_copy_for_h264(self, monkeypatch):
+        plan = _plan([_ki(100.0, 300.0)], needs_reencode=False)
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        assert "-c" in cmd
+        copy_idx = cmd.index("-c")
+        assert cmd[copy_idx + 1] == "copy"
+
+    def test_output_path_is_the_target(self, monkeypatch):
+        plan = _plan([_ki(100.0, 300.0)], needs_reencode=False)
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        cmd = captured_cmds[0]
+        assert _OUT in cmd
+
+    def test_no_temp_concat_file_created(self, monkeypatch):
+        """Single-interval path must not use -f concat."""
+        plan = _plan([_ki(100.0, 300.0)], needs_reencode=False)
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # Only one subprocess call, no -f concat used
+        assert all("-f" not in cmd for cmd in captured_cmds)
+
+
+# ---------------------------------------------------------------------------
+# 2.2 Single keep interval, AV1 source → re-encode (no -c copy)
+# ---------------------------------------------------------------------------
+
+class TestSingleIntervalAV1Reencode:
+    """AV1 source → force_reencode=True → build_ffmpeg_cut_cmd(reencode=True)."""
+
+    def test_av1_uses_reencode_flags(self, monkeypatch):
+        plan = _plan([_ki(0.0, 600.0)], needs_reencode=False)
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "av1",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="av1")
+
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        # Re-encode uses libx264, not -c copy
+        assert "libx264" in cmd
+
+    def test_av1_does_not_use_copy(self, monkeypatch):
+        plan = _plan([_ki(0.0, 600.0)], needs_reencode=False)
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "av1",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="av1")
+
+        cmd = captured_cmds[0]
+        # No bare -c copy (stream copy): either -c is absent, or its value != copy
+        if "-c" in cmd:
+            c_idx = cmd.index("-c")
+            assert cmd[c_idx + 1] != "copy"
+
+
+# ---------------------------------------------------------------------------
+# 2.3 Multi-interval (excision): N segments + 1 concat join
+# ---------------------------------------------------------------------------
+
+class TestMultiIntervalExcision:
+    """Two keep intervals → 2 segment cuts (re-encode) + 1 concat join (-c copy)."""
+
+    def _plan_two_intervals(self):
+        # Turn from 100s to 700s, trim excised 300–350 → keep [100,300] + [350,700]
+        return _plan(
+            [_ki(100.0, 300.0), _ki(350.0, 700.0)],
+            needs_reencode=True,
+        )
+
+    def test_n_segment_cuts_plus_one_concat(self, monkeypatch, tmp_path):
+        plan = self._plan_two_intervals()
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.tempfile",
+            MagicMock(mkdtemp=lambda **kw: str(tmp_path)),
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # 2 segment cuts + 1 concat → total 3 subprocess.run calls
+        assert len(captured_cmds) == 3
+
+    def test_segment_cuts_use_reencode(self, monkeypatch, tmp_path):
+        plan = self._plan_two_intervals()
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.tempfile",
+            MagicMock(mkdtemp=lambda **kw: str(tmp_path)),
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # The first two commands (segment cuts) must use libx264, not -c copy
+        for cmd in captured_cmds[:2]:
+            assert "libx264" in cmd
+
+    def test_concat_join_uses_stream_copy(self, monkeypatch, tmp_path):
+        plan = self._plan_two_intervals()
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.tempfile",
+            MagicMock(mkdtemp=lambda **kw: str(tmp_path)),
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # Final concat command uses -f concat
+        concat_cmd = captured_cmds[-1]
+        assert "-f" in concat_cmd
+        f_idx = concat_cmd.index("-f")
+        assert concat_cmd[f_idx + 1] == "concat"
+        # And stream copies the segments
+        assert "-c" in concat_cmd
+        c_idx = concat_cmd.index("-c")
+        assert concat_cmd[c_idx + 1] == "copy"
+
+
+# ---------------------------------------------------------------------------
+# 2.4 Temp files cleaned up on ffmpeg failure
+# ---------------------------------------------------------------------------
+
+class TestTempFileCleanup:
+    """On ffmpeg failure (non-zero returncode), temp segment files must be deleted."""
+
+    def test_temp_segments_deleted_on_failure(self, monkeypatch, tmp_path):
+        plan = _plan(
+            [_ki(100.0, 300.0), _ki(350.0, 700.0)],
+            needs_reencode=True,
+        )
+        call_count = [0]
+        deleted_paths = []
+        original_remove = os.remove
+        original_path_exists = os.path.exists
+
+        def tracking_remove(path):
+            deleted_paths.append(path)
+            # Don't call real remove; the file may not exist in tests
+            pass
+
+        def tracking_exists(path):
+            # Say all segment files exist so cleanup runs
+            if "seg_" in str(path) or "concat_list" in str(path):
+                return True
+            return original_path_exists(path)
+
+        def fake_run(cmd, **kwargs):
+            call_count[0] += 1
+            result = MagicMock()
+            # First segment cut succeeds, second fails
+            if call_count[0] == 1:
+                result.returncode = 0
+                return result
+            result.returncode = 1
+            result.stderr = "ffmpeg error"
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.tempfile",
+            MagicMock(mkdtemp=lambda **kw: str(tmp_path)),
+        )
+        _patch_makedirs(monkeypatch)
+        monkeypatch.setattr("congress_videos.modules.materialization_executor.os.remove", tracking_remove)
+        monkeypatch.setattr("congress_videos.modules.materialization_executor.os.path.exists", tracking_exists)
+
+        with pytest.raises(RuntimeError):
+            execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # Cleanup was triggered: os.remove was called for segment paths
+        removed_segs = [p for p in deleted_paths if "seg_" in p]
+        assert len(removed_segs) >= 1, f"Expected segment cleanup calls, got: {deleted_paths}"
+
+    def test_cleanup_happens_before_reraise(self, monkeypatch, tmp_path):
+        """Cleanup must occur even when the concat step fails."""
+        plan = _plan(
+            [_ki(100.0, 300.0), _ki(350.0, 700.0)],
+            needs_reencode=True,
+        )
+        call_count = [0]
+        deleted_paths = []
+        original_path_exists = os.path.exists
+
+        def tracking_remove(path):
+            deleted_paths.append(path)
+
+        def tracking_exists(path):
+            if "seg_" in str(path) or "concat_list" in str(path):
+                return True
+            return original_path_exists(path)
+
+        def fake_run(cmd, **kwargs):
+            call_count[0] += 1
+            result = MagicMock()
+            if call_count[0] <= 2:
+                result.returncode = 0
+                return result
+            # Concat step fails
+            result.returncode = 1
+            result.stderr = "concat failed"
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.tempfile",
+            MagicMock(mkdtemp=lambda **kw: str(tmp_path)),
+        )
+        _patch_makedirs(monkeypatch)
+        monkeypatch.setattr("congress_videos.modules.materialization_executor.os.remove", tracking_remove)
+        monkeypatch.setattr("congress_videos.modules.materialization_executor.os.path.exists", tracking_exists)
+
+        with pytest.raises(RuntimeError):
+            execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # Both segment paths AND concat_list were cleaned
+        removed_segs = [p for p in deleted_paths if "seg_" in p]
+        removed_list = [p for p in deleted_paths if "concat_list" in p]
+        assert len(removed_segs) == 2, f"Expected 2 segment cleanups, got: {removed_segs}"
+        assert len(removed_list) == 1, f"Expected concat_list cleanup, got: {removed_list}"
+
+
+# ---------------------------------------------------------------------------
+# 2.5 Grouped short turns: single continuous interval, non-AV1 → stream copy
+# ---------------------------------------------------------------------------
+
+class TestGroupedContinuousInterval:
+    """Single continuous interval (grouped short turns, needs_reencode=False) uses stream copy."""
+
+    def test_grouped_turns_stream_copy(self, monkeypatch):
+        # Grouped short turns produce one continuous interval, no concat
+        plan = _plan(
+            [_ki(50.0, 250.0)],
+            needs_reencode=False,
+            turn_ids=(3, 4),
+        )
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        assert len(captured_cmds) == 1
+        cmd = captured_cmds[0]
+        # Stream copy
+        assert "-c" in cmd
+        c_idx = cmd.index("-c")
+        assert cmd[c_idx + 1] == "copy"
+
+    def test_grouped_turns_no_concat_invocation(self, monkeypatch):
+        plan = _plan(
+            [_ki(50.0, 250.0)],
+            needs_reencode=False,
+            turn_ids=(3, 4),
+        )
+        captured_cmds = []
+
+        def fake_run(cmd, **kwargs):
+            captured_cmds.append(list(cmd))
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        # Only one subprocess call, no -f concat
+        assert all("-f" not in cmd for cmd in captured_cmds)
+
+
+# ---------------------------------------------------------------------------
+# 2.5b Timeout computed from total kept duration
+# ---------------------------------------------------------------------------
+
+class TestTimeoutComputation:
+    """Timeout passed to subprocess.run is derived from total kept duration."""
+
+    def test_timeout_scales_with_duration(self, monkeypatch):
+        # 200s keep interval → compute_ffmpeg_timeout(200) = 120 + 8*200 = 1720
+        plan = _plan([_ki(0.0, 200.0)], needs_reencode=False)
+        captured_timeouts = []
+
+        def fake_run(cmd, timeout=None, **kwargs):
+            captured_timeouts.append(timeout)
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        assert len(captured_timeouts) == 1
+        # timeout for 200s clip ≥ 120 (base) + 8*200 = 1720, capped at 3600
+        assert captured_timeouts[0] >= 1720
+
+    def test_timeout_capped_at_3600(self, monkeypatch):
+        # 500s keep interval → 120 + 8*500 = 4120 → capped at 3600
+        plan = _plan([_ki(0.0, 500.0)], needs_reencode=False)
+        captured_timeouts = []
+
+        def fake_run(cmd, timeout=None, **kwargs):
+            captured_timeouts.append(timeout)
+            result = MagicMock()
+            result.returncode = 0
+            return result
+
+        monkeypatch.setattr(subprocess, "run", fake_run)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        _patch_makedirs(monkeypatch)
+
+        execute_plan(plan, _SRC, _OUT, codec="h264")
+
+        assert captured_timeouts[0] == 3600

--- a/tests/congress_videos/sql/test_migration_024.py
+++ b/tests/congress_videos/sql/test_migration_024.py
@@ -1,0 +1,136 @@
+"""[RED] Test: migration 024 — add approval columns to speaker_turn_trim_proposals.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, ALTER TABLE adds is_approved and approved_at idempotently
+(ADD COLUMN IF NOT EXISTS), DOWN block drops both columns, no DROP TABLE.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "024_add_approval_to_trim_proposals.sql"
+)
+
+
+class TestMigration024FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration024UpBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_alters_correct_table(self):
+        """Migration must ALTER TABLE speaker_turn_trim_proposals."""
+        sql = self._sql().upper()
+        assert "ALTER TABLE SPEAKER_TURN_TRIM_PROPOSALS" in sql
+
+    def test_adds_is_approved_idempotent(self):
+        """is_approved column must be added with ADD COLUMN IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS IS_APPROVED" in sql
+
+    def test_is_approved_type_boolean_not_null_default_false(self):
+        """is_approved must be BOOLEAN NOT NULL DEFAULT FALSE."""
+        sql = self._sql().upper()
+        assert re.search(
+            r"ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+IS_APPROVED\s+BOOLEAN\s+NOT\s+NULL\s+DEFAULT\s+FALSE",
+            sql,
+        ), "is_approved must be BOOLEAN NOT NULL DEFAULT FALSE"
+
+    def test_adds_approved_at_idempotent(self):
+        """approved_at column must be added with ADD COLUMN IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "ADD COLUMN IF NOT EXISTS APPROVED_AT" in sql
+
+    def test_approved_at_type_timestamptz(self):
+        """approved_at must be TIMESTAMPTZ (nullable — no NOT NULL)."""
+        sql = self._sql().upper()
+        assert re.search(
+            r"ADD\s+COLUMN\s+IF\s+NOT\s+EXISTS\s+APPROVED_AT\s+TIMESTAMPTZ",
+            sql,
+        ), "approved_at must be TIMESTAMPTZ"
+
+    def test_approved_at_is_nullable(self):
+        """approved_at must NOT have NOT NULL constraint (nullable column)."""
+        sql = self._sql().upper()
+        # Find the approved_at line and ensure NOT NULL is absent on that line
+        for line in sql.splitlines():
+            if "APPROVED_AT" in line and "ADD COLUMN" in line:
+                assert "NOT NULL" not in line, (
+                    "approved_at must be nullable (no NOT NULL)"
+                )
+                break
+
+    def test_no_schema_qualification(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        sql = self._sql()
+        assert not re.search(r"\bpublic\.speaker_turn_trim_proposals\b", sql)
+
+
+class TestMigration024Idempotency:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_up_uses_add_column_if_not_exists_for_is_approved(self):
+        """UP block must guard is_approved with IF NOT EXISTS to be re-runnable."""
+        sql = self._sql().upper()
+        count = sql.count("ADD COLUMN IF NOT EXISTS IS_APPROVED")
+        assert count >= 1, "is_approved must use ADD COLUMN IF NOT EXISTS"
+
+    def test_up_uses_add_column_if_not_exists_for_approved_at(self):
+        """UP block must guard approved_at with IF NOT EXISTS to be re-runnable."""
+        sql = self._sql().upper()
+        count = sql.count("ADD COLUMN IF NOT EXISTS APPROVED_AT")
+        assert count >= 1, "approved_at must use ADD COLUMN IF NOT EXISTS"
+
+
+class TestMigration024DownBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_down_block_present(self):
+        """Migration must include a down-migration block."""
+        sql = self._sql().upper()
+        assert "DROP COLUMN" in sql or "-- DOWN" in sql or "DOWN MIGRATION" in sql
+
+    def test_down_drops_is_approved(self):
+        """DOWN block must drop the is_approved column."""
+        sql = self._sql().upper()
+        assert "IS_APPROVED" in sql
+        # Both ADD (UP) and DROP (DOWN) must reference IS_APPROVED
+        assert sql.count("IS_APPROVED") >= 2, (
+            "is_approved must appear in both UP (ADD) and DOWN (DROP)"
+        )
+
+    def test_down_drops_approved_at(self):
+        """DOWN block must drop the approved_at column."""
+        sql = self._sql().upper()
+        assert "APPROVED_AT" in sql
+        assert sql.count("APPROVED_AT") >= 2, (
+            "approved_at must appear in both UP (ADD) and DOWN (DROP)"
+        )
+
+    def test_down_does_not_drop_table(self):
+        """DOWN block must NOT drop the entire table — only the two new columns."""
+        sql = self._sql().upper()
+        assert "DROP TABLE" not in sql, (
+            "DOWN migration must only drop columns, not the whole table"
+        )

--- a/tests/congress_videos/sql/test_migration_025.py
+++ b/tests/congress_videos/sql/test_migration_025.py
@@ -1,0 +1,112 @@
+"""[RED] Test: migration 025 — create speaker_turn_videos idempotency table.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, CREATE TABLE IF NOT EXISTS, required columns, FK to speaker_turns,
+UNIQUE constraint on turn_id, and DOWN block drops the table.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "025_create_speaker_turn_videos.sql"
+)
+
+
+class TestMigration025FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration025TableDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_creates_table_if_not_exists(self):
+        """Migration must use CREATE TABLE IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "CREATE TABLE IF NOT EXISTS SPEAKER_TURN_VIDEOS" in sql
+
+    def test_turn_id_column_integer_not_null(self):
+        """turn_id column must be INTEGER NOT NULL."""
+        sql = self._sql().upper()
+        assert re.search(r"TURN_ID\s+INTEGER\s+NOT\s+NULL", sql), (
+            "turn_id must be INTEGER NOT NULL"
+        )
+
+    def test_output_path_column_text_not_null(self):
+        """output_path column must be TEXT NOT NULL."""
+        sql = self._sql().upper()
+        assert re.search(r"OUTPUT_PATH\s+TEXT\s+NOT\s+NULL", sql), (
+            "output_path must be TEXT NOT NULL"
+        )
+
+    def test_materialized_at_column_timestamptz_not_null_default_now(self):
+        """materialized_at must be TIMESTAMPTZ NOT NULL DEFAULT NOW()."""
+        sql = self._sql().upper()
+        assert "MATERIALIZED_AT" in sql
+        assert re.search(
+            r"MATERIALIZED_AT\s+TIMESTAMPTZ\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)",
+            sql,
+        ), "materialized_at must be TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+
+    def test_fk_references_speaker_turns(self):
+        """turn_id must reference speaker_turns(turn_id)."""
+        sql = self._sql()
+        assert "REFERENCES speaker_turns(turn_id)" in sql
+
+    def test_fk_has_on_delete_cascade(self):
+        """FK must include ON DELETE CASCADE."""
+        sql = self._sql().upper()
+        assert "ON DELETE CASCADE" in sql
+
+    def test_unique_constraint_on_turn_id(self):
+        """UNIQUE constraint on turn_id must be present."""
+        sql = self._sql().upper()
+        assert "UNIQUE" in sql
+        # Could be inline UNIQUE or a named CONSTRAINT
+        assert re.search(
+            r"UNIQUE\s*\(\s*TURN_ID\s*\)|TURN_ID.*UNIQUE|UNIQUE.*TURN_ID",
+            sql,
+        ), "UNIQUE constraint on turn_id must be present"
+
+    def test_no_schema_qualification(self):
+        """Migration must use unqualified table names (runner sets search_path)."""
+        sql = self._sql()
+        assert not re.search(r"\bpublic\.speaker_turn_videos\b", sql)
+        assert not re.search(r"\bpublic\.speaker_turns\b", sql)
+
+
+class TestMigration025DownBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_down_block_present(self):
+        """Migration must include a down-migration block."""
+        sql = self._sql().upper()
+        assert "DROP TABLE" in sql or "-- DOWN" in sql or "DOWN MIGRATION" in sql
+
+    def test_down_drops_speaker_turn_videos(self):
+        """DOWN block must reference DROP TABLE for speaker_turn_videos."""
+        sql = self._sql().upper()
+        # Table name must appear in context of drop
+        assert "SPEAKER_TURN_VIDEOS" in sql
+        # At minimum a drop comment or statement must exist alongside the table name
+        drop_lines = [
+            line for line in sql.splitlines()
+            if "SPEAKER_TURN_VIDEOS" in line and "DROP" in line
+        ]
+        assert drop_lines, "DOWN block must drop speaker_turn_videos table"

--- a/tests/congress_videos/test_speaker_turn_videos_dag.py
+++ b/tests/congress_videos/test_speaker_turn_videos_dag.py
@@ -1,0 +1,261 @@
+"""Tests for congress_videos.speaker_turn_videos_dag (PR2).
+
+All I/O collaborators are mocked — no real Airflow execution, no DB, no ffmpeg.
+
+Test organisation:
+  TestDagLoads           — DAG import smoke test, schedule=None, task IDs
+  TestSelectTurns        — idempotency skip for already-materialized turns
+  TestMaterializeTurns   — missing source skip, INSERT on success, no INSERT on failure
+  TestApprovedOnlyFilter — only approved+voice-free trims drive excision
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from datetime import date
+from unittest.mock import MagicMock, call
+
+import pytest
+
+MODULE = "congress_videos.speaker_turn_videos_dag"
+
+
+def _fresh():
+    """Reload the DAG module fresh each time to avoid caching side effects."""
+    if MODULE in sys.modules:
+        del sys.modules[MODULE]
+    return importlib.import_module(MODULE)
+
+
+# ---------------------------------------------------------------------------
+# 2.8 DAG load test
+# ---------------------------------------------------------------------------
+
+class TestDagLoads:
+    def test_dag_imports_cleanly(self):
+        mod = _fresh()
+        assert mod.dag is not None
+
+    def test_schedule_is_none(self):
+        mod = _fresh()
+        assert mod.dag.schedule_interval is None
+
+    def test_expected_task_ids_present(self):
+        mod = _fresh()
+        task_ids = {t.task_id for t in mod.dag.tasks}
+        assert "select_turns" in task_ids
+        assert "materialize_turns" in task_ids
+        assert "collect_results" in task_ids
+
+    def test_max_active_tasks_is_one(self):
+        mod = _fresh()
+        assert mod.dag.max_active_tasks == 1
+
+
+# ---------------------------------------------------------------------------
+# 2.9 select_turns skips already-materialized turns
+# ---------------------------------------------------------------------------
+
+class TestSelectTurns:
+    """Turns already in speaker_turn_videos must be excluded from the XCom output."""
+
+    def _make_pg_mock(self, monkeypatch, mod, turns_rows, already_materialized_ids):
+        """Wire a mock PostgresConnection that returns turns_rows and already_materialized_ids."""
+        cur = MagicMock()
+        # Two queries: one for turns, one for already-materialized ids
+        cur.description = [
+            ("turn_id",), ("chapter_id",), ("video_id",), ("session_date",),
+            ("start_seconds",), ("end_seconds",),
+        ]
+        # First fetchall returns speaker_turns rows
+        # Second fetchall returns [(turn_id,)] for already-materialized
+        already_rows = [(tid,) for tid in already_materialized_ids]
+        cur.fetchall.side_effect = [turns_rows, already_rows]
+        conn = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        pg = MagicMock()
+        pg.get_qualified_table.side_effect = lambda name: f"test.{name}"
+        pg.get_connection.return_value.__enter__.return_value = conn
+        monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
+        return cur
+
+    def test_already_materialized_turns_excluded(self, monkeypatch):
+        mod = _fresh()
+        turns_rows = [
+            (1, 10, "vid1", "2026-01-01", 0.0, 100.0),
+            (2, 10, "vid1", "2026-01-01", 100.0, 200.0),
+        ]
+        self._make_pg_mock(monkeypatch, mod, turns_rows, already_materialized_ids=[1])
+
+        ti = MagicMock()
+        pushed = {}
+
+        def xcom_push(key, value):
+            pushed[key] = value
+
+        ti.xcom_push.side_effect = xcom_push
+        dag_run = MagicMock()
+        dag_run.conf = {}
+
+        mod._select_task(ti=ti, dag_run=dag_run)
+
+        turns_out = pushed["turns"]
+        returned_ids = [t["turn_id"] for t in turns_out]
+        assert 1 not in returned_ids, "Already-materialized turn_id 1 must be excluded"
+        assert 2 in returned_ids, "Non-materialized turn_id 2 must be included"
+
+    def test_no_turns_when_all_already_materialized(self, monkeypatch):
+        mod = _fresh()
+        turns_rows = [
+            (5, 10, "vid1", "2026-01-01", 0.0, 100.0),
+        ]
+        self._make_pg_mock(monkeypatch, mod, turns_rows, already_materialized_ids=[5])
+
+        ti = MagicMock()
+        pushed = {}
+
+        def xcom_push(key, value):
+            pushed[key] = value
+
+        ti.xcom_push.side_effect = xcom_push
+        dag_run = MagicMock()
+        dag_run.conf = {}
+
+        mod._select_task(ti=ti, dag_run=dag_run)
+
+        assert pushed["turns"] == []
+
+
+# ---------------------------------------------------------------------------
+# 2.10 materialize_turns skips when source video is not found
+# ---------------------------------------------------------------------------
+
+class TestMaterializeTurns:
+    def _turn(self, turn_id=7, chapter_id=3, video_id="vid1",
+              session_date="2026-01-01", start=600.0, end=700.0):
+        return {
+            "turn_id": turn_id,
+            "chapter_id": chapter_id,
+            "video_id": video_id,
+            "session_date": session_date,
+            "start_seconds": start,
+            "end_seconds": end,
+        }
+
+    def test_missing_source_video_skips_without_ffmpeg(self, monkeypatch):
+        mod = _fresh()
+        monkeypatch.setattr(mod, "_find_source_video", lambda date, vid: None)
+        execute_plan = MagicMock()
+        monkeypatch.setattr(mod, "execute_plan", execute_plan)
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = [self._turn()]
+
+        pg = MagicMock()
+        conn = MagicMock()
+        cur = MagicMock()
+        conn.cursor.return_value.__enter__.return_value = cur
+        pg.get_connection.return_value.__enter__.return_value = conn
+        pg.get_qualified_table.side_effect = lambda n: f"test.{n}"
+        monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
+
+        result = mod._materialize_task(ti=ti, dag_run=MagicMock(conf={}))
+
+        execute_plan.assert_not_called()
+        assert result["skipped"] >= 1
+
+    def test_inserts_row_on_success(self, monkeypatch):
+        mod = _fresh()
+        monkeypatch.setattr(mod, "_find_source_video", lambda date, vid: "/data/src.mp4")
+
+        plan_mock = MagicMock()
+        plan_mock.turn_ids = (7,)
+        plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
+        plan_mock.needs_reencode = False
+        plan_mock.output_turn_id = 7
+
+        monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
+        monkeypatch.setattr(mod, "execute_plan", lambda *a, **kw: None)
+        monkeypatch.setattr(
+            "congress_videos.modules.materialization_executor.get_cached_codec",
+            lambda path, cache: "h264",
+        )
+        monkeypatch.setattr(mod, "get_turn_video_path", lambda date, vid, tid: f"/out/{tid}.mp4")
+        monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
+
+        pg = MagicMock()
+        conn = MagicMock()
+        cur = MagicMock()
+        # approved trims query returns empty (no trims)
+        cur.fetchall.return_value = []
+        cur.description = [("turn_id",), ("start_seconds",), ("end_seconds",),
+                           ("is_approved",), ("is_voice_free",)]
+        conn.cursor.return_value.__enter__.return_value = cur
+        pg.get_connection.return_value.__enter__.return_value = conn
+        pg.get_qualified_table.side_effect = lambda n: f"test.{n}"
+        monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = [self._turn()]
+
+        result = mod._materialize_task(ti=ti, dag_run=MagicMock(conf={}))
+
+        # cur.execute should have been called with an INSERT
+        all_calls = [str(c) for c in cur.execute.call_args_list]
+        insert_calls = [c for c in all_calls if "INSERT" in c.upper()]
+        assert len(insert_calls) >= 1, f"Expected INSERT call; got: {all_calls}"
+        assert result["materialized"] >= 1
+
+    def test_no_insert_on_execute_plan_failure(self, monkeypatch):
+        mod = _fresh()
+        monkeypatch.setattr(mod, "_find_source_video", lambda date, vid: "/data/src.mp4")
+
+        plan_mock = MagicMock()
+        plan_mock.turn_ids = (7,)
+        plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
+        plan_mock.needs_reencode = False
+        plan_mock.output_turn_id = 7
+
+        monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
+        monkeypatch.setattr(mod, "execute_plan", MagicMock(side_effect=RuntimeError("ffmpeg boom")))
+        monkeypatch.setattr(mod, "get_turn_video_path", lambda date, vid, tid: f"/out/{tid}.mp4")
+        monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
+
+        pg = MagicMock()
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        cur.description = [("turn_id",), ("start_seconds",), ("end_seconds",),
+                           ("is_approved",), ("is_voice_free",)]
+        conn.cursor.return_value.__enter__.return_value = cur
+        pg.get_connection.return_value.__enter__.return_value = conn
+        pg.get_qualified_table.side_effect = lambda n: f"test.{n}"
+        monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = [self._turn()]
+
+        result = mod._materialize_task(ti=ti, dag_run=MagicMock(conf={}))
+
+        # No INSERT should happen on failure
+        all_calls = [str(c) for c in cur.execute.call_args_list]
+        insert_calls = [c for c in all_calls if "INSERT" in c.upper()]
+        assert len(insert_calls) == 0, f"INSERT must not be called on ffmpeg failure; got: {insert_calls}"
+        assert result["skipped"] >= 1
+
+
+# ---------------------------------------------------------------------------
+# 2.12 collect_results aggregates the summary
+# ---------------------------------------------------------------------------
+
+class TestCollectResults:
+    def test_aggregates_xcom_summary(self, monkeypatch):
+        mod = _fresh()
+        ti = MagicMock()
+        ti.xcom_pull.return_value = {"materialized": 3, "skipped": 1}
+
+        result = mod._collect_task(ti=ti, dag_run=MagicMock(conf={}))
+
+        assert result["materialized"] == 3
+        assert result["skipped"] == 1


### PR DESCRIPTION
Slice **PR2/2** de #88 · **Base: `feat/issue-88-materialize-speaker-videos` (PR #100), NO dev** · depende de que PR1 mergee primero

## Qué hace (PR2 — ejecución ffmpeg + DAG)
Sobre la capa de PR1, ejecuta los cortes AV1-safe y orquesta el DAG on-demand.

- **`congress_videos/modules/materialization_executor.py`** — `execute_plan(plan, source, output, codec)`:
  - 1 keep-interval, h264 → **stream copy** (`-c copy`, rápido).
  - 1 keep-interval, AV1/otros codecs → **re-encode** libx264/aac (evita moov atom inválido en AV1). Política conservadora: solo h264 hace copy.
  - N keep-intervals (excisión de silencio/aplausos aprobados) → **concat demuxer**: N cortes + join `-c copy`, con limpieza de temporales en `finally` (sin fugas en el NAS).
- **`congress_videos/speaker_turn_videos_dag.py`** — on-demand (`schedule=None`): `select_turns` (solo `is_approved=TRUE`) → `materialize_turns` (planifica, resuelve fuente, **salta** turnos ya en `speaker_turn_videos`, ejecuta, inserta con `ON CONFLICT DO NOTHING`) → `collect_results`. Concurrencia acotada: `pool="nas_ffmpeg"` (slots=1) + `max_active_tasks=1`.
- **Ops**: nota del pool `nas_ffmpeg` en el docstring y en `docs/DEPLOYMENT_NAS.md`.

## ⚠️ Antes de mergear
1. **Provisionar el pool** `nas_ffmpeg` con `airflow pools set nas_ffmpeg 1 "..."` o el DAG se queda en cola.
2. **Verificar `airflow dags list-import-errors` a mano en el NAS**: el e2e docker local falla por un conflicto **pre-existente** numpy/snowflake (reproduce en dev, no es regresión de este cambio).

## Test plan
- [x] 25 tests nuevos (ejecutor con subprocess/codec mockeados: stream-copy h264, re-encode AV1, re-encode h265, excisión multi-intervalo, limpieza de temporales; DAG load + wiring + idempotencia + filtro approved-only). TDD RED→GREEN.
- [x] Suite completa: 2312 verdes, 87.32% cobertura.
- [ ] Import del DAG confirmado en entorno Airflow real (NAS) — pendiente manual.