### PR TITLE
fix(refinement): RealDictCursor row-handling en los 3 DAGs + esquema video_id en trim_proposals

### DIFF
--- a/congress_videos/speaker_turn_videos_dag.py
+++ b/congress_videos/speaker_turn_videos_dag.py
@@ -122,8 +122,8 @@ def _select_task(**context) -> list[dict]:
                 )
             else:
                 cur.execute(f"{base} ORDER BY st.turn_id LIMIT 10")
-            names = [d[0] for d in cur.description]
-            turns = [dict(zip(names, row)) for row in cur.fetchall()]
+            # PostgresConnection uses RealDictCursor: rows are dict-like.
+            turns = [dict(row) for row in cur.fetchall()]
 
             # Idempotency: exclude turns already in speaker_turn_videos
             if turns:
@@ -131,7 +131,7 @@ def _select_task(**context) -> list[dict]:
                     f"SELECT turn_id FROM {stv_table} WHERE turn_id = ANY(%s)",
                     ([t["turn_id"] for t in turns],),
                 )
-                already_done = {row[0] for row in cur.fetchall()}
+                already_done = {row["turn_id"] for row in cur.fetchall()}
                 turns = [t for t in turns if t["turn_id"] not in already_done]
 
     logger.info("speaker_turn_videos: selected %d turn(s) for materialization", len(turns))
@@ -175,8 +175,8 @@ def _materialize_task(**context) -> dict:
                 f"WHERE turn_id = ANY(%s) AND is_approved = TRUE AND is_voice_free = TRUE",
                 (turn_ids,),
             )
-            trim_names = [d[0] for d in cur.description]
-            approved_trims = [dict(zip(trim_names, row)) for row in cur.fetchall()]
+            # RealDictCursor rows are dict-like.
+            approved_trims = [dict(row) for row in cur.fetchall()]
 
         plans = plan_turn_materialization(turns, approved_trims)
 

--- a/congress_videos/speaker_turns_dag.py
+++ b/congress_videos/speaker_turns_dag.py
@@ -71,8 +71,8 @@ def select_chapters(limit: int = DEFAULT_LIMIT, chapter_ids: list[int] | None = 
                     f"SELECT {cols} FROM {view} ORDER BY chapter_id LIMIT %s",
                     (limit,),
                 )
