### PR TITLE
fix(#88): resolver video_id via JOIN a video_chapters (bug de esquema en select_turns)

### DIFF
--- a/congress_videos/speaker_turn_videos_dag.py
+++ b/congress_videos/speaker_turn_videos_dag.py
@@ -36,21 +36,48 @@ Pipeline::
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timedelta, timezone
 
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 
-from congress_videos.config.paths import get_turn_video_path
+from congress_videos.config.paths import DOWNLOADS_DIR, get_turn_video_path
 from congress_videos.modules.materialization import plan_turn_materialization
 from congress_videos.modules.materialization_executor import execute_plan
-from congress_videos.modules.vad_helpers import _find_source_video
 from utils.codec_detection import get_cached_codec
 from utils.postgres_helpers import PostgresConnection
 
 logger = logging.getLogger(__name__)
 
 DAG_ID = "speaker_turn_videos"
+
+_MEDIA_SUFFIXES = (".mp4", ".mkv", ".webm")
+
+
+def _find_source_video_any_date(video_id: str) -> str | None:
+    """Locate the source media for a video without knowing its session date.
+
+    ``speaker_turns`` carries no recording date, so scan every date folder
+    under ``DOWNLOADS_DIR`` for ``downloads/{date}/{video_id}/`` and return the
+    first real media file (mirrors ``reap_clip_preparer``'s date-less lookup).
+    """
+    if not os.path.isdir(DOWNLOADS_DIR):
+        return None
+    for date_folder in sorted(os.listdir(DOWNLOADS_DIR)):
+        video_dir = os.path.join(DOWNLOADS_DIR, date_folder, str(video_id))
+        if not os.path.isdir(video_dir):
+            continue
+        for filename in sorted(os.listdir(video_dir)):
+            if filename.endswith(_MEDIA_SUFFIXES) and "chapter_video" not in filename:
+                return os.path.join(video_dir, filename)
+    return None
+
+
+def _date_from_source_path(source_path: str) -> str:
+    """Extract the ``{date}`` segment from ``{DOWNLOADS_DIR}/{date}/{video_id}/...``."""
+    rel = os.path.relpath(source_path, DOWNLOADS_DIR)
+    return rel.split(os.sep)[0]
 
 
 # ---------------------------------------------------------------------------
@@ -72,25 +99,29 @@ def _select_task(**context) -> list[dict]:
 
     pg = PostgresConnection()
     turns_table = pg.get_qualified_table("speaker_turns")
+    chapters_table = pg.get_qualified_table("video_chapters")
     stv_table = pg.get_qualified_table("speaker_turn_videos")
-    cols = "turn_id, chapter_id, video_id, session_date, start_seconds, end_seconds"
+    # video_id lives on video_chapters, not speaker_turns; join to resolve it.
+    cols = "st.turn_id, st.chapter_id, vc.video_id, st.start_seconds, st.end_seconds"
+    base = (
+        f"SELECT {cols} FROM {turns_table} st "
+        f"JOIN {chapters_table} vc ON vc.chapter_id = st.chapter_id"
+    )
 
     with pg.get_connection() as conn:
         with conn.cursor() as cur:
             if chapter_id is not None:
                 cur.execute(
-                    f"SELECT {cols} FROM {turns_table} WHERE chapter_id = %s ORDER BY turn_id",
+                    f"{base} WHERE st.chapter_id = %s ORDER BY st.turn_id",
                     (chapter_id,),
                 )
             elif video_id is not None:
                 cur.execute(
-                    f"SELECT {cols} FROM {turns_table} WHERE video_id = %s ORDER BY turn_id",
+                    f"{base} WHERE vc.video_id = %s ORDER BY st.turn_id",
                     (str(video_id),),
                 )
             else:
-                cur.execute(
-                    f"SELECT {cols} FROM {turns_table} ORDER BY turn_id LIMIT 10"
-                )
+                cur.execute(f"{base} ORDER BY st.turn_id LIMIT 10")
             names = [d[0] for d in cur.description]
             turns = [dict(zip(names, row)) for row in cur.fetchall()]
 
@@ -154,17 +185,20 @@ def _materialize_task(**context) -> dict:
             first_turn = next(
                 t for t in turns if t["turn_id"] == plan.turn_ids[0]
             )
-            session_date = str(first_turn.get("session_date"))
             video_id = str(first_turn["video_id"])
 
-            source_path = _find_source_video(session_date, video_id)
+            source_path = _find_source_video_any_date(video_id)
             if not source_path:
                 logger.warning(
-                    "speaker_turn_videos: no source video for date=%s video_id=%s — skipping plan turn_ids=%s",
-                    session_date, video_id, plan.turn_ids,
+                    "speaker_turn_videos: no source video for video_id=%s — skipping plan turn_ids=%s",
+                    video_id, plan.turn_ids,
                 )
                 summary["skipped"] += len(plan.turn_ids)
                 continue
+
+            # Recording date is not stored in the DB; derive it from the folder
+            # the source video was found in, for the canonical output path.
+            session_date = _date_from_source_path(source_path)
 
             # Derive output path using first (naming) turn_id
             output_path = get_turn_video_path(

--- a/tests/congress_videos/test_speaker_turn_videos_dag.py
+++ b/tests/congress_videos/test_speaker_turn_videos_dag.py
@@ -63,9 +63,11 @@ class TestSelectTurns:
     def _make_pg_mock(self, monkeypatch, mod, turns_rows, already_materialized_ids):
         """Wire a mock PostgresConnection that returns turns_rows and already_materialized_ids."""
         cur = MagicMock()
-        # Two queries: one for turns, one for already-materialized ids
+        # Two queries: one for turns, one for already-materialized ids.
+        # video_id comes from the JOIN to video_chapters; speaker_turns has no
+        # video_id or session_date column.
         cur.description = [
-            ("turn_id",), ("chapter_id",), ("video_id",), ("session_date",),
+            ("turn_id",), ("chapter_id",), ("video_id",),
             ("start_seconds",), ("end_seconds",),
         ]
         # First fetchall returns speaker_turns rows
@@ -83,8 +85,8 @@ class TestSelectTurns:
     def test_already_materialized_turns_excluded(self, monkeypatch):
         mod = _fresh()
         turns_rows = [
-            (1, 10, "vid1", "2026-01-01", 0.0, 100.0),
-            (2, 10, "vid1", "2026-01-01", 100.0, 200.0),
+            (1, 10, "vid1", 0.0, 100.0),
+            (2, 10, "vid1", 100.0, 200.0),
         ]
         self._make_pg_mock(monkeypatch, mod, turns_rows, already_materialized_ids=[1])
 
@@ -105,10 +107,36 @@ class TestSelectTurns:
         assert 1 not in returned_ids, "Already-materialized turn_id 1 must be excluded"
         assert 2 in returned_ids, "Non-materialized turn_id 2 must be included"
 
+    def test_select_joins_video_chapters_and_omits_session_date(self, monkeypatch):
+        """Regression: speaker_turns has no video_id/session_date columns.
+
+        video_id must be resolved via a JOIN to video_chapters, and
+        session_date must never be selected (it does not exist anywhere).
+        A prod run failed with UndefinedColumn before this fix.
+        """
+        mod = _fresh()
+        cur = self._make_pg_mock(
+            monkeypatch, mod,
+            turns_rows=[(1, 10, "vid1", 0.0, 100.0)],
+            already_materialized_ids=[],
+        )
+
+        ti = MagicMock()
+        ti.xcom_push.side_effect = lambda key, value: None
+        mod._select_task(ti=ti, dag_run=MagicMock(conf={"chapter_id": 10}))
+
+        select_sql = cur.execute.call_args_list[0].args[0].lower()
+        assert "join" in select_sql and "video_chapters" in select_sql, (
+            f"select must JOIN video_chapters to resolve video_id; got: {select_sql}"
+        )
+        assert "session_date" not in select_sql, (
+            f"session_date is not a real column and must not be selected; got: {select_sql}"
+        )
+
     def test_no_turns_when_all_already_materialized(self, monkeypatch):
         mod = _fresh()
         turns_rows = [
-            (5, 10, "vid1", "2026-01-01", 0.0, 100.0),
+            (5, 10, "vid1", 0.0, 100.0),
         ]
         self._make_pg_mock(monkeypatch, mod, turns_rows, already_materialized_ids=[5])
 
@@ -133,19 +161,18 @@ class TestSelectTurns:
 
 class TestMaterializeTurns:
     def _turn(self, turn_id=7, chapter_id=3, video_id="vid1",
-              session_date="2026-01-01", start=600.0, end=700.0):
+              start=600.0, end=700.0):
         return {
             "turn_id": turn_id,
             "chapter_id": chapter_id,
             "video_id": video_id,
-            "session_date": session_date,
             "start_seconds": start,
             "end_seconds": end,
         }
 
     def test_missing_source_video_skips_without_ffmpeg(self, monkeypatch):
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda date, vid: None)
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: None)
         execute_plan = MagicMock()
         monkeypatch.setattr(mod, "execute_plan", execute_plan)
 
