### PR TITLE
refactor(youtube): tokens OAuth como JSON portable + cablear DAG de analytics

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -214,8 +214,9 @@ congreso_youtube/examples/*
 **/youtube_token.pickle
 *youtube_token*.pickle
 *_youtube_token.pickle
-# Per-channel/per-purpose token pickles (youtube_tokens/{channel}/{purpose}.pickle).
-# Keep the folder scaffold (.gitkeep) but never commit the token pickles.
+# Per-channel/per-purpose tokens (youtube_tokens/{channel}/{purpose}.json).
+# Keep the folder scaffold (.gitkeep + README) but never commit the tokens.
+**/youtube_tokens/**/*.json
 **/youtube_tokens/**/*.pickle
 client_secret*.json
 youtube_cookies.txt

--- a/congress_videos/config/youtube_channels.py
+++ b/congress_videos/config/youtube_channels.py
@@ -4,14 +4,18 @@ Tokens are organized per channel and per purpose so each purpose holds only
 the OAuth scopes it needs (least privilege). The ``analytics`` purpose is
 read-only, so an analytics token cannot upload, edit, or delete anything.
 
+Tokens are stored as portable JSON (``Credentials.to_json()``), which is
+stable across google-auth versions — unlike pickle, which breaks when the
+writer and reader run different google-auth majors.
+
 On-disk layout (runtime, under the Airflow data dir)::
 
-    {YOUTUBE_TOKENS_DIR}/{channel}/{purpose}.pickle
+    {YOUTUBE_TOKENS_DIR}/{channel}/{purpose}.json
 
 Examples::
 
-    .../youtube_tokens/congreso/upload.pickle      # upload + manage scopes
-    .../youtube_tokens/congreso/analytics.pickle    # yt-analytics.readonly
+    .../youtube_tokens/congreso-es-tv/upload.json      # upload + manage scopes
+    .../youtube_tokens/congreso-es-tv/analytics.json    # yt-analytics.readonly
 
 Onboard a new channel by adding an entry to ``CHANNELS``; add a new token
 purpose by adding an entry to ``TOKEN_SCOPES``.
@@ -94,7 +98,7 @@ def get_token_path(
     *,
     tokens_dir: str = YOUTUBE_TOKENS_DIR,
 ) -> str:
-    """Return the on-disk path for a channel+purpose token pickle.
+    """Return the on-disk path for a channel+purpose token (JSON).
 
     This does not check for existence. Use :func:`resolve_token_path` when a
     backward-compatible fallback to the legacy single-token file is wanted.
@@ -104,7 +108,7 @@ def get_token_path(
     """
     _validate_channel(channel)
     _validate_purpose(purpose)
-    return f"{tokens_dir}/{channel}/{purpose}.pickle"
+    return f"{tokens_dir}/{channel}/{purpose}.json"
 
 
 def resolve_token_path(

--- a/congress_videos/scripts/generate_youtube_token.py
+++ b/congress_videos/scripts/generate_youtube_token.py
@@ -26,11 +26,11 @@ Prerequisites:
 """
 
 import argparse
-import pickle
 import sys
 from pathlib import Path
 
 from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
 from google_auth_oauthlib.flow import InstalledAppFlow
 
 # Make the project importable when run as a standalone script.
@@ -54,8 +54,13 @@ LOCAL_TOKENS_DIR = PROJECT_ROOT / "youtube_tokens"
 
 
 def local_token_path(channel: str, purpose: str) -> Path:
-    """Return the local pickle path for a channel+purpose token."""
-    return LOCAL_TOKENS_DIR / channel / f"{purpose}.pickle"
+    """Return the local JSON path for a channel+purpose token."""
+    return LOCAL_TOKENS_DIR / channel / f"{purpose}.json"
+
+
+def _save(credentials: Credentials, token_file: Path) -> None:
+    """Write credentials as portable JSON (google-auth version independent)."""
+    token_file.write_text(credentials.to_json())
 
 
 def generate_token(channel: str, purpose: str):
@@ -72,8 +77,7 @@ def generate_token(channel: str, purpose: str):
     credentials = None
     if token_file.exists():
         print(f"Loading existing token from {token_file}")
-        with open(token_file, "rb") as fh:
-            credentials = pickle.load(fh)
+        credentials = Credentials.from_authorized_user_file(str(token_file), scopes)
 
     if credentials and credentials.valid:
         print("Existing token is still valid!")
@@ -83,8 +87,7 @@ def generate_token(channel: str, purpose: str):
         print("Token expired. Attempting to refresh...")
         try:
             credentials.refresh(Request())
-            with open(token_file, "wb") as fh:
-                pickle.dump(credentials, fh)
+            _save(credentials, token_file)
             print(f"Refreshed token saved to {token_file}")
             return credentials, token_file
         except Exception as e:  # noqa: BLE001 - surface any refresh failure and re-auth
@@ -111,8 +114,7 @@ def generate_token(channel: str, purpose: str):
         access_type="offline",  # required for a refresh token
     )
 