-            names = [d[0] for d in cur.description]
-            return [dict(zip(names, row)) for row in cur.fetchall()]
+            # PostgresConnection uses RealDictCursor: rows are dict-like.
+            return [dict(row) for row in cur.fetchall()]
 
 
 def run_chapter_turns(

--- a/congress_videos/trim_proposals_dag.py
+++ b/congress_videos/trim_proposals_dag.py
@@ -34,18 +34,40 @@ from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 
+from congress_videos.config.paths import DOWNLOADS_DIR
 from congress_videos.modules.trim_proposals import (
     _upsert_proposals,
     generate_trim_proposals,
 )
 from congress_videos.modules.trim_proposals_docker import docker_yamnet_fn
-from congress_videos.modules.vad_helpers import _find_source_video, extract_audio_wav
+from congress_videos.modules.vad_helpers import extract_audio_wav
 from utils.postgres_helpers import PostgresConnection
 
 logger = logging.getLogger(__name__)
 
 DAG_ID = "trim_proposals"
 DEFAULT_LIMIT = 10
+
+_MEDIA_SUFFIXES = (".mp4", ".mkv", ".webm")
+
+
+def _find_source_video_any_date(video_id: str) -> str | None:
+    """Locate the source media for a video without knowing its session date.
+
+    ``speaker_turns`` carries no recording date, so scan every date folder
+    under ``DOWNLOADS_DIR`` for ``downloads/{date}/{video_id}/`` and return the
+    first real media file (mirrors ``reap_clip_preparer``'s date-less lookup).
+    """
+    if not os.path.isdir(DOWNLOADS_DIR):
+        return None
+    for date_folder in sorted(os.listdir(DOWNLOADS_DIR)):
+        video_dir = os.path.join(DOWNLOADS_DIR, date_folder, str(video_id))
+        if not os.path.isdir(video_dir):
+            continue
+        for filename in sorted(os.listdir(video_dir)):
+            if filename.endswith(_MEDIA_SUFFIXES) and "chapter_video" not in filename:
+                return os.path.join(video_dir, filename)
+    return None
 
 
 # ---------------------------------------------------------------------------
@@ -95,22 +117,27 @@ def select_turns(
     """
     pg = PostgresConnection()
     table = pg.get_qualified_table("speaker_turns")
-    cols = "turn_id, chapter_id, video_id, session_date, start_seconds, end_seconds"
+    chapters_table = pg.get_qualified_table("video_chapters")
+    # video_id lives on video_chapters, not speaker_turns; join to resolve it.
+    cols = "st.turn_id, st.chapter_id, vc.video_id, st.start_seconds, st.end_seconds"
+    base = (
+        f"SELECT {cols} FROM {table} st "
+        f"JOIN {chapters_table} vc ON vc.chapter_id = st.chapter_id"
+    )
     with pg.get_connection() as conn:
         with conn.cursor() as cur:
             if turn_ids:
                 cur.execute(
-                    f"SELECT {cols} FROM {table} WHERE turn_id = ANY(%s) "
-                    f"ORDER BY turn_id",
+                    f"{base} WHERE st.turn_id = ANY(%s) ORDER BY st.turn_id",
                     (list(turn_ids),),
                 )
             else:
                 cur.execute(
-                    f"SELECT {cols} FROM {table} ORDER BY turn_id LIMIT %s",
+                    f"{base} ORDER BY st.turn_id LIMIT %s",
                     (limit,),
                 )
-            names = [d[0] for d in cur.description]
-            return [dict(zip(names, row)) for row in cur.fetchall()]
+            # PostgresConnection uses RealDictCursor: rows are dict-like.
+            return [dict(row) for row in cur.fetchall()]
 
 
 def run_turn_proposals(
@@ -138,16 +165,15 @@ def run_turn_proposals(
     """
     turn_id = turn["turn_id"]
     video_id = turn["video_id"]
-    session_date = str(turn.get("session_date"))
     start_secs = float(turn["start_seconds"])
     end_secs = float(turn["end_seconds"])
     duration = max(0.0, end_secs - start_secs)
 
-    video_path = _find_source_video(session_date, video_id)
+    video_path = _find_source_video_any_date(video_id)
     if not video_path:
         logger.warning(
-            "turn %s: no source video for %s/%s — skipping",
-            turn_id, session_date, video_id,
+            "turn %s: no source video for video_id=%s — skipping",
+            turn_id, video_id,
         )
         return {"status": "skipped_no_video", "turn_id": turn_id, "proposals": 0}
 

--- a/tests/congress_videos/modules/test_trim_proposals.py
+++ b/tests/congress_videos/modules/test_trim_proposals.py
@@ -600,7 +600,7 @@ class TestUpsertProposalsCursorContract:
             "end_seconds": 130.0,
         }
 
-        monkeypatch.setattr(mod, "_find_source_video", lambda *a, **k: "/v/src.mp4")
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda *a, **k: "/v/src.mp4")
         monkeypatch.setattr(mod, "extract_audio_wav", lambda *a, **k: None)
 
         # Return one real proposal so _upsert_proposals is actually called

--- a/tests/congress_videos/test_speaker_turn_videos_dag.py
+++ b/tests/congress_videos/test_speaker_turn_videos_dag.py
@@ -70,10 +70,13 @@ class TestSelectTurns:
             ("turn_id",), ("chapter_id",), ("video_id",),
             ("start_seconds",), ("end_seconds",),
         ]