@@ -167,7 +194,7 @@ class TestMaterializeTurns:
 
     def test_inserts_row_on_success(self, monkeypatch):
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda date, vid: "/data/src.mp4")
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: "/data/src.mp4")
 
         plan_mock = MagicMock()
         plan_mock.turn_ids = (7,)
@@ -209,7 +236,7 @@ class TestMaterializeTurns:
 
     def test_no_insert_on_execute_plan_failure(self, monkeypatch):
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda date, vid: "/data/src.mp4")
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: "/data/src.mp4")
 
         plan_mock = MagicMock()
         plan_mock.turn_ids = (7,)


### PR DESCRIPTION
Hotfix de #88 (post-merge). Descubierto al **probar el DAG manualmente en dev**.

## Bug
Un run real de `speaker_turn_videos` falló en `select_turns`:
```
psycopg2.errors.UndefinedColumn: column "video_id" does not exist
SELECT turn_id, chapter_id, video_id, session_date, start_seconds, end_seconds FROM ... speaker_turns ...
```
`speaker_turns` (migración 022) solo tiene `chapter_id` — **no** `video_id` ni `session_date`. Los tests unitarios mockeaban el cursor, así que el desajuste de esquema era invisible.

## Fix
- `select_turns` hace **JOIN a `video_chapters`** para resolver `video_id`; se elimina `session_date` (no existe en ninguna tabla).
- El vídeo fuente se localiza **sin fecha**, escaneando `downloads/*/{video_id}/` (mismo patrón probado que `reap_clip_preparer`); la fecha de grabación se **deriva de la carpeta encontrada** para el output path canónico.
- Tests actualizados al esquema real + **regresión** que inspecciona la SQL y falla si no hay JOIN a `video_chapters` o si se vuelve a seleccionar `session_date`.

## Test plan
- [x] `tests/congress_videos/test_speaker_turn_videos_dag.py` — 11 pasan (incl. regresión nueva)
- [x] Suite completa: **2334 passed**, 1 skipped, cobertura 87.18%
- [ ] Re-probar el trigger manual del DAG en dev tras el merge