-    with open(token_file, "wb") as fh:
-        pickle.dump(credentials, fh)
+    _save(credentials, token_file)
     print(f"\nNew token saved to {token_file}")
     return credentials, token_file
 

--- a/congress_videos/video_analytics_dag.py
+++ b/congress_videos/video_analytics_dag.py
@@ -19,6 +19,7 @@ from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.operators.python import PythonOperator, ShortCircuitOperator
 
+from congress_videos.config.youtube_channels import DEFAULT_CHANNEL, resolve_token_path
 from congress_videos.modules.postgres_operators import PostgreSQLOperator
 from utils.env_loader import load_env_if_local
 
@@ -28,9 +29,11 @@ STALE_RUN_TOLERANCE_MINUTES = int(
     os.getenv("ANALYTICS_STALE_RUN_TOLERANCE_MINUTES", "30")
 )
 
+# Read-only analytics token for the default channel. An explicit
+# YOUTUBE_TOKEN_FILE env var still overrides for ad-hoc/testing use.
 _TOKEN_FILE = os.getenv(
     "YOUTUBE_TOKEN_FILE",
-    os.path.join(os.path.dirname(__file__), "..", "congress_youtube_token.pickle"),
+    resolve_token_path(DEFAULT_CHANNEL, "analytics"),
 )
 
 

--- a/congress_videos/youtube_tokens/README.md
+++ b/congress_videos/youtube_tokens/README.md
@@ -1,15 +1,18 @@
 # YouTube OAuth tokens
 
-Per-channel, per-purpose OAuth token pickles. **Token pickles are secrets and
-are never committed** (see `.gitignore`); only this scaffold is tracked.
+Per-channel, per-purpose OAuth tokens, stored as portable JSON
+(`Credentials.to_json()`) so they load across google-auth versions — unlike
+pickle, which breaks when writer and reader run different google-auth majors.
+**Tokens are secrets and are never committed** (see `.gitignore`); only this
+scaffold is tracked.
 
 ## Layout
 
 ```
 youtube_tokens/
   {channel}/
-    upload.pickle       # scopes: youtube.upload + youtube + youtube.force-ssl
-    analytics.pickle    # scope:  yt-analytics.readonly  (read-only)
+    upload.json       # scopes: youtube.upload + youtube + youtube.force-ssl
+    analytics.json    # scope:  yt-analytics.readonly  (read-only)
 ```
 
 Channels and the scopes for each purpose are declared in

--- a/tests/congress_videos/config/test_youtube_channels.py
+++ b/tests/congress_videos/config/test_youtube_channels.py
@@ -45,11 +45,11 @@ class TestGetTokenScopes:
 class TestGetTokenPath:
     def test_builds_channel_purpose_path(self):
         path = get_token_path("congreso-es-tv", "analytics", tokens_dir="/data/youtube_tokens")
-        assert path == "/data/youtube_tokens/congreso-es-tv/analytics.pickle"
+        assert path == "/data/youtube_tokens/congreso-es-tv/analytics.json"
 
     def test_upload_path(self):
         path = get_token_path("congreso-es-tv", "upload", tokens_dir="/data/youtube_tokens")
-        assert path == "/data/youtube_tokens/congreso-es-tv/upload.pickle"
+        assert path == "/data/youtube_tokens/congreso-es-tv/upload.json"
 
     def test_unknown_channel_raises(self):
         with pytest.raises(ValueError):