-        # First fetchall returns speaker_turns rows
-        # Second fetchall returns [(turn_id,)] for already-materialized
-        already_rows = [(tid,) for tid in already_materialized_ids]
-        cur.fetchall.side_effect = [turns_rows, already_rows]
+        # PostgresConnection uses RealDictCursor, so real rows are dict-like.
+        # Convert the tuple fixtures into dict rows so the mock matches prod and
+        # the old dict(zip(names,row)) bug would surface (keys as values).
+        col_names = [d[0] for d in cur.description]
+        turns_dicts = [dict(zip(col_names, r)) for r in turns_rows]
+        already_rows = [{"turn_id": tid} for tid in already_materialized_ids]
+        cur.fetchall.side_effect = [turns_dicts, already_rows]
         conn = MagicMock()
         conn.cursor.return_value.__enter__.return_value = cur
         pg = MagicMock()
@@ -106,6 +109,11 @@ class TestSelectTurns:
         returned_ids = [t["turn_id"] for t in turns_out]
         assert 1 not in returned_ids, "Already-materialized turn_id 1 must be excluded"
         assert 2 in returned_ids, "Non-materialized turn_id 2 must be included"
+        # RealDictCursor regression: values must be real data, not column names.
+        assert turns_out[0]["video_id"] == "vid1"
+        assert not any(k == v for t in turns_out for k, v in t.items()), (
+            "row values must be real data, not their own column names"
+        )
 
     def test_select_joins_video_chapters_and_omits_session_date(self, monkeypatch):
         """Regression: speaker_turns has no video_id/session_date columns.

--- a/tests/congress_videos/test_speaker_turns_dag.py
+++ b/tests/congress_videos/test_speaker_turns_dag.py
@@ -111,7 +111,11 @@ class TestSelectChapters:
         cur = MagicMock()
         cur.description = [("chapter_id",), ("video_id",), ("session_date",),
                            ("start_time",), ("end_time",)]
-        cur.fetchall.return_value = [(7, "abc", "2026-06-10", "00:10:00,000", "00:40:00,000")]
+        # PostgresConnection uses RealDictCursor, so rows are dict-like, not tuples.
+        cur.fetchall.return_value = [{"chapter_id": 7, "video_id": "abc",
+                                      "session_date": "2026-06-10",
+                                      "start_time": "00:10:00,000",
+                                      "end_time": "00:40:00,000"}]
         conn = MagicMock()
         conn.cursor.return_value.__enter__.return_value = cur
         pg = MagicMock()

--- a/tests/congress_videos/test_trim_proposals_dag.py
+++ b/tests/congress_videos/test_trim_proposals_dag.py
@@ -50,7 +50,7 @@ class TestRunTurnProposals:
 
     def test_missing_source_video_skips(self, monkeypatch):
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda *a, **k: None)
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda *a, **k: None)
         generate = MagicMock()
         monkeypatch.setattr(mod, "generate_trim_proposals", generate)
         cursor = MagicMock()
@@ -64,7 +64,7 @@ class TestRunTurnProposals:
         from congress_videos.modules.trim_proposals import TrimProposal
 
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda *a, **k: "/v/src.mp4")
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda *a, **k: "/v/src.mp4")
         monkeypatch.setattr(mod, "extract_audio_wav", lambda *a, **k: None)
 
         proposals = [
@@ -90,7 +90,7 @@ class TestRunTurnProposals:
 
     def test_wav_is_cleaned_up_after_processing(self, monkeypatch, tmp_path):
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda *a, **k: "/v/src.mp4")
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda *a, **k: "/v/src.mp4")
         wav_file = tmp_path / "turn_7.wav"
         wav_file.write_bytes(b"RIFF")
 
@@ -119,7 +119,7 @@ class TestRunTurnProposals:
     def test_yamnet_fn_injected_into_generate(self, monkeypatch):
         """The yamnet_fn from trim_proposals_docker is wired into generate_trim_proposals."""
         mod = _fresh()
-        monkeypatch.setattr(mod, "_find_source_video", lambda *a, **k: "/v/src.mp4")
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda *a, **k: "/v/src.mp4")
         monkeypatch.setattr(mod, "extract_audio_wav", lambda *a, **k: None)
 
         captured_kwargs: dict = {}
@@ -139,17 +139,17 @@ class TestSelectTurns:
     def test_maps_view_rows_to_dicts(self, monkeypatch):
         mod = _fresh()
         cur = MagicMock()
-        cur.description = [
-            ("turn_id",), ("chapter_id",), ("video_id",),
-            ("session_date",), ("start_seconds",), ("end_seconds",),
-        ]
+        # PostgresConnection uses RealDictCursor, so rows are dict-like, not tuples.
+        # video_id comes from the JOIN to video_chapters; speaker_turns has no
+        # video_id or session_date column, so neither is selected here.
         cur.fetchall.return_value = [
-            (7, 3, "abc123", "2026-06-10", 600.0, 700.0)
+            {"turn_id": 7, "chapter_id": 3, "video_id": "abc123",
+             "start_seconds": 600.0, "end_seconds": 700.0}
         ]
         conn = MagicMock()
         conn.cursor.return_value.__enter__.return_value = cur
         pg = MagicMock()
-        pg.get_qualified_table.return_value = "development.speaker_turns"
+        pg.get_qualified_table.side_effect = lambda name: f"development.{name}"
         pg.get_connection.return_value.__enter__.return_value = conn
         monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
 
@@ -157,8 +157,12 @@ class TestSelectTurns:
 
         assert rows == [{
             "turn_id": 7, "chapter_id": 3, "video_id": "abc123",
-            "session_date": "2026-06-10", "start_seconds": 600.0, "end_seconds": 700.0,
+            "start_seconds": 600.0, "end_seconds": 700.0,
         }]
+        # Regression: video_id resolved via JOIN, session_date never selected.
+        select_sql = cur.execute.call_args_list[0].args[0].lower()
+        assert "join" in select_sql and "video_chapters" in select_sql
+        assert "session_date" not in select_sql
 
 
 class TestProcessTask:


### PR DESCRIPTION
Fix sistémico descubierto al correr el **primer e2e con datos reales** del pipeline de refinamiento (#86→#87→#88). Vía flujo SDD (explore #695 + proposal #696; implementación inline por límite de presupuesto de sub-agents).

## Bug 1 — RealDictCursor (los 3 DAGs)
`PostgresConnection.get_connection()` usa `cursor_factory=RealDictCursor` → `fetchall()` devuelve dicts (`RealDictRow`), no tuplas. Los DAGs hacían `dict(zip(names, row))`, que al iterar un dict toma sus **claves** y produce `{col: col}` (nombres como valores) — corrupción silenciosa. `speaker_turn_videos` además hacía `{row[0] ...}` → `KeyError` con dicts.

**Fix:** convergir en el patrón canónico del repo (`dict(row)` / `row['col']`, usado en `database.py`). Sitios: `speaker_turns.select_chapters`, `trim_proposals.select_turns`, `speaker_turn_videos._select_task` (turns + approved_trims + idempotencia).

## Bug 2 — esquema de `trim_proposals` (análogo a #104)
`select_turns` seleccionaba `video_id, session_date FROM speaker_turns`, columnas que esa tabla no tiene → `UndefinedColumn`. **Fix:** JOIN a `video_chapters` para `video_id`; localización del vídeo fuente sin fecha (`_find_source_video_any_date`, como en #88); fuera `session_date`.

## Por qué no se detectó antes
Los tests unitarios mockeaban el cursor con **tuplas**, así que `dict(zip)` parecía correcto; y en prod nunca hubo filas reales. Este e2e es la primera vez que el pipeline toca datos reales.

## Test plan
- [x] Tests de los 3 DAGs migrados a filas **dict** (RealDictRow-like) + regresiones: firma de corrupción (`no key==value`), JOIN a video_chapters, `session_date` nunca seleccionado.
- [x] Suite completa: **2334 passed**, 1 skipped, cobertura 86.97%.
- [ ] Re-correr e2e #86→#87→#88 sobre capítulo largo tras el merge.

Follow-up (no bloqueante): `_find_source_video_any_date` quedó duplicado en dos DAGs; se puede mover a `vad_helpers` (DRY).