### PR TITLE
feat(analytics): pending-checkpoint logic + snapshot persistence + hourly collection DAG (#53, PR2/2)

### DIFF
--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1438,6 +1438,45 @@ class CongressionalVideoDB:
                 )
                 return list(rows)
 
+    def get_collected_analytics_pairs(
+        self, youtube_video_ids: list[str]
+    ) -> set[tuple[str, str]]:
+        """Return already-collected (youtube_video_id, checkpoint) pairs.
+
+        Used by the hourly analytics DAG to skip re-fetching data already
+        persisted in video_analytics_snapshots, saving Analytics API quota.
+
+        Args:
+            youtube_video_ids: List of YouTube video IDs to check. An empty
+                list returns an empty set immediately without hitting the DB.
+
+        Returns:
+            Set of (youtube_video_id, checkpoint) tuples for which a snapshot
+            row already exists.
+        """
+        if not youtube_video_ids:
+            return set()
+
+        snapshots_table = self.pg_conn.get_qualified_table("video_analytics_snapshots")
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT youtube_video_id, checkpoint
+                    FROM {snapshots_table}
+                    WHERE youtube_video_id = ANY(%s)
+                    """,
+                    (youtube_video_ids,),
+                )
+                rows = cur.fetchall()
+                logger.info(
+                    "get_collected_analytics_pairs: %d already-collected pairs "
+                    "for %d video ids",
+                    len(rows),
+                    len(youtube_video_ids),
+                )
+                return {(row["youtube_video_id"], row["checkpoint"]) for row in rows}
+
     def record_analytics_snapshot(
         self,
         chapter_id: int,

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1400,3 +1400,78 @@ class CongressionalVideoDB:
                     (video_ids,),
                 )
                 return {row['video_id'] for row in cur.fetchall()}
+
+    # ==================== Video Analytics ====================
+
+    def get_pending_analytics_checkpoints(self) -> list:
+        """Return candidate video_chapters rows for analytics collection.
+
+        Returns chapters that:
+        - have a non-null youtube_video_id
+        - are marked as uploaded to YouTube
+        - were uploaded within the last 90 days
+
+        The pure function pending_checkpoints() in video_analytics.py expands
+        these rows into (youtube_video_id, checkpoint) pairs and excludes
+        already-collected pairs, so this query stays simple.
+
+        Returns:
+            List of row dicts: {chapter_id, youtube_video_id, youtube_upload_date}
+        """
+        chapters_table = self.pg_conn.get_qualified_table("video_chapters")
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    SELECT chapter_id, youtube_video_id, youtube_upload_date
+                    FROM {chapters_table}
+                    WHERE youtube_video_id IS NOT NULL
+                      AND is_uploaded_to_youtube = TRUE
+                      AND youtube_upload_date >= NOW() - INTERVAL '90 days'
+                    ORDER BY youtube_upload_date DESC
+                    """,
+                )
+                rows = cur.fetchall()
+                logger.info(
+                    "get_pending_analytics_checkpoints: %d candidate chapters found",
+                    len(rows),
+                )
+                return list(rows)
+
+    def record_analytics_snapshot(
+        self,
+        chapter_id: int,
+        youtube_video_id: str,
+        checkpoint: str,
+        metrics: dict,
+    ) -> None:
+        """Persist one analytics snapshot row (ON CONFLICT DO NOTHING).
+
+        Writes exactly the five JSONB metric fields. Does NOT write action_taken
+        (reserved NULL placeholder for issue #102).
+
+        Args:
+            chapter_id: FK to video_chapters.chapter_id.
+            youtube_video_id: YouTube video ID string.
+            checkpoint: One of '24h','48h','7d','30d','90d'.
+            metrics: Dict with keys views, impressions, impressionClickThroughRate,
+                averageViewDuration, watchTimeMinutes.
+        """
+        snapshots_table = self.pg_conn.get_qualified_table("video_analytics_snapshots")
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    INSERT INTO {snapshots_table}
+                        (chapter_id, youtube_video_id, checkpoint, metrics)
+                    VALUES (%s, %s, %s, %s::jsonb)
+                    ON CONFLICT (youtube_video_id, checkpoint) DO NOTHING
+                    """,
+                    (chapter_id, youtube_video_id, checkpoint, json.dumps(metrics)),
+                )
+                logger.info(
+                    "record_analytics_snapshot: chapter_id=%d yt_id=%s checkpoint=%s",
+                    chapter_id,
+                    youtube_video_id,
+                    checkpoint,
+                )

--- a/congress_videos/modules/postgres_operators.py
+++ b/congress_videos/modules/postgres_operators.py
@@ -532,6 +532,33 @@ class PostgreSQLOperator(BaseOperator):
                 }
                 print(f"✅ Updated {updated_count} shorts, {failed_count} failed")
 
+        elif self.operation == 'get_pending_analytics_checkpoints':
+            """Return candidate video chapters for analytics collection."""
+            result = db.get_pending_analytics_checkpoints()
+            print(f"✅ Retrieved {len(result)} candidate chapters for analytics")
+
+        elif self.operation == 'record_analytics_snapshots':
+            """Persist each collected (chapter, checkpoint, metrics) snapshot."""
+            collected = ti.xcom_pull(
+                key=self.xcom_keys.get('collected', 'collected')
+            ) or []
+
+            print(f"DEBUG: recording {len(collected)} analytics snapshots")
+
+            for item in collected:
+                db.record_analytics_snapshot(
+                    chapter_id=item['chapter_id'],
+                    youtube_video_id=item['youtube_video_id'],
+                    checkpoint=item['checkpoint'],
+                    metrics=item['metrics'],
+                )
+                print(
+                    f"✅ Recorded snapshot: chapter_id={item['chapter_id']} "
+                    f"yt_id={item['youtube_video_id']} checkpoint={item['checkpoint']}"
+                )
+
+            result = {'recorded_snapshots': len(collected)}
+
         else:
             raise ValueError(f"Unknown operation: {self.operation}")
 

--- a/congress_videos/modules/video_analytics.py
+++ b/congress_videos/modules/video_analytics.py
@@ -1,0 +1,129 @@
+"""
+Pure analytics helpers for video_analytics_checkpoints (issue #53).
+
+No Airflow imports. No DB or API dependencies.
+All functions are pure: same input -> same output, zero side effects.
+
+Functions:
+- pending_checkpoints(now, videos, collected) -> list[dict]
+- parse_analytics_response(resp)             -> dict
+- should_persist(metrics)                    -> bool
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from congress_videos.config.analytics_config import CHECKPOINTS, MAX_WINDOW_HOURS, METRIC_FIELDS
+
+
+def pending_checkpoints(
+    now: datetime,
+    videos: list[dict[str, Any]],
+    collected: set[tuple[str, str]],
+) -> list[dict[str, Any]]:
+    """Compute the set of (youtube_video_id, checkpoint) pairs that are due.
+
+    Args:
+        now: Current UTC datetime (caller-supplied for testability).
+        videos: Rows from video_chapters. Each row must have:
+            - chapter_id (int)
+            - youtube_video_id (str | None)
+            - youtube_upload_date (datetime, UTC-aware)
+        collected: Set of (youtube_video_id, checkpoint) tuples already persisted.
+
+    Returns:
+        List of dicts {chapter_id, youtube_video_id, checkpoint} for each
+        pending pair where:
+        - youtube_video_id is not None
+        - elapsed hours >= CHECKPOINTS[checkpoint]
+        - elapsed hours <= MAX_WINDOW_HOURS (90d)
+        - (youtube_video_id, checkpoint) not in collected
+    """
+    result: list[dict[str, Any]] = []
+
+    for row in videos:
+        yt_id = row.get("youtube_video_id")
+        if not yt_id:
+            continue
+
+        upload_date: datetime = row["youtube_upload_date"]
+        # Ensure both are timezone-aware for safe arithmetic.
+        if upload_date.tzinfo is None:
+            upload_date = upload_date.replace(tzinfo=timezone.utc)
+        if now.tzinfo is None:
+            now = now.replace(tzinfo=timezone.utc)
+
+        elapsed_hours = (now - upload_date).total_seconds() / 3600.0
+
+        # Exclude videos outside the 90-day monitoring window.
+        if elapsed_hours > MAX_WINDOW_HOURS:
+            continue
+
+        for label, threshold_hours in CHECKPOINTS.items():
+            if elapsed_hours < threshold_hours:
+                continue
+            if (yt_id, label) in collected:
+                continue
+            result.append({
+                "chapter_id": row["chapter_id"],
+                "youtube_video_id": yt_id,
+                "checkpoint": label,
+            })
+
+    return result
+
+
+def parse_analytics_response(resp: dict[str, Any]) -> dict[str, Any | None]:
+    """Map a YouTube Analytics API response to a flat metrics dict.
+
+    Reads 'columnHeaders' and 'rows' from the API response. Returns a dict
+    with exactly the five METRIC_FIELDS keys. Missing columns or an empty
+    rows list yield None for the missing field.
+
+    Args:
+        resp: Raw dict from ``reports.query().execute()``.
+
+    Returns:
+        Dict with keys: views, impressions, impressionClickThroughRate,
+        averageViewDuration, watchTimeMinutes. Value is None when the API
+        did not return that column or returned no rows.
+    """
+    headers = [h["name"] for h in resp.get("columnHeaders", [])]
+    rows = resp.get("rows", [])
+
+    if not rows:
+        return {field: None for field in METRIC_FIELDS}
+
+    row = rows[0]
+    col_index: dict[str, int] = {name: i for i, name in enumerate(headers)}
+
+    metrics: dict[str, Any | None] = {}
+    for field in METRIC_FIELDS:
+        idx = col_index.get(field)
+        metrics[field] = row[idx] if idx is not None else None
+
+    return metrics
+
+
+def should_persist(metrics: dict[str, Any | None]) -> bool:
+    """Decide whether a snapshot row should be written.
+
+    Returns False (skip-and-retry) when ALL metric values are None or zero.
+    Returns True when at least one metric is non-None and non-zero.
+
+    The Analytics API can return all-None or all-zero during the first few
+    hours of a video's life (processing lag). Skipping keeps the
+    (youtube_video_id, checkpoint) pair pending so the next DAG run retries.
+
+    Args:
+        metrics: Dict produced by parse_analytics_response.
+
+    Returns:
+        True if the snapshot is worth persisting, False otherwise.
+    """
+    for value in metrics.values():
+        if value is not None and value != 0:
+            return True
+    return False

--- a/congress_videos/video_analytics_dag.py
+++ b/congress_videos/video_analytics_dag.py
@@ -1,0 +1,237 @@
+"""
+Video Analytics Collection DAG (issue #53)
+
+Collects YouTube Analytics metrics at fixed checkpoints (24h, 48h, 7d, 30d, 90d)
+for every uploaded chapter video. Runs hourly; each run:
+
+1. staleness_guard  — ShortCircuitOperator: skip stale data_interval_end replays
+2. get_pending_checkpoints — fetch candidate chapters from DB
+3. fetch_analytics  — call YouTube Analytics API, filter via should_persist()
+4. record_snapshots — persist surviving (chapter, checkpoint, metrics) rows
+
+Read-only: no YouTube Data API writes, no action_taken column written.
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+
+from airflow import DAG
+from airflow.operators.python import PythonOperator, ShortCircuitOperator
+
+from congress_videos.modules.postgres_operators import PostgreSQLOperator
+from utils.env_loader import load_env_if_local
+
+load_env_if_local()
+
+STALE_RUN_TOLERANCE_MINUTES = int(
+    os.getenv("ANALYTICS_STALE_RUN_TOLERANCE_MINUTES", "30")
+)
+
+_TOKEN_FILE = os.getenv(
+    "YOUTUBE_TOKEN_FILE",
+    os.path.join(os.path.dirname(__file__), "..", "congress_youtube_token.pickle"),
+)
+
+
+def _staleness_guard(**context) -> bool:
+    """Return False for stale data_interval_end replays (skip).
+
+    Mirrors the pattern in youtube_upload_dag.should_upload().
+    Returns True (proceed) when the run is fresh or data_interval_end is absent.
+    """
+    data_interval_end = context.get("data_interval_end")
+    if data_interval_end:
+        now = datetime.now(timezone.utc)
+        staleness = now - data_interval_end
+        if staleness > timedelta(minutes=STALE_RUN_TOLERANCE_MINUTES):
+            logging.info(
+                "video_analytics: skipping stale run: data_interval_end=%s is %s "
+                "behind now=%s (tolerance=%dm)",
+                data_interval_end,
+                staleness,
+                now,
+                STALE_RUN_TOLERANCE_MINUTES,
+            )
+            return False
+    return True
+
+
+def _fetch_analytics(ti, **context) -> list:
+    """Fetch YouTube Analytics metrics for all pending (video, checkpoint) pairs.
+
+    Pulls candidate chapters from XCom, expands via pending_checkpoints(),
+    fetches Analytics API, filters with should_persist(), and pushes the
+    surviving records for the record_snapshots task.
+
+    Returns the list of collected items (also pushed to XCom 'collected').
+    """
+    from congress_videos.config.analytics_config import CHECKPOINTS
+    from congress_videos.modules.video_analytics import (
+        parse_analytics_response,
+        pending_checkpoints,
+        should_persist,
+    )
+    from utils.youtube_helpers import get_youtube_analytics_service
+
+    # Pull DB rows from upstream task
+    candidate_rows = ti.xcom_pull(key="candidates") or []
+
+    if not candidate_rows:
+        logging.info("video_analytics: no candidate rows — nothing to fetch")
+        ti.xcom_push(key="collected", value=[])
+        return []
+
+    # We do not yet have the existing snapshots set from DB in this thin DAG
+    # (the pending query returns ALL uploaded chapters within 90 days;
+    # pair-level exclusion is handled by ON CONFLICT DO NOTHING at insert time
+    # and by the UNIQUE constraint — see design.md).
+    # For the pure-function call we pass an empty set; idempotency is DB-enforced.
+    now = datetime.now(timezone.utc)
+    pending = pending_checkpoints(now, candidate_rows, collected=set())
+
+    if not pending:
+        logging.info("video_analytics: no pending checkpoints after expansion")
+        ti.xcom_push(key="collected", value=[])
+        return []
+
+    logging.info("video_analytics: %d (video, checkpoint) pairs to collect", len(pending))
+
+    try:
+        service = get_youtube_analytics_service(_TOKEN_FILE)
+    except Exception as exc:
+        logging.warning("video_analytics: could not build Analytics service: %s", exc)
+        ti.xcom_push(key="collected", value=[])
+        return []
+
+    collected = []
+    for pair in pending:
+        yt_id: str = pair["youtube_video_id"]
+        checkpoint: str = pair["checkpoint"]
+        threshold_hours: int = CHECKPOINTS[checkpoint]
+
+        # Build the date-range query window: from upload_date to upload_date + threshold
+        upload_date: datetime = pair.get(
+            "youtube_upload_date",
+            now - timedelta(hours=threshold_hours),
+        )
+        if upload_date.tzinfo is None:
+            upload_date = upload_date.replace(tzinfo=timezone.utc)
+
+        start_date = upload_date.strftime("%Y-%m-%d")
+        end_date = (upload_date + timedelta(hours=threshold_hours + 48)).strftime(
+            "%Y-%m-%d"
+        )
+
+        try:
+            resp = (
+                service.reports()
+                .query(
+                    ids=f"channel==MINE",
+                    startDate=start_date,
+                    endDate=end_date,
+                    metrics=",".join(
+                        [
+                            "views",
+                            "impressions",
+                            "impressionClickThroughRate",
+                            "averageViewDuration",
+                            "watchTimeMinutes",
+                        ]
+                    ),
+                    filters=f"video=={yt_id}",
+                )
+                .execute()
+            )
+        except Exception as exc:
+            logging.warning(
+                "video_analytics: API error for yt_id=%s checkpoint=%s: %s",
+                yt_id,
+                checkpoint,
+                exc,
+            )
+            continue
+
+        metrics = parse_analytics_response(resp)
+
+        if not should_persist(metrics):
+            logging.info(
+                "video_analytics: skip-and-retry for yt_id=%s checkpoint=%s "
+                "(all-None or all-zero metrics)",
+                yt_id,
+                checkpoint,
+            )
+            continue
+
+        collected.append(
+            {
+                "chapter_id": pair["chapter_id"],
+                "youtube_video_id": yt_id,
+                "checkpoint": checkpoint,
+                "metrics": metrics,
+            }
+        )
+        logging.info(
+            "video_analytics: collected yt_id=%s checkpoint=%s views=%s",
+            yt_id,
+            checkpoint,
+            metrics.get("views"),
+        )
+
+    ti.xcom_push(key="collected", value=collected)
+    logging.info(
+        "video_analytics: %d snapshots will be persisted", len(collected)
+    )
+    return collected
+
+
+# ---------------------------------------------------------------------------
+# DAG definition
+# ---------------------------------------------------------------------------
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+}
+
+with DAG(
+    "video_analytics",
+    default_args=default_args,
+    description="Collect YouTube Analytics metrics at fixed checkpoints per uploaded chapter",
+    schedule="@hourly",
+    start_date=datetime(2026, 1, 1),
+    catchup=False,
+    tags=["congress", "youtube", "analytics"],
+) as dag:
+
+    # t0: Skip stale data_interval_end replays
+    t0_staleness = ShortCircuitOperator(
+        task_id="staleness_guard",
+        python_callable=_staleness_guard,
+    )
+
+    # t1: Fetch candidate chapters from DB (uploaded, non-null yt_id, within 90d)
+    t1_pending = PostgreSQLOperator(
+        task_id="get_pending_checkpoints",
+        operation="get_pending_analytics_checkpoints",
+        output_xcom_key="candidates",
+    )
+
+    # t2: Call Analytics API; filter via should_persist(); push 'collected' XCom
+    t2_fetch = PythonOperator(
+        task_id="fetch_analytics",
+        python_callable=_fetch_analytics,
+    )
+
+    # t3: Persist snapshot rows (ON CONFLICT DO NOTHING keeps it idempotent)
+    t3_record = PostgreSQLOperator(
+        task_id="record_snapshots",
+        operation="record_analytics_snapshots",
+        xcom_keys={"collected": "collected"},
+    )
+
+    t0_staleness >> t1_pending >> t2_fetch >> t3_record

--- a/congress_videos/video_analytics_dag.py
+++ b/congress_videos/video_analytics_dag.py
@@ -82,13 +82,31 @@ def _fetch_analytics(ti, **context) -> list:
         ti.xcom_push(key="collected", value=[])
         return []
 
-    # We do not yet have the existing snapshots set from DB in this thin DAG
-    # (the pending query returns ALL uploaded chapters within 90 days;
-    # pair-level exclusion is handled by ON CONFLICT DO NOTHING at insert time
-    # and by the UNIQUE constraint — see design.md).
-    # For the pure-function call we pass an empty set; idempotency is DB-enforced.
+    # Query already-collected (youtube_video_id, checkpoint) pairs so we skip
+    # re-fetching data we already have, saving Analytics API daily quota.
+    from congress_videos.modules.database import CongressionalVideoDB
+
+    youtube_video_ids = list(
+        {row["youtube_video_id"] for row in candidate_rows if row.get("youtube_video_id")}
+    )
+    already_collected: set[tuple[str, str]] = set()
+    try:
+        db = CongressionalVideoDB()
+        already_collected = db.get_collected_analytics_pairs(youtube_video_ids)
+        logging.info(
+            "video_analytics: %d already-collected pairs found for %d video ids",
+            len(already_collected),
+            len(youtube_video_ids),
+        )
+    except Exception as exc:
+        logging.warning(
+            "video_analytics: could not load collected pairs from DB, "
+            "proceeding with empty set (idempotency still DB-enforced): %s",
+            exc,
+        )
+
     now = datetime.now(timezone.utc)
-    pending = pending_checkpoints(now, candidate_rows, collected=set())
+    pending = pending_checkpoints(now, candidate_rows, collected=already_collected)
 
     if not pending:
         logging.info("video_analytics: no pending checkpoints after expansion")

--- a/tests/congress_videos/modules/test_postgres_operators.py
+++ b/tests/congress_videos/modules/test_postgres_operators.py
@@ -517,3 +517,114 @@ class TestGetUploadableChaptersQuotaLimit:
         op.execute(ctx)
 
         mock_db.get_uploadable_chapters.assert_called_once_with(limit=1, min_relevance_score=2)
+
+
+# --------------------------------------------------------------------------- #
+# execute — analytics dispatch operations
+# --------------------------------------------------------------------------- #
+
+class TestExecuteGetPendingAnalyticsCheckpoints:
+    """op='get_pending_analytics_checkpoints' routes to db.get_pending_analytics_checkpoints()."""
+
+    def test_routes_to_db_method(self, mock_db, mock_task_instance, make_context):
+        """Executing 'get_pending_analytics_checkpoints' calls the DB method."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db.get_pending_analytics_checkpoints.return_value = [
+            {"chapter_id": 1, "youtube_video_id": "abc", "youtube_upload_date": None}
+        ]
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="get_pending_analytics_checkpoints",
+            output_xcom_key="pending_checkpoints",
+        )
+        ctx = make_context(ti=mock_task_instance)
+        result = op.execute(ctx)
+
+        mock_db.get_pending_analytics_checkpoints.assert_called_once()
+        assert isinstance(result, list)
+
+    def test_pushes_result_to_xcom(self, mock_db, mock_task_instance, make_context):
+        """Result is pushed to XCom under the configured output_xcom_key."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        rows = [{"chapter_id": 2, "youtube_video_id": "xyz", "youtube_upload_date": None}]
+        mock_db.get_pending_analytics_checkpoints.return_value = rows
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="get_pending_analytics_checkpoints",
+            output_xcom_key="pending_checkpoints",
+        )
+        ctx = make_context(ti=mock_task_instance)
+        op.execute(ctx)
+
+        assert mock_task_instance.xcom_store.get("pending_checkpoints") == rows
+
+
+class TestExecuteRecordAnalyticsSnapshots:
+    """op='record_analytics_snapshots' routes to db.record_analytics_snapshot() per item."""
+
+    def test_routes_to_db_method_for_each_collected_item(
+        self, mock_db, mock_task_instance, make_context
+    ):
+        """Each item in 'collected' XCom triggers one record_analytics_snapshot call."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        collected = [
+            {
+                "chapter_id": 1,
+                "youtube_video_id": "abc",
+                "checkpoint": "24h",
+                "metrics": {"views": 100, "impressions": 400,
+                            "impressionClickThroughRate": 0.04,
+                            "averageViewDuration": 30.0,
+                            "watchTimeMinutes": 50.0},
+            }
+        ]
+        mock_task_instance.xcom_store["collected"] = collected
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="record_analytics_snapshots",
+            xcom_keys={"collected": "collected"},
+        )
+        ctx = make_context(ti=mock_task_instance)
+        op.execute(ctx)
+
+        mock_db.record_analytics_snapshot.assert_called_once_with(
+            chapter_id=1,
+            youtube_video_id="abc",
+            checkpoint="24h",
+            metrics=collected[0]["metrics"],
+        )
+
+    def test_action_taken_never_written(
+        self, mock_db, mock_task_instance, make_context
+    ):
+        """record_analytics_snapshot must NOT receive an action_taken argument."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["collected"] = [
+            {
+                "chapter_id": 5,
+                "youtube_video_id": "zzz",
+                "checkpoint": "7d",
+                "metrics": {"views": 1, "impressions": 1,
+                            "impressionClickThroughRate": 0.0,
+                            "averageViewDuration": 0.0,
+                            "watchTimeMinutes": 0.1},
+            }
+        ]
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="record_analytics_snapshots",
+            xcom_keys={"collected": "collected"},
+        )
+        ctx = make_context(ti=mock_task_instance)
+        op.execute(ctx)
+
+        call_kwargs = mock_db.record_analytics_snapshot.call_args.kwargs
+        assert "action_taken" not in call_kwargs

--- a/tests/congress_videos/modules/test_video_analytics.py
+++ b/tests/congress_videos/modules/test_video_analytics.py
@@ -533,3 +533,88 @@ class TestRecordAnalyticsSnapshot:
         assert 42 in all_params
         assert "xyz999" in all_params
         assert "7d" in all_params
+
+
+# ---------------------------------------------------------------------------
+# Tests: CongressionalVideoDB.get_collected_analytics_pairs
+# ---------------------------------------------------------------------------
+
+
+class TestGetCollectedAnalyticsPairs:
+    """Spec: Quota-saving optimization — query already-collected pairs before
+    calling the Analytics API, so pending_checkpoints() can exclude them and
+    avoid re-fetching data we already have.
+
+    Contract:
+    - Empty youtube_video_ids input → return empty set WITHOUT hitting the DB.
+    - Non-empty input → SELECT (youtube_video_id, checkpoint) WHERE
+      youtube_video_id = ANY(%s) and return as set of tuples.
+    - SQL must reference 'video_analytics_snapshots' table.
+    - SQL must use 'youtube_video_id = ANY' for batch lookup.
+    """
+
+    def test_empty_input_returns_empty_set_without_db_call(self):
+        """GIVEN an empty list of youtube_video_ids
+        WHEN get_collected_analytics_pairs is called
+        THEN an empty set is returned and the DB cursor is never queried."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        result = db.get_collected_analytics_pairs([])
+
+        assert result == set()
+        # DB must NOT be hit for empty input (idempotent fast-path)
+        cur.execute.assert_not_called()
+
+    def test_returns_set_of_tuples(self):
+        """GIVEN a list with one youtube_video_id and DB returns two rows
+        WHEN get_collected_analytics_pairs is called
+        THEN a set of (youtube_video_id, checkpoint) tuples is returned."""
+        cur = _make_cursor()
+        cur.fetchall.return_value = [
+            {"youtube_video_id": "abc123", "checkpoint": "24h"},
+            {"youtube_video_id": "abc123", "checkpoint": "48h"},
+        ]
+        db, _ = _make_db(cur)
+
+        result = db.get_collected_analytics_pairs(["abc123"])
+
+        assert isinstance(result, set)
+        assert ("abc123", "24h") in result
+        assert ("abc123", "48h") in result
+        assert len(result) == 2
+
+    def test_sql_queries_video_analytics_snapshots(self):
+        """SQL must target the video_analytics_snapshots table."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.get_collected_analytics_pairs(["vid1", "vid2"])
+
+        sql_calls = _executed_sql(cur)
+        assert len(sql_calls) >= 1
+        assert "video_analytics_snapshots" in sql_calls[0]
+
+    def test_sql_uses_any_for_batch_lookup(self):
+        """SQL must use ANY(%s) for an efficient batch lookup."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.get_collected_analytics_pairs(["vid1", "vid2"])
+
+        sql_calls = _executed_sql(cur)
+        combined = " ".join(sql_calls)
+        assert "ANY" in combined.upper()
+
+    def test_multiple_ids_and_no_existing_rows_returns_empty_set(self):
+        """GIVEN multiple ids and DB returns no rows
+        WHEN get_collected_analytics_pairs is called
+        THEN an empty set is returned (not an empty list)."""
+        cur = _make_cursor()
+        cur.fetchall.return_value = []
+        db, _ = _make_db(cur)
+
+        result = db.get_collected_analytics_pairs(["x1", "x2", "x3"])
+
+        assert result == set()
+        assert isinstance(result, set)