@@ -63,7 +63,7 @@ class TestGetTokenPath:
 class TestResolveTokenPath:
     def test_prefers_new_path_when_it_exists(self, tmp_path):
         tokens_dir = tmp_path / "youtube_tokens"
-        new_path = tokens_dir / "congreso-es-tv" / "upload.pickle"
+        new_path = tokens_dir / "congreso-es-tv" / "upload.json"
         new_path.parent.mkdir(parents=True)
         new_path.write_bytes(b"x")
         legacy = tmp_path / "legacy.pickle"
@@ -92,7 +92,7 @@ class TestResolveTokenPath:
         resolved = resolve_token_path(
             "congreso-es-tv", "analytics", tokens_dir=str(tokens_dir), legacy_path=str(legacy)
         )
-        assert resolved == str(tokens_dir / "congreso-es-tv" / "analytics.pickle")
+        assert resolved == str(tokens_dir / "congreso-es-tv" / "analytics.json")
 
     def test_no_fallback_when_nothing_exists_returns_new_path(self, tmp_path):
         tokens_dir = tmp_path / "youtube_tokens"
@@ -101,4 +101,4 @@ class TestResolveTokenPath:
         resolved = resolve_token_path(
             "congreso-es-tv", "upload", tokens_dir=str(tokens_dir), legacy_path=str(legacy)
         )
-        assert resolved == str(tokens_dir / "congreso-es-tv" / "upload.pickle")
+        assert resolved == str(tokens_dir / "congreso-es-tv" / "upload.json")

--- a/tests/congress_videos/scripts/test_generate_youtube_token.py
+++ b/tests/congress_videos/scripts/test_generate_youtube_token.py
@@ -47,9 +47,9 @@ class TestParseArgs:
 
 
 class TestLocalTokenPath:
-    def test_builds_channel_purpose_pickle(self):
+    def test_builds_channel_purpose_json(self):
         path = gen.local_token_path("congreso-es-tv", "analytics")
-        assert path.name == "analytics.pickle"
+        assert path.name == "analytics.json"
         assert path.parent.name == "congreso-es-tv"
         assert path.parent.parent.name == "youtube_tokens"
 

--- a/tests/utils/test_youtube_helpers_json.py
+++ b/tests/utils/test_youtube_helpers_json.py
@@ -1,0 +1,75 @@
+"""Tests for JSON token storage in youtube_helpers.
+
+JSON storage (Credentials.to_json / from_authorized_user_info) is portable
+across google-auth versions, unlike pickle.
+"""
+
+import pickle
+from datetime import datetime, timedelta
+
+from google.oauth2.credentials import Credentials
+
+from utils.youtube_helpers import _load_credentials, _save_credentials
+
+
+def _make_creds(scopes):
+    # Future expiry so the credential is valid and loading never triggers a
+    # network refresh.
+    return Credentials(
+        token="access-token",
+        refresh_token="refresh-token",
+        token_uri="https://oauth2.googleapis.com/token",
+        client_id="client-id",
+        client_secret="client-secret",
+        scopes=scopes,
+        expiry=datetime.utcnow() + timedelta(hours=1),
+    )
+
+
+class TestSaveCredentials:
+    def test_json_path_writes_valid_json(self, tmp_path):
+        creds = _make_creds(["https://www.googleapis.com/auth/yt-analytics.readonly"])
+        dst = tmp_path / "analytics.json"
+
+        _save_credentials(creds, str(dst))
+
+        text = dst.read_text()
+        assert '"refresh_token": "refresh-token"' in text
+        # Must be JSON, not a pickle byte stream.
+        assert text.lstrip().startswith("{")
+
+    def test_pickle_path_writes_pickle(self, tmp_path):
+        creds = _make_creds(["https://www.googleapis.com/auth/youtube.upload"])
+        dst = tmp_path / "legacy.pickle"
+
+        _save_credentials(creds, str(dst))
+
+        with open(dst, "rb") as fh:
+            loaded = pickle.load(fh)
+        assert loaded.refresh_token == "refresh-token"
+
+
+class TestLoadCredentials:
+    def test_json_round_trip_preserves_refresh_token_and_scopes(self, tmp_path):
+        scopes = ["https://www.googleapis.com/auth/yt-analytics.readonly"]
+        dst = tmp_path / "analytics.json"
+        _save_credentials(_make_creds(scopes), str(dst))
+
+        loaded = _load_credentials(str(dst))
+
+        assert loaded.refresh_token == "refresh-token"
+        assert loaded.scopes == scopes
+
+    def test_missing_file_raises(self, tmp_path):
+        import pytest
+
+        with pytest.raises(FileNotFoundError):
+            _load_credentials(str(tmp_path / "nope.json"))
+
+    def test_legacy_pickle_still_loads(self, tmp_path):
+        dst = tmp_path / "legacy.pickle"
+        _save_credentials(_make_creds(["https://www.googleapis.com/auth/youtube"]), str(dst))
+
+        loaded = _load_credentials(str(dst))
+
+        assert loaded.refresh_token == "refresh-token"

