### PR TITLE
feat(analytics): video_analytics_snapshots schema + checkpoint config + YT Analytics client (#53, PR1/2)

### DIFF
--- a/congress_videos/config/analytics_config.py
+++ b/congress_videos/config/analytics_config.py
@@ -1,0 +1,31 @@
+"""
+Analytics configuration for video_analytics_checkpoints.
+
+Plain Python dict — no Airflow Variables, no runtime dependencies.
+Import-safe in any context (pure Python module).
+"""
+
+# Checkpoint labels mapped to their elapsed-time thresholds in hours.
+# A snapshot is collected once per (youtube_video_id, checkpoint) pair
+# when the video age >= CHECKPOINTS[label] hours and no snapshot exists yet.
+CHECKPOINTS: dict[str, int] = {
+    "24h": 24,
+    "48h": 48,
+    "7d": 168,
+    "30d": 720,
+    "90d": 2160,
+}
+
+# Maximum monitoring window in hours (90 days).
+# Videos uploaded more than this many hours ago are excluded from collection.
+MAX_WINDOW_HOURS: int = 2160
+
+# Ordered list of metric field names expected in every snapshot JSONB payload.
+# Matches the columnHeaders returned by the YouTube Analytics API reports.query.
+METRIC_FIELDS: list[str] = [
+    "views",
+    "impressions",
+    "impressionClickThroughRate",
+    "averageViewDuration",
+    "watchTimeMinutes",
+]

--- a/congress_videos/sql/migrations/026_create_video_analytics_snapshots.sql
+++ b/congress_videos/sql/migrations/026_create_video_analytics_snapshots.sql
@@ -1,0 +1,30 @@
+-- Migration 026: Create video_analytics_snapshots table
+--
+-- Stores YouTube Analytics metrics at fixed post-upload checkpoints
+-- (24h, 48h, 7d, 30d, 90d) for each uploaded chapter video.
+--
+-- Exactly-once persistence is enforced by the UNIQUE constraint on
+-- (youtube_video_id, checkpoint). The analytics DAG queries pending
+-- pairs (NOT EXISTS) before calling the Analytics API.
+--
+-- action_taken is a reserved NULL placeholder for future threshold
+-- evaluation (#102) and is never written by this change.
+--
+-- Migration is idempotent via CREATE TABLE IF NOT EXISTS.
+
+CREATE TABLE IF NOT EXISTS video_analytics_snapshots (
+    snapshot_id       SERIAL PRIMARY KEY,
+    chapter_id        INTEGER      NOT NULL REFERENCES video_chapters(chapter_id) ON DELETE CASCADE,
+    youtube_video_id  VARCHAR(50)  NOT NULL,
+    checkpoint        TEXT         NOT NULL,          -- '24h'|'48h'|'7d'|'30d'|'90d'
+    metrics           JSONB        NOT NULL,          -- {views, impressions, impressionClickThroughRate, averageViewDuration, watchTimeMinutes}
+    action_taken      TEXT,                           -- reserved NULL placeholder for #102; never written by this change
+    collected_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+    CONSTRAINT uq_video_analytics_snapshot UNIQUE (youtube_video_id, checkpoint)
+);
+
+CREATE INDEX IF NOT EXISTS idx_video_analytics_chapter
+    ON video_analytics_snapshots (chapter_id);
+
+-- Down migration:
+-- DROP TABLE IF EXISTS video_analytics_snapshots;

--- a/tests/congress_videos/config/test_analytics_config.py
+++ b/tests/congress_videos/config/test_analytics_config.py
@@ -1,0 +1,115 @@
+"""[RED] Tests for congress_videos.config.analytics_config.
+
+Verifies:
+- CHECKPOINTS is a plain dict with exactly five keys and the correct hour values
+- MAX_WINDOW_HOURS equals 2160 (90 days in hours)
+- METRIC_FIELDS is a list of exactly five field names
+- No Airflow imports leak into this module (import succeeds in isolation)
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def fresh_import():
+    """Force fresh import of analytics_config for each test."""
+    module_name = "congress_videos.config.analytics_config"
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+    yield
+    if module_name in sys.modules:
+        del sys.modules[module_name]
+
+
+def _load():
+    return importlib.import_module("congress_videos.config.analytics_config")
+
+
+class TestCheckpoints:
+
+    def test_checkpoints_has_exactly_five_keys(self):
+        cfg = _load()
+        assert set(cfg.CHECKPOINTS.keys()) == {"24h", "48h", "7d", "30d", "90d"}
+
+    def test_checkpoint_24h_is_24_hours(self):
+        cfg = _load()
+        assert cfg.CHECKPOINTS["24h"] == 24
+
+    def test_checkpoint_48h_is_48_hours(self):
+        cfg = _load()
+        assert cfg.CHECKPOINTS["48h"] == 48
+
+    def test_checkpoint_7d_is_168_hours(self):
+        cfg = _load()
+        assert cfg.CHECKPOINTS["7d"] == 168
+
+    def test_checkpoint_30d_is_720_hours(self):
+        cfg = _load()
+        assert cfg.CHECKPOINTS["30d"] == 720
+
+    def test_checkpoint_90d_is_2160_hours(self):
+        cfg = _load()
+        assert cfg.CHECKPOINTS["90d"] == 2160
+
+    def test_checkpoints_is_plain_dict(self):
+        cfg = _load()
+        assert isinstance(cfg.CHECKPOINTS, dict)
+
+
+class TestMaxWindowHours:
+
+    def test_max_window_hours_equals_2160(self):
+        cfg = _load()
+        assert cfg.MAX_WINDOW_HOURS == 2160
+
+    def test_max_window_hours_matches_90d_checkpoint(self):
+        cfg = _load()
+        assert cfg.MAX_WINDOW_HOURS == cfg.CHECKPOINTS["90d"]
+
+
+class TestMetricFields:
+
+    def test_metric_fields_has_exactly_five_entries(self):
+        cfg = _load()
+        assert len(cfg.METRIC_FIELDS) == 5
+
+    def test_metric_fields_contains_views(self):
+        cfg = _load()
+        assert "views" in cfg.METRIC_FIELDS
+
+    def test_metric_fields_contains_impressions(self):
+        cfg = _load()
+        assert "impressions" in cfg.METRIC_FIELDS
+
+    def test_metric_fields_contains_impression_ctr(self):
+        cfg = _load()
+        assert "impressionClickThroughRate" in cfg.METRIC_FIELDS
+
+    def test_metric_fields_contains_average_view_duration(self):
+        cfg = _load()
+        assert "averageViewDuration" in cfg.METRIC_FIELDS
+
+    def test_metric_fields_contains_watch_time_minutes(self):
+        cfg = _load()
+        assert "watchTimeMinutes" in cfg.METRIC_FIELDS
+
+    def test_metric_fields_is_a_list(self):
+        cfg = _load()
+        assert isinstance(cfg.METRIC_FIELDS, list)
+
+
+class TestNoAirflowImports:
+
+    def test_module_imports_without_airflow(self, monkeypatch):
+        """analytics_config must not require Airflow to import."""
+        # Block airflow from being importable; module must still load
+        monkeypatch.setitem(sys.modules, "airflow", None)
+        monkeypatch.setitem(sys.modules, "airflow.models", None)
+        # Should not raise even if airflow is absent
+        cfg = _load()
+        assert cfg.CHECKPOINTS is not None

--- a/tests/congress_videos/sql/test_migration_026.py
+++ b/tests/congress_videos/sql/test_migration_026.py
@@ -1,0 +1,130 @@
+"""[RED] Test: migration 026 — create video_analytics_snapshots table.
+
+Reads the SQL file statically and asserts structural properties:
+file exists, CREATE TABLE IF NOT EXISTS, required columns, FK to video_chapters,
+UNIQUE constraint on (youtube_video_id, checkpoint), JSONB metrics column,
+nullable action_taken column, and DOWN block.
+No DB connection required.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+MIGRATION_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "congress_videos"
+    / "sql"
+    / "migrations"
+    / "026_create_video_analytics_snapshots.sql"
+)
+
+
+class TestMigration026FileExists:
+
+    def test_migration_file_exists(self):
+        """Migration file must exist at the expected path."""
+        assert MIGRATION_PATH.exists(), f"Migration file not found: {MIGRATION_PATH}"
+
+
+class TestMigration026TableDefinition:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_creates_table_if_not_exists(self):
+        """Migration must use CREATE TABLE IF NOT EXISTS for idempotency."""
+        sql = self._sql().upper()
+        assert "CREATE TABLE IF NOT EXISTS VIDEO_ANALYTICS_SNAPSHOTS" in sql
+
+    def test_chapter_id_column_fk_references_video_chapters(self):
+        """chapter_id must reference video_chapters(chapter_id)."""
+        sql = self._sql()
+        assert "REFERENCES video_chapters(chapter_id)" in sql
+
+    def test_fk_has_on_delete_cascade(self):
+        """FK must include ON DELETE CASCADE."""
+        sql = self._sql().upper()
+        assert "ON DELETE CASCADE" in sql
+
+    def test_youtube_video_id_column_not_null(self):
+        """youtube_video_id must be NOT NULL."""
+        sql = self._sql().upper()
+        assert "YOUTUBE_VIDEO_ID" in sql
+        assert re.search(r"YOUTUBE_VIDEO_ID\s+VARCHAR\S*\s+NOT\s+NULL", sql) or \
+               re.search(r"YOUTUBE_VIDEO_ID\s+TEXT\s+NOT\s+NULL", sql), (
+            "youtube_video_id must be NOT NULL"
+        )
+
+    def test_checkpoint_column_text_not_null(self):
+        """checkpoint column must be TEXT NOT NULL."""
+        sql = self._sql().upper()
+        assert re.search(r"CHECKPOINT\s+TEXT\s+NOT\s+NULL", sql), (
+            "checkpoint must be TEXT NOT NULL"
+        )
+
+    def test_metrics_column_jsonb_not_null(self):
+        """metrics column must be JSONB NOT NULL."""
+        sql = self._sql().upper()
+        assert re.search(r"METRICS\s+JSONB\s+NOT\s+NULL", sql), (
+            "metrics must be JSONB NOT NULL"
+        )
+
+    def test_action_taken_column_text_nullable(self):
+        """action_taken column must exist as TEXT with no NOT NULL constraint (nullable)."""
+        sql = self._sql().upper()
+        assert "ACTION_TAKEN" in sql
+        # action_taken must NOT be followed by NOT NULL
+        lines = [line for line in sql.splitlines() if "ACTION_TAKEN" in line]
+        assert lines, "action_taken column must be present"
+        for line in lines:
+            assert "NOT NULL" not in line, (
+                f"action_taken must be nullable (no NOT NULL), got: {line}"
+            )
+
+    def test_collected_at_column_timestamptz_not_null_default_now(self):
+        """collected_at must be TIMESTAMPTZ NOT NULL DEFAULT NOW()."""
+        sql = self._sql().upper()
+        assert re.search(
+            r"COLLECTED_AT\s+TIMESTAMPTZ\s+NOT\s+NULL\s+DEFAULT\s+NOW\(\)",
+            sql,
+        ), "collected_at must be TIMESTAMPTZ NOT NULL DEFAULT NOW()"
+
+    def test_unique_constraint_on_youtube_video_id_and_checkpoint(self):
+        """UNIQUE constraint on (youtube_video_id, checkpoint) must be present."""
+        sql = self._sql().upper()
+        # Named CONSTRAINT ... UNIQUE (youtube_video_id, checkpoint)
+        assert re.search(
+            r"UNIQUE\s*\(\s*YOUTUBE_VIDEO_ID\s*,\s*CHECKPOINT\s*\)",
+            sql,
+        ), "UNIQUE (youtube_video_id, checkpoint) constraint must be present"
+
+    def test_index_on_chapter_id_is_idempotent(self):
+        """Index on chapter_id must use CREATE INDEX IF NOT EXISTS."""
+        sql = self._sql().upper()
+        assert "CREATE INDEX IF NOT EXISTS" in sql
+        assert "VIDEO_ANALYTICS" in sql  # index references this table
+
+    def test_no_schema_qualification(self):
+        """Migration must use unqualified table names."""
+        sql = self._sql()
+        assert not re.search(r"\bpublic\.video_analytics_snapshots\b", sql)
+        assert not re.search(r"\bpublic\.video_chapters\b", sql)
+
+
+class TestMigration026DownBlock:
+
+    @staticmethod
+    def _sql() -> str:
+        return MIGRATION_PATH.read_text(encoding="utf-8")
+
+    def test_down_block_references_video_analytics_snapshots(self):
+        """DOWN block must reference video_analytics_snapshots for rollback."""
+        sql = self._sql().upper()
+        drop_lines = [
+            line for line in sql.splitlines()
+            if "VIDEO_ANALYTICS_SNAPSHOTS" in line and "DROP" in line
+        ]
+        assert drop_lines, "DOWN block must drop video_analytics_snapshots table"

--- a/tests/utils/test_youtube_analytics_service.py
+++ b/tests/utils/test_youtube_analytics_service.py
@@ -1,0 +1,114 @@
+"""[RED] Tests for utils.youtube_helpers.get_youtube_analytics_service.
+
+Verifies:
+- Function calls build('youtubeAnalytics', 'v2', credentials=...) with correct args
+- Function reuses the same pickle-load + refresh path as get_authenticated_youtube_service
+- Missing token file raises FileNotFoundError
+- Expired token is refreshed before building the service
+- Returns the service object produced by build()
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, call
+
+import pytest
+
+from utils.youtube_helpers import get_youtube_analytics_service
+
+
+class TestGetYoutubeAnalyticsServiceMissingToken:
+
+    def test_missing_token_file_raises_file_not_found(self, tmp_path):
+        """Must raise FileNotFoundError when token file does not exist."""
+        missing = str(tmp_path / "no_analytics_token.pickle")
+        with pytest.raises(FileNotFoundError, match="Token file not found"):
+            get_youtube_analytics_service(missing)
+
+
+class TestGetYoutubeAnalyticsServiceBuildsCorrectApi:
+
+    def test_calls_build_with_youtube_analytics_v2(self, mocker, tmp_path):
+        """Must call build('youtubeAnalytics', 'v2', ...) — not the Data API."""
+        token_file = tmp_path / "token.pickle"
+        token_file.write_bytes(b"placeholder")
+
+        fake_creds = MagicMock()
+        fake_creds.expired = False
+        fake_creds.refresh_token = None
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b""))
+        mocker.patch("utils.youtube_helpers.pickle.load", return_value=fake_creds)
+        mock_build = mocker.patch("utils.youtube_helpers.build", return_value=MagicMock())
+
+        get_youtube_analytics_service(str(token_file))
+
+        # Verify the positional args are ('youtubeAnalytics', 'v2')
+        assert mock_build.call_count == 1
+        pos_args = mock_build.call_args.args
+        assert pos_args[0] == "youtubeAnalytics", (
+            f"First arg to build() must be 'youtubeAnalytics', got '{pos_args[0]}'"
+        )
+        assert pos_args[1] == "v2", (
+            f"Second arg to build() must be 'v2', got '{pos_args[1]}'"
+        )
+
+    def test_returns_service_from_build(self, mocker, tmp_path):
+        """Must return the object produced by build()."""
+        token_file = tmp_path / "token.pickle"
+        token_file.write_bytes(b"placeholder")
+
+        fake_creds = MagicMock()
+        fake_creds.expired = False
+        fake_creds.refresh_token = None
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b""))
+        mocker.patch("utils.youtube_helpers.pickle.load", return_value=fake_creds)
+
+        fake_service = MagicMock(name="analytics_service")
+        mocker.patch("utils.youtube_helpers.build", return_value=fake_service)
+
+        result = get_youtube_analytics_service(str(token_file))
+
+        assert result is fake_service
+
+    def test_credentials_passed_to_build(self, mocker, tmp_path):
+        """Loaded credentials must be forwarded to build() as keyword arg."""
+        token_file = tmp_path / "token.pickle"
+        token_file.write_bytes(b"placeholder")
+
+        fake_creds = MagicMock(name="my_creds")
+        fake_creds.expired = False
+        fake_creds.refresh_token = None
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b""))
+        mocker.patch("utils.youtube_helpers.pickle.load", return_value=fake_creds)
+        mock_build = mocker.patch("utils.youtube_helpers.build", return_value=MagicMock())
+
+        get_youtube_analytics_service(str(token_file))
+
+        kwargs = mock_build.call_args.kwargs
+        assert "credentials" in kwargs, "build() must receive credentials= keyword arg"
+        assert kwargs["credentials"] is fake_creds
+
+
+class TestGetYoutubeAnalyticsServiceTokenRefresh:
+
+    def test_expired_token_is_refreshed_before_build(self, mocker, tmp_path):
+        """Expired credentials must be refreshed before build() is called."""
+        token_file = tmp_path / "token.pickle"
+        token_file.write_bytes(b"placeholder")
+
+        fake_creds = MagicMock()
+        fake_creds.expired = True
+        fake_creds.refresh_token = "refresh-tok"
+
+        mocker.patch("builtins.open", mocker.mock_open(read_data=b""))
+        mocker.patch("utils.youtube_helpers.pickle.load", return_value=fake_creds)
+        mocker.patch("utils.youtube_helpers.pickle.dump")
+        mocker.patch("utils.youtube_helpers.build", return_value=MagicMock())
+        mocker.patch("utils.youtube_helpers.Request")
+
+        get_youtube_analytics_service(str(token_file))
+
+        fake_creds.refresh.assert_called_once()

--- a/utils/youtube_helpers.py
+++ b/utils/youtube_helpers.py
@@ -68,6 +68,51 @@ def get_authenticated_youtube_service(token_file: str):
     return youtube
 
 
+def get_youtube_analytics_service(token_file: str):
+    """
+    Get authenticated YouTube Analytics API service using saved OAuth token.
+
+    Reuses the same pickle-load and token-refresh path as
+    ``get_authenticated_youtube_service`` but targets the
+    ``youtubeAnalytics v2`` API with ``yt-analytics.readonly`` scope.
+
+    Args:
+        token_file: Path to the OAuth token pickle file.  The token must
+            have been generated with the ``yt-analytics.readonly`` scope
+            (see ``generate_youtube_token.py``).
+
+    Returns:
+        Resource: Authenticated YouTube Analytics API service object.
+
+    Raises:
+        FileNotFoundError: If the token file does not exist.
+        Exception: If authentication or service construction fails.
+    """
+    if not os.path.exists(token_file):
+        raise FileNotFoundError(
+            f"Token file not found: {token_file}. "
+            "Please authenticate first using the token generation script."
+        )
+
+    logging.info(f"Loading YouTube Analytics credentials from {token_file}")
+
+    with open(token_file, 'rb') as token:
+        credentials = pickle.load(token)
+
+    if credentials.expired and credentials.refresh_token:
+        logging.info("Token expired. Refreshing...")
+        credentials.refresh(Request())
+
+        with open(token_file, 'wb') as token:
+            pickle.dump(credentials, token)
+        logging.info("Token refreshed and saved")
+
+    service = build('youtubeAnalytics', 'v2', credentials=credentials)
+    logging.info("YouTube Analytics service authenticated successfully")
+
+    return service
+
+
 def upload_video_to_youtube(
     youtube,
     video_file: str,


### PR DESCRIPTION
## PR1 de 2 — issue #53 (recolección de métricas de vídeo por checkpoints)

Primer slice (feature-branch-chain) del DAG de analítica. **Solo cimientos**, sin lógica de negocio ni DAG todavía (eso es PR2).

### Incluye
- **Migración `026_create_video_analytics_snapshots.sql`**: tabla `video_analytics_snapshots` (`chapter_id` FK → `video_chapters`, `youtube_video_id`, `checkpoint`, `collected_at`, `metrics` JSONB, `action_taken` reservada NULL). UNIQUE `(youtube_video_id, checkpoint)` para idempotencia una-vez-por-checkpoint. Idempotente (`IF NOT EXISTS`).
- **`congress_videos/config/analytics_config.py`**: checkpoints 24h/48h/7d/30d/90d + ventana ≤90d. Sin Airflow Variables (dict Python, convención del proyecto).
- **`get_youtube_analytics_service()`** en `utils/youtube_helpers.py`: cliente `youtubeAnalytics` v2 (scope `yt-analytics.readonly`).

### Alcance / decisiones
- Issue #53 acotado a **solo recolección de métricas**; las acciones automáticas (thumbnail/title swap) se movieron a **#102**.
- `action_taken` existe en el DDL como placeholder forward-compat pero **ningún código la escribe** (verificado por grep global).

### Tests
- TDD estricto (RED→GREEN→REFACTOR). 35 tests nuevos.
- Suite completa: **2372 passed, 1 skipped**, sin regresiones.

### Prerrequisito de deploy (no es código)
El token OAuth `congress_youtube_token.pickle` debe regenerarse con el scope `yt-analytics.readonly` antes de que la recolección funcione en prod (lo consumirá PR2).

Siguiente: **PR2** (módulo puro `video_analytics.py` + métodos DB + DAG) apuntando a esta rama.

Closes parcial de #53.