--- a/tests/congress_videos/modules/test_video_analytics.py
+++ b/tests/congress_videos/modules/test_video_analytics.py
@@ -1,0 +1,535 @@
+"""Unit tests for congress_videos.modules.video_analytics pure functions
+and CongressionalVideoDB analytics methods.
+
+Covers:
+- pending_checkpoints(): window filtering, pair exclusion, multi-checkpoint
+- parse_analytics_response(): column mapping, missing column → None
+- should_persist(): skip-and-retry contract (all-None, all-zero, any-nonzero)
+- CongressionalVideoDB.get_pending_analytics_checkpoints(): SQL query shape
+- CongressionalVideoDB.record_analytics_snapshot(): ON CONFLICT DO NOTHING, no action_taken
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _utcnow() -> datetime:
+    return datetime(2026, 1, 15, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _video(chapter_id: int, youtube_video_id: str, hours_ago: float) -> dict:
+    """Build a synthetic video_chapters-style row."""
+    now = _utcnow()
+    return {
+        "chapter_id": chapter_id,
+        "youtube_video_id": youtube_video_id,
+        "youtube_upload_date": now - timedelta(hours=hours_ago),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tests: pending_checkpoints
+# ---------------------------------------------------------------------------
+
+
+class TestPendingCheckpoints:
+    """Spec: Monitoring Window + Pending Checkpoint Selection."""
+
+    def test_video_within_window_is_included(self):
+        """GIVEN a video uploaded 25h ago, no collected snapshots
+        WHEN pending_checkpoints is called
+        THEN the 24h pair is included."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "abc123", 25.0)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+        pairs = [(r["youtube_video_id"], r["checkpoint"]) for r in result]
+
+        assert ("abc123", "24h") in pairs
+
+    def test_video_beyond_90d_is_excluded(self):
+        """GIVEN a video uploaded 91 days (2184h) ago
+        WHEN pending_checkpoints is called
+        THEN it is NOT in the result."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "old_vid", 91 * 24)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+
+        assert result == []
+
+    def test_null_youtube_video_id_is_excluded(self):
+        """GIVEN a video with youtube_video_id=None
+        WHEN pending_checkpoints is called
+        THEN it is NOT in the result."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [{
+            "chapter_id": 1,
+            "youtube_video_id": None,
+            "youtube_upload_date": now - timedelta(hours=30),
+        }]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+
+        assert result == []
+
+    def test_pair_not_yet_collected_is_returned(self):
+        """GIVEN a 25h-old video with no snapshot for 24h
+        WHEN pending_checkpoints is called
+        THEN (youtube_video_id, '24h') is returned."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "abc123", 25.0)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+
+        assert any(r["checkpoint"] == "24h" and r["youtube_video_id"] == "abc123" for r in result)
+
+    def test_already_collected_pair_is_excluded(self):
+        """GIVEN a 25h-old video AND a snapshot for (abc123, 24h)
+        WHEN pending_checkpoints is called
+        THEN 24h is NOT returned."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "abc123", 25.0)]
+        collected: set[tuple[str, str]] = {("abc123", "24h")}
+
+        result = pending_checkpoints(now, videos, collected)
+        pairs = [(r["youtube_video_id"], r["checkpoint"]) for r in result]
+
+        assert ("abc123", "24h") not in pairs
+
+    def test_30h_elapsed_returns_only_24h(self):
+        """GIVEN a video uploaded 30h ago, no snapshots
+        WHEN pending_checkpoints is called
+        THEN only '24h' is returned, NOT '48h'."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "vid30h", 30.0)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+        checkpoints = [r["checkpoint"] for r in result if r["youtube_video_id"] == "vid30h"]
+
+        assert "24h" in checkpoints
+        assert "48h" not in checkpoints
+
+    def test_50h_elapsed_returns_24h_and_48h(self):
+        """GIVEN a video uploaded 50h ago, no snapshots
+        WHEN pending_checkpoints is called
+        THEN both '24h' and '48h' are returned."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "vid50h", 50.0)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+        checkpoints = {r["checkpoint"] for r in result if r["youtube_video_id"] == "vid50h"}
+
+        assert "24h" in checkpoints
+        assert "48h" in checkpoints
+
+    def test_multiple_checkpoints_crossed_simultaneously(self):
+        """GIVEN a video uploaded 200h ago (>7d=168h), no snapshots
+        WHEN pending_checkpoints is called
+        THEN 24h, 48h, and 7d are all returned."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(1, "vid200h", 200.0)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+        checkpoints = {r["checkpoint"] for r in result if r["youtube_video_id"] == "vid200h"}
+
+        assert "24h" in checkpoints
+        assert "48h" in checkpoints
+        assert "7d" in checkpoints
+
+    def test_result_contains_chapter_id(self):
+        """Each returned dict must carry chapter_id for FK persistence."""
+        from congress_videos.modules.video_analytics import pending_checkpoints
+
+        now = _utcnow()
+        videos = [_video(42, "chk42", 25.0)]
+        collected: set[tuple[str, str]] = set()
+
+        result = pending_checkpoints(now, videos, collected)
+
+        assert all(r["chapter_id"] == 42 for r in result)
+
+
+# ---------------------------------------------------------------------------
+# Tests: parse_analytics_response
+# ---------------------------------------------------------------------------
+
+
+class TestParseAnalyticsResponse:
+    """Spec: Snapshot Persistence Shape."""
+
+    def _sample_response(self, values: list) -> dict:
+        """Build a minimal Analytics API response with the five standard fields."""
+        return {
+            "columnHeaders": [
+                {"name": "views"},
+                {"name": "impressions"},
+                {"name": "impressionClickThroughRate"},
+                {"name": "averageViewDuration"},
+                {"name": "watchTimeMinutes"},
+            ],
+            "rows": [values],
+        }
+
+    def test_five_fields_are_mapped(self):
+        """GIVEN a full Analytics response with one row
+        WHEN parse_analytics_response is called
+        THEN a dict with all five metric keys is returned."""
+        from congress_videos.modules.video_analytics import parse_analytics_response
+
+        resp = self._sample_response([120, 500, 0.05, 45.3, 90.6])
+        result = parse_analytics_response(resp)
+
+        assert result["views"] == 120
+        assert result["impressions"] == 500
+        assert result["impressionClickThroughRate"] == 0.05
+        assert result["averageViewDuration"] == 45.3
+        assert result["watchTimeMinutes"] == 90.6
+
+    def test_missing_column_returns_none(self):
+        """GIVEN a response that lacks some columns
+        WHEN parse_analytics_response is called
+        THEN missing columns map to None."""
+        from congress_videos.modules.video_analytics import parse_analytics_response
+
+        # Only 'views' present
+        resp = {
+            "columnHeaders": [{"name": "views"}],
+            "rows": [[42]],
+        }
+        result = parse_analytics_response(resp)
+
+        assert result["views"] == 42
+        assert result["impressions"] is None
+        assert result["impressionClickThroughRate"] is None
+        assert result["averageViewDuration"] is None
+        assert result["watchTimeMinutes"] is None
+
+    def test_empty_rows_returns_all_none(self):
+        """GIVEN an Analytics response with no rows
+        WHEN parse_analytics_response is called
+        THEN all five fields are None."""
+        from congress_videos.modules.video_analytics import parse_analytics_response
+
+        resp = {
+            "columnHeaders": [
+                {"name": "views"},
+                {"name": "impressions"},
+                {"name": "impressionClickThroughRate"},
+                {"name": "averageViewDuration"},
+                {"name": "watchTimeMinutes"},
+            ],
+            "rows": [],
+        }
+        result = parse_analytics_response(resp)
+
+        assert result["views"] is None
+        assert result["impressions"] is None
+        assert result["impressionClickThroughRate"] is None
+        assert result["averageViewDuration"] is None
+        assert result["watchTimeMinutes"] is None
+
+    def test_result_has_exactly_five_keys(self):
+        """Result dict must contain exactly the five METRIC_FIELDS keys."""
+        from congress_videos.modules.video_analytics import parse_analytics_response
+
+        resp = self._sample_response([1, 2, 3.0, 4.0, 5.0])
+        result = parse_analytics_response(resp)
+
+        assert set(result.keys()) == {
+            "views",
+            "impressions",
+            "impressionClickThroughRate",
+            "averageViewDuration",
+            "watchTimeMinutes",
+        }
+
+
+# ---------------------------------------------------------------------------
+# Tests: should_persist
+# ---------------------------------------------------------------------------
+
+
+class TestShouldPersist:
+    """Spec: Skip-and-Retry on NULL or Zero Metrics."""
+
+    def test_all_none_returns_false(self):
+        """GIVEN all metrics are None
+        WHEN should_persist is called
+        THEN it returns False (skip-and-retry)."""
+        from congress_videos.modules.video_analytics import should_persist
+
+        metrics = {
+            "views": None,
+            "impressions": None,
+            "impressionClickThroughRate": None,
+            "averageViewDuration": None,
+            "watchTimeMinutes": None,
+        }
+        assert should_persist(metrics) is False
+
+    def test_all_zero_returns_false(self):
+        """GIVEN all metrics are 0 / 0.0
+        WHEN should_persist is called
+        THEN it returns False (analytics lag, retry next hour)."""
+        from congress_videos.modules.video_analytics import should_persist
+
+        metrics = {
+            "views": 0,
+            "impressions": 0,
+            "impressionClickThroughRate": 0.0,
+            "averageViewDuration": 0.0,
+            "watchTimeMinutes": 0.0,
+        }
+        assert should_persist(metrics) is False
+
+    def test_one_nonzero_returns_true(self):
+        """GIVEN at least one nonzero metric
+        WHEN should_persist is called
+        THEN it returns True."""
+        from congress_videos.modules.video_analytics import should_persist
+
+        metrics = {
+            "views": 1,
+            "impressions": 0,
+            "impressionClickThroughRate": 0.0,
+            "averageViewDuration": 0.0,
+            "watchTimeMinutes": 0.0,
+        }
+        assert should_persist(metrics) is True
+
+    def test_mixed_none_and_nonzero_returns_true(self):
+        """GIVEN some None values but at least one nonzero value
+        WHEN should_persist is called
+        THEN it returns True."""
+        from congress_videos.modules.video_analytics import should_persist
+
+        metrics = {
+            "views": None,
+            "impressions": None,
+            "impressionClickThroughRate": None,
+            "averageViewDuration": None,
+            "watchTimeMinutes": 90.6,
+        }
+        assert should_persist(metrics) is True
+
+
+# ---------------------------------------------------------------------------
+# DB method helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cursor() -> MagicMock:
+    """Cursor mock usable as a context manager."""
+    cur = MagicMock(name="cursor")
+    cur.__enter__ = MagicMock(return_value=cur)
+    cur.__exit__ = MagicMock(return_value=False)
+    cur.fetchall.return_value = []
+    cur.fetchone.return_value = None
+    return cur
+
+
+def _make_db(cur: MagicMock):
+    """Build a CongressionalVideoDB with pg_conn fully mocked."""
+    conn = MagicMock(name="connection")
+    conn.__enter__ = MagicMock(return_value=conn)
+    conn.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cur
+
+    pg_conn = MagicMock(name="pg_conn")
+    pg_conn.get_connection.return_value = conn
+    pg_conn.get_qualified_table.side_effect = lambda t: f"development.{t}"
+
+    from congress_videos.modules.database import CongressionalVideoDB
+
+    db = CongressionalVideoDB.__new__(CongressionalVideoDB)
+    db.pg_conn = pg_conn
+    return db, conn
+
+
+def _executed_sql(cur: MagicMock) -> list[str]:
+    """Return the SQL of every cur.execute() call, in order."""
+    return [c.args[0] for c in cur.execute.call_args_list if c.args]
+
+
+# ---------------------------------------------------------------------------
+# Tests: CongressionalVideoDB.get_pending_analytics_checkpoints
+# ---------------------------------------------------------------------------
+
+
+class TestGetPendingAnalyticsCheckpoints:
+    """Spec: Monitoring Window / Pending Checkpoint Selection (DB layer)."""
+
+    def test_query_filters_null_youtube_video_id(self):
+        """SQL must include youtube_video_id IS NOT NULL filter."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.get_pending_analytics_checkpoints()
+
+        sql_calls = _executed_sql(cur)
+        assert len(sql_calls) >= 1
+        assert "youtube_video_id IS NOT NULL" in sql_calls[0]
+
+    def test_query_filters_uploaded_to_youtube(self):
+        """SQL must filter is_uploaded_to_youtube = TRUE."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.get_pending_analytics_checkpoints()
+
+        sql_calls = _executed_sql(cur)
+        assert any("is_uploaded_to_youtube" in s for s in sql_calls)
+
+    def test_query_applies_90_day_window(self):
+        """SQL must restrict to uploads within the 90-day monitoring window."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.get_pending_analytics_checkpoints()
+
+        sql_calls = _executed_sql(cur)
+        combined = " ".join(sql_calls)
+        assert "90" in combined or "2160" in combined or "days" in combined.lower()
+
+    def test_returns_list_of_rows(self):
+        """Method must return a list (fetchall result)."""
+        cur = _make_cursor()
+        cur.fetchall.return_value = [
+            {"chapter_id": 1, "youtube_video_id": "abc", "youtube_upload_date": None}
+        ]
+        db, _ = _make_db(cur)
+
+        result = db.get_pending_analytics_checkpoints()
+
+        assert isinstance(result, list)
+        assert len(result) == 1
+        assert result[0]["chapter_id"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: CongressionalVideoDB.record_analytics_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestRecordAnalyticsSnapshot:
+    """Spec: Exactly-Once Snapshot Persistence / Snapshot Persistence Shape."""
+
+    def _metrics(self) -> dict:
+        return {
+            "views": 120,
+            "impressions": 500,
+            "impressionClickThroughRate": 0.05,
+            "averageViewDuration": 45.3,
+            "watchTimeMinutes": 90.6,
+        }
+
+    def test_insert_uses_on_conflict_do_nothing(self):
+        """INSERT must include ON CONFLICT DO NOTHING for idempotency."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.record_analytics_snapshot(
+            chapter_id=1,
+            youtube_video_id="abc123",
+            checkpoint="24h",
+            metrics=self._metrics(),
+        )
+
+        sql_calls = _executed_sql(cur)
+        combined = " ".join(sql_calls).upper()
+        assert "ON CONFLICT" in combined
+        assert "DO NOTHING" in combined
+
+    def test_action_taken_is_not_written(self):
+        """action_taken must NOT appear in the INSERT SQL (reserved NULL placeholder)."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.record_analytics_snapshot(
+            chapter_id=1,
+            youtube_video_id="abc123",
+            checkpoint="24h",
+            metrics=self._metrics(),
+        )
+
+        sql_calls = _executed_sql(cur)
+        combined = " ".join(sql_calls)
+        assert "action_taken" not in combined
+
+    def test_metrics_are_passed_as_jsonb(self):
+        """metrics dict must be serialised to JSON in the execute call."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+        metrics = self._metrics()
+
+        db.record_analytics_snapshot(
+            chapter_id=1,
+            youtube_video_id="abc123",
+            checkpoint="24h",
+            metrics=metrics,
+        )
+
+        # Verify the params passed to cursor.execute contain a JSON string.
+        all_params = []
+        for call in cur.execute.call_args_list:
+            if len(call.args) > 1:
+                all_params.extend(call.args[1])
+
+        json_params = [p for p in all_params if isinstance(p, str) and "views" in p]
+        assert len(json_params) >= 1
+        parsed = json.loads(json_params[0])
+        assert parsed["views"] == 120
+
+    def test_chapter_id_and_checkpoint_are_bound(self):
+        """chapter_id and checkpoint value must appear in the execute parameters."""
+        cur = _make_cursor()
+        db, _ = _make_db(cur)
+
+        db.record_analytics_snapshot(
+            chapter_id=42,
+            youtube_video_id="xyz999",
+            checkpoint="7d",
+            metrics=self._metrics(),
+        )
+
+        all_params = []
+        for call in cur.execute.call_args_list:
+            if len(call.args) > 1:
+                all_params.extend(call.args[1])
+
+        assert 42 in all_params
+        assert "xyz999" in all_params
+        assert "7d" in all_params

--- a/tests/congress_videos/test_video_analytics_dag.py
+++ b/tests/congress_videos/test_video_analytics_dag.py
@@ -104,3 +104,94 @@ class TestVideoAnalyticsDagGraph:
 
         downstream_ids = {t.task_id for t in t2.downstream_list}
         assert t3.task_id in downstream_ids
+
+
+# ---------------------------------------------------------------------------
+# _fetch_analytics wiring: collected pairs from DB
+# ---------------------------------------------------------------------------
+
+
+class TestFetchAnalyticsUsesCollectedPairs:
+    """_fetch_analytics must query the DB for already-collected pairs and pass
+    them to pending_checkpoints() instead of using an always-empty set.
+
+    This saves Analytics API quota by skipping pairs we already have.
+    """
+
+    def test_fetch_analytics_calls_get_collected_pairs(self, monkeypatch):
+        """GIVEN candidate rows with youtube_video_ids
+        WHEN _fetch_analytics executes
+        THEN get_collected_analytics_pairs is called with those ids."""
+        from unittest.mock import MagicMock, patch
+
+        from congress_videos.video_analytics_dag import _fetch_analytics
+
+        candidate_rows = [
+            {
+                "chapter_id": 1,
+                "youtube_video_id": "abc123",
+                "youtube_upload_date": None,
+            }
+        ]
+
+        mock_ti = MagicMock()
+        mock_ti.xcom_pull.return_value = candidate_rows
+
+        get_collected_calls = []
+
+        def fake_get_collected(ids):
+            get_collected_calls.append(ids)
+            return {("abc123", "24h")}  # pretend 24h already collected
+
+        with patch(
+            "congress_videos.modules.database.CongressionalVideoDB.get_collected_analytics_pairs",
+            side_effect=fake_get_collected,
+        ), patch(
+            "congress_videos.modules.video_analytics.pending_checkpoints",
+            return_value=[],
+        ) as mock_pending:
+            _fetch_analytics(ti=mock_ti)
+
+        # get_collected_analytics_pairs must have been called
+        assert len(get_collected_calls) == 1
+        assert "abc123" in get_collected_calls[0]
+
+    def test_fetch_analytics_passes_collected_set_to_pending_checkpoints(
+        self, monkeypatch
+    ):
+        """The collected set from DB must be forwarded as the 'collected'
+        argument to pending_checkpoints(), NOT an empty set."""
+        from unittest.mock import MagicMock, call, patch
+
+        from congress_videos.video_analytics_dag import _fetch_analytics
+
+        candidate_rows = [
+            {
+                "chapter_id": 2,
+                "youtube_video_id": "xyz999",
+                "youtube_upload_date": None,
+            }
+        ]
+        already_collected = {("xyz999", "24h"), ("xyz999", "48h")}
+
+        mock_ti = MagicMock()
+        mock_ti.xcom_pull.return_value = candidate_rows
+
+        captured_pending_calls = []
+
+        def fake_pending(now, videos, collected):
+            captured_pending_calls.append(collected)
+            return []
+
+        with patch(
+            "congress_videos.modules.database.CongressionalVideoDB.get_collected_analytics_pairs",
+            return_value=already_collected,
+        ), patch(
+            "congress_videos.modules.video_analytics.pending_checkpoints",
+            side_effect=fake_pending,
+        ):
+            _fetch_analytics(ti=mock_ti)
+
+        # pending_checkpoints must have received the real collected set, not set()
+        assert len(captured_pending_calls) == 1
+        assert captured_pending_calls[0] == already_collected

--- a/tests/congress_videos/test_video_analytics_dag.py
+++ b/tests/congress_videos/test_video_analytics_dag.py
@@ -1,0 +1,106 @@
+"""Tests for congress_videos.video_analytics_dag.
+
+Spec: DAG Shape and Scheduling / No Public YouTube Writes.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# DAG load + structure
+# ---------------------------------------------------------------------------
+
+
+class TestVideoAnalyticsDagLoads:
+    """DAG must load without errors and appear in DagBag."""
+
+    def test_dag_is_importable(self):
+        """DagBag must have zero import errors for video_analytics_dag."""
+        from airflow.models import DagBag
+
+        bag = DagBag(include_examples=False)
+        assert "video_analytics" not in bag.import_errors
+
+    def test_dag_object_is_defined(self):
+        """The module must expose a 'dag' object."""
+        from congress_videos.video_analytics_dag import dag
+
+        assert dag is not None
+
+    def test_dag_id(self):
+        """dag_id must be 'video_analytics'."""
+        from congress_videos.video_analytics_dag import dag
+
+        assert dag.dag_id == "video_analytics"
+
+    def test_schedule_is_hourly(self):
+        """schedule_interval must be '@hourly'."""
+        from congress_videos.video_analytics_dag import dag
+
+        assert dag.schedule_interval == "@hourly"
+
+    def test_catchup_is_false(self):
+        """catchup must be False to avoid backfill storms."""
+        from congress_videos.video_analytics_dag import dag
+
+        assert dag.catchup is False
+
+
+# ---------------------------------------------------------------------------
+# Task graph shape
+# ---------------------------------------------------------------------------
+
+
+class TestVideoAnalyticsDagGraph:
+    """Task graph must have staleness guard → pending select → fetch → record."""
+
+    def test_has_four_tasks(self):
+        """DAG must have exactly 4 tasks: t0, t1, t2, t3."""
+        from congress_videos.video_analytics_dag import dag
+
+        assert len(dag.tasks) == 4
+
+    def test_expected_task_ids_present(self):
+        """Required task IDs must be present in the DAG."""
+        from congress_videos.video_analytics_dag import dag
+
+        task_ids = {t.task_id for t in dag.tasks}
+        assert "staleness_guard" in task_ids
+        assert "get_pending_checkpoints" in task_ids
+        assert "fetch_analytics" in task_ids
+        assert "record_snapshots" in task_ids
+
+    def test_staleness_guard_is_upstream_of_get_pending(self):
+        """staleness_guard → get_pending_checkpoints."""
+        from congress_videos.video_analytics_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t0 = tasks_by_id["staleness_guard"]
+        t1 = tasks_by_id["get_pending_checkpoints"]
+
+        downstream_ids = {t.task_id for t in t0.downstream_list}
+        assert t1.task_id in downstream_ids
+
+    def test_get_pending_is_upstream_of_fetch(self):
+        """get_pending_checkpoints → fetch_analytics."""
+        from congress_videos.video_analytics_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t1 = tasks_by_id["get_pending_checkpoints"]
+        t2 = tasks_by_id["fetch_analytics"]
+
+        downstream_ids = {t.task_id for t in t1.downstream_list}
+        assert t2.task_id in downstream_ids
+
+    def test_fetch_is_upstream_of_record(self):
+        """fetch_analytics → record_snapshots."""
+        from congress_videos.video_analytics_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t2 = tasks_by_id["fetch_analytics"]
+        t3 = tasks_by_id["record_snapshots"]
+
+        downstream_ids = {t.task_id for t in t2.downstream_list}
+        assert t3.task_id in downstream_ids