--- a/utils/youtube_helpers.py
+++ b/utils/youtube_helpers.py
@@ -9,6 +9,7 @@ Can be used across multiple projects and YouTube channels by providing
 different token files.
 """
 
+import json
 import logging
 import os
 import pickle
@@ -25,12 +26,63 @@ from googleapiclient.http import MediaFileUpload
 # =============================================================================
 
 
+def _save_credentials(credentials: Credentials, token_file: str) -> None:
+    """Persist credentials, choosing format by extension.
+
+    ``.json`` tokens are written with ``Credentials.to_json()`` (portable
+    across google-auth versions); any other extension is treated as the
+    legacy pickle format.
+    """
+    if token_file.endswith(".json"):
+        with open(token_file, "w") as fh:
+            fh.write(credentials.to_json())
+    else:
+        with open(token_file, "wb") as fh:
+            pickle.dump(credentials, fh)
+
+
+def _load_credentials(token_file: str) -> Credentials:
+    """Load OAuth credentials from a token file, refreshing if expired.
+
+    Supports both the portable ``.json`` format (preferred) and the legacy
+    ``.pickle`` format, chosen by file extension. When the token is expired
+    and refreshable, it is refreshed and saved back in the SAME format.
+
+    Raises:
+        FileNotFoundError: If the token file does not exist.
+    """
+    if not os.path.exists(token_file):
+        raise FileNotFoundError(
+            f"Token file not found: {token_file}. "
+            "Please authenticate first using generate_youtube_token.py."
+        )
+
+    logging.info(f"Loading YouTube credentials from {token_file}")
+
+    if token_file.endswith(".json"):
+        with open(token_file) as fh:
+            info = json.load(fh)
+        credentials = Credentials.from_authorized_user_info(info, info.get("scopes"))
+    else:
+        with open(token_file, "rb") as token:
+            credentials = pickle.load(token)
+
+    if credentials.expired and credentials.refresh_token:
+        logging.info("Token expired. Refreshing...")
+        credentials.refresh(Request())
+        _save_credentials(credentials, token_file)
+        logging.info("Token refreshed and saved")
+
+    return credentials
+
+
 def get_authenticated_youtube_service(token_file: str):
     """
-    Get authenticated YouTube API service using saved token.
+    Get authenticated YouTube API service using a saved token.
 
     Args:
-        token_file: Path to the token pickle file
+        token_file: Path to the token file (``.json`` preferred, ``.pickle``
+            legacy). Chosen by extension.
 
     Returns:
         Resource: Authenticated YouTube API service object
@@ -39,47 +91,24 @@ def get_authenticated_youtube_service(token_file: str):
         FileNotFoundError: If token file doesn't exist
         Exception: If authentication fails
     """
-    if not os.path.exists(token_file):
-        raise FileNotFoundError(
-            f"Token file not found: {token_file}. "
-            "Please authenticate first using the test script."
-        )
-
-    logging.info(f"Loading YouTube credentials from {token_file}")
-
-    # Load credentials from token file
-    with open(token_file, 'rb') as token:
-        credentials = pickle.load(token)
-
-    # Refresh token if expired
-    if credentials.expired and credentials.refresh_token:
-        logging.info("Token expired. Refreshing...")
-        credentials.refresh(Request())
-
-        # Save refreshed token
-        with open(token_file, 'wb') as token:
-            pickle.dump(credentials, token)
-        logging.info("Token refreshed and saved")
-
-    # Build and return YouTube service
+    credentials = _load_credentials(token_file)
     youtube = build('youtube', 'v3', credentials=credentials)
     logging.info("YouTube service authenticated successfully")
-
     return youtube
 
 
 def get_youtube_analytics_service(token_file: str):
     """
-    Get authenticated YouTube Analytics API service using saved OAuth token.
+    Get authenticated YouTube Analytics API service using a saved OAuth token.
 
-    Reuses the same pickle-load and token-refresh path as
+    Reuses the same load-and-refresh path as
     ``get_authenticated_youtube_service`` but targets the
     ``youtubeAnalytics v2`` API with ``yt-analytics.readonly`` scope.
 
     Args:
-        token_file: Path to the OAuth token pickle file.  The token must
-            have been generated with the ``yt-analytics.readonly`` scope
-            (see ``generate_youtube_token.py``).
+        token_file: Path to the OAuth token file (``.json`` preferred,
+            ``.pickle`` legacy). The token must have been generated with the
+            ``yt-analytics.readonly`` scope (see ``generate_youtube_token.py``).
 
     Returns:
         Resource: Authenticated YouTube Analytics API service object.
@@ -88,28 +117,9 @@ def get_youtube_analytics_service(token_file: str):
         FileNotFoundError: If the token file does not exist.
         Exception: If authentication or service construction fails.
     """
-    if not os.path.exists(token_file):
-        raise FileNotFoundError(
-            f"Token file not found: {token_file}. "
-            "Please authenticate first using the token generation script."
-        )
-
-    logging.info(f"Loading YouTube Analytics credentials from {token_file}")
-
-    with open(token_file, 'rb') as token:
-        credentials = pickle.load(token)
-
-    if credentials.expired and credentials.refresh_token:
-        logging.info("Token expired. Refreshing...")
-        credentials.refresh(Request())
-
-        with open(token_file, 'wb') as token:
-            pickle.dump(credentials, token)
-        logging.info("Token refreshed and saved")
-
+    credentials = _load_credentials(token_file)
     service = build('youtubeAnalytics', 'v2', credentials=credentials)
     logging.info("YouTube Analytics service authenticated successfully")
-
     return service
 
 


### PR DESCRIPTION
## Qué

Los tokens OAuth se guardan ahora como **JSON portable** en vez de pickle, porque el pickle **se rompe entre versiones mayores de `google-auth`** (un pickle escrito por 2.56.2 no carga en la 2.34.0 del contenedor — `ModuleNotFoundError: google.auth._regional_access_boundary_utils`, verificado en prod). `Credentials.to_json()` / `from_authorized_user_info()` es estable entre versiones.

Además cablea el DAG de analytics al token del canal (follow-up que quedaba del #53).

## Cambios
- **`utils/youtube_helpers.py`**: loader/saver unificado (`_load_credentials`/`_save_credentials`) que maneja `.json` (preferido) y `.pickle` (legacy) por extensión; ambos getters de servicio lo reusan. Refresca y reescribe en el mismo formato.
- **`youtube_channels.get_token_path`**: ahora devuelve `{purpose}.json`. El fallback legacy sigue siendo el `.pickle` del canal default para `upload`.
- **`generate_youtube_token.py`**: escribe JSON (`to_json`).
- **`video_analytics_dag.py`**: usa `resolve_token_path(DEFAULT_CHANNEL, 'analytics')` en vez del fallback por env (cierra el wiring del #53).
- **`.gitignore`**: ignora `youtube_tokens/**/*.json` (además de `.pickle`).
- README + tests (round-trip JSON) actualizados.

## Tests
- Suite completa: **2444 passed, 1 skipped**. **E2E Docker smoke: PASS** (exit 0, sin import-errors).

## Deploy
Los tokens ya generados en la NAS se convierten a JSON en la misma carpeta (mismo canal congreso-es-tv), reemplazando los `.pickle`.