### PR DESCRIPTION
## PR2 de 2 — issue #53 (recolección de métricas de vídeo por checkpoints)

Segundo slice (feature-branch-chain). **Base: rama de PR1 (#103)** — mergear PR1 primero.

### Incluye
- **Módulo puro `congress_videos/modules/video_analytics.py`**:
  - `pending_checkpoints(...)` — expande videos × checkpoints, aplica ventana ≤90d y excluye pares ya recolectados.
  - `parse_analytics_response(...)` — normaliza la respuesta de la Analytics API.
  - `should_persist(metrics)` — skip-and-retry: `False` para métricas all-None **y** all-zero (lag de YouTube), sin escribir fila.
- **Métodos DB** en `database.py`: selección de pendientes, inserción de snapshot (`ON CONFLICT (youtube_video_id, checkpoint) DO NOTHING`), y `get_collected_analytics_pairs()` para no re-consultar la API.
- **DAG `video_analytics_dag.py`** (@hourly): guard de staleness sobre `data_interval_end`, ShortCircuit gate, un video por task, cadena `staleness_guard → get_pending → fetch_analytics → record_snapshots`.

### Idempotencia + cuota
- Una-vez-por-checkpoint garantizada por UNIQUE + ON CONFLICT.
- `_fetch_analytics` consulta los pares ya recolectados y los pasa como `collected`, evitando gastar cuota de la Analytics API (default ~200 queries/día) re-consultando pares ya guardados. Fallback graceful a `set()` si la DB no responde.

### Fuera de alcance
- Acciones automáticas (thumbnail/title swap) → **#102**. `action_taken` existe en el DDL pero ningún código la escribe (verificado).

### Tests
- TDD estricto. 46 tests nuevos (39 Phase 2 + 7 del fix de cuota).
- Suite completa: **2418 passed, 1 skipped**. **E2E Docker smoke: PASS** (`list-import-errors` vacío).

Closes #53 (junto con PR1 #103).