### PR TITLE
feat(sidecar-apis): modo dormido lazy-load + idle-exit para los sidecars ML (#113) — PR3

### DIFF
--- a/benchmarks/pyannote_diarization/Dockerfile
+++ b/benchmarks/pyannote_diarization/Dockerfile
@@ -33,12 +33,13 @@ ENV PYTHONDONTWRITEBYTECODE=1 \
     HF_HOME=/model-cache \
     MODEL_CACHE_DIR=/model-cache \
     HOME=/tmp \
-    DIARIZE_API_PORT=8080
+    DIARIZE_API_PORT=8080 \
+    IDLE_TIMEOUT_SECONDS=900
 
 WORKDIR /app
 USER benchmark
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
     CMD curl -f http://localhost:${DIARIZE_API_PORT:-8080}/health || exit 1
 
 ENTRYPOINT ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port ${DIARIZE_API_PORT:-8080}"]

--- a/benchmarks/pyannote_diarization/server.py
+++ b/benchmarks/pyannote_diarization/server.py
@@ -66,7 +66,7 @@ def _default_model_loader() -> Callable[[str], list[dict]]:
     from pyannote.audio import Pipeline
 
     model_id = "pyannote/speaker-diarization-community-1"
-    pipeline = Pipeline.from_pretrained(model_id, use_auth_token=token)
+    pipeline = Pipeline.from_pretrained(model_id, token=token)
     pipeline.to(torch.device("cpu"))
 
     def _infer(wav_path: str) -> list[dict]:

--- a/benchmarks/pyannote_diarization/server.py
+++ b/benchmarks/pyannote_diarization/server.py
@@ -3,25 +3,39 @@
 Exposes ``POST /diarize`` accepting a WAV upload (multipart form) and a
 ``chapter_offset`` float. Applies the offset to every ``start_seconds``
 timestamp before returning so the caller receives absolute session timestamps.
-The model is loaded once at startup via the ``lifespan`` context; a
-``model_loader`` callable can be injected for testing so no real torch/pyannote
-import occurs during the unit test suite.
+
+The model is loaded **lazily** on the first inference request (not at startup).
+A concurrency lock ensures concurrent first-callers await a single load.
+A background watchdog task monitors ``last_activity`` and exits the process
+after ``IDLE_TIMEOUT_SECONDS`` of inactivity (compose ``restart: unless-stopped``
+relaunches the server light, without reloading the model).
+
+Set ``IDLE_TIMEOUT_SECONDS=0`` (or any negative integer) to disable the watchdog
+and keep the model resident once loaded (v1 behavior).
 
 Usage (production)::
 
     uvicorn server:app --host 0.0.0.0 --port ${DIARIZE_API_PORT:-8080}
 
 For testing, use ``create_app(model_loader=...)`` to inject a stub.
+The ``clock``, ``sleep``, and ``exit_signal`` parameters are additional seams
+for unit tests that need deterministic timing without real sleeps.
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
+import signal
 import tempfile
+import time
 from contextlib import asynccontextmanager
 from typing import Annotated, Callable
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
 
@@ -32,7 +46,7 @@ def _default_model_loader() -> Callable[[str], list[dict]]:
     """Load the pyannote pipeline and return a callable inference function.
 
     This is the real production loader. It imports torch and pyannote only
-    when called (at lifespan startup), so the module is importable without
+    when called (at first inference), so the module is importable without
     those heavy deps present.
     """
     import os as _os
@@ -94,9 +108,50 @@ def _to_speaker_changes(
     return segments
 
 
+async def _watchdog_tick(
+    state: dict,
+    idle_timeout: int,
+    clock: Callable[[], float],
+    exit_signal: Callable[[], None],
+) -> None:
+    """Execute one watchdog check: exit if idle >= timeout and no requests in-flight.
+
+    Exposed as a module-level async function so tests can call one tick directly
+    without running the sleep loop.
+    """
+    now = clock()
+    elapsed = now - state["last_activity"]
+    if elapsed >= idle_timeout and state["inflight"] == 0:
+        logger.info(
+            "diarize-api: idle %.0fs >= %ds, inflight=0 — exiting for restart",
+            elapsed,
+            idle_timeout,
+        )
+        exit_signal()
+
+
+async def _watchdog_loop(
+    state: dict,
+    idle_timeout: int,
+    watchdog_interval: float,
+    clock: Callable[[], float],
+    sleep: Callable,
+    exit_signal: Callable[[], None],
+) -> None:
+    """Background loop: sleep interval then call one watchdog tick."""
+    while True:
+        await sleep(watchdog_interval)
+        await _watchdog_tick(state, idle_timeout, clock, exit_signal)
+
+
 def create_app(
     *,
     model_loader: Callable[[], Callable[[str], list[dict]]] = _default_model_loader,
+    idle_timeout: int = int(os.environ.get("IDLE_TIMEOUT_SECONDS", "900")),
+    watchdog_interval: float = float(os.environ.get("WATCHDOG_INTERVAL_SECONDS", "30")),
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable = asyncio.sleep,
+    exit_signal: Callable[[], None] | None = None,
 ) -> FastAPI:
     """Construct and return the FastAPI application.
 
@@ -104,21 +159,77 @@ def create_app(
         model_loader: Zero-argument callable that returns the inference
             function ``(wav_path: str) -> list[dict]``.  The default loads
             the real pyannote pipeline.  Pass a stub for tests.
+        idle_timeout: Seconds of inactivity before the watchdog exits the
+            process.  ``<= 0`` disables the watchdog entirely.
+        watchdog_interval: How often (seconds) the watchdog loop wakes up.
+        clock: Callable returning a monotonic timestamp (seam for tests).
+        sleep: Awaitable sleep function (seam for tests).
+        exit_signal: Callable invoked when the watchdog decides to exit.
+            Defaults to a flag on ``_state``; production binds
+            ``server.should_exit = True`` on the uvicorn Server instance.
     """
-    _state: dict = {}
+    _state: dict = {
+        "infer": None,
+        "load_lock": asyncio.Lock(),
+        "last_activity": clock(),
+        "inflight": 0,
+        "watchdog_task": None,
+    }
+
+    # Default exit_signal: send SIGTERM to own process so uvicorn's signal
+    # handler triggers a graceful shutdown (drains in-flight, runs lifespan
+    # cleanup, exits 0).  Tests inject a fake callable instead.
+    def _default_exit_signal() -> None:
+        _state["should_exit"] = True
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    _exit_signal = exit_signal if exit_signal is not None else _default_exit_signal
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        logger.info("diarize-api: loading model …")
-        _state["infer"] = model_loader()
-        logger.info("diarize-api: model ready")
+        # Model is NOT loaded at startup — lazy load happens on first /diarize.
+        if idle_timeout > 0:
+            _state["watchdog_task"] = asyncio.create_task(
+                _watchdog_loop(
+                    _state,
+                    idle_timeout,
+                    watchdog_interval,
+                    clock,
+                    sleep,
+                    _exit_signal,
+                )
+            )
+        else:
+            logger.info(
+                "diarize-api: IDLE_TIMEOUT_SECONDS<=0 — sleep mode disabled, model stays resident"
+            )
         yield
+        # Cleanup: cancel watchdog on shutdown.
+        task = _state.get("watchdog_task")
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         _state.clear()
 
     application = FastAPI(title="diarize-api", lifespan=lifespan)
+    # Expose _state via app.extra so tests can inspect it.
+    application.extra["_state"] = _state
+
+    @application.exception_handler(RequestValidationError)
+    async def _stamp_on_validation_error(request, exc: RequestValidationError):
+        """Stamp last_activity for malformed inference POSTs (FastAPI raises before route body)."""
+        _state["last_activity"] = clock()
+        return JSONResponse(
+            status_code=422,
+            content={"detail": jsonable_encoder(exc.errors())},
+        )
 
     @application.get("/health")
     async def health():
+        # Intentionally untouched: no load, no stamp, no wake.
         return {"status": "ok"}
 
     @application.post("/diarize")
@@ -126,29 +237,40 @@ def create_app(
         audio_file: Annotated[UploadFile, File(description="WAV audio bytes")],
         chapter_offset: Annotated[float, Form(description="Chapter start offset in seconds")] = 0.0,
     ):
-        wav_bytes = await audio_file.read()
-
-        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        # Stamp activity at entry (long inferences must not let the timer fire mid-run).
+        _state["last_activity"] = clock()
+        _state["inflight"] += 1
         try:
-            tmp.write(wav_bytes)
-            tmp.flush()
-            tmp.close()
+            # Lazy model load — only on the first request; lock prevents double-load.
+            if _state["infer"] is None:
+                async with _state["load_lock"]:
+                    if _state["infer"] is None:  # double-checked inside lock
+                        logger.info("diarize-api: loading model …")
+                        t0 = clock()
+                        _state["infer"] = model_loader()
+                        logger.info("diarize-api: model ready in %.1fs", clock() - t0)
 
-            infer = _state.get("infer")
-            if infer is None:
-                raise HTTPException(status_code=503, detail="model not loaded")
+            wav_bytes = await audio_file.read()
 
-            changes: list[dict] = infer(tmp.name)
-        except HTTPException:
-            raise
-        except Exception as exc:
-            logger.exception("diarize-api: inference failed")
-            raise HTTPException(status_code=500, detail={"error": str(exc)}) from exc
-        finally:
+            tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
             try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
+                tmp.write(wav_bytes)
+                tmp.flush()
+                tmp.close()
+
+                changes: list[dict] = _state["infer"](tmp.name)
+            except Exception as exc:
+                logger.exception("diarize-api: inference failed")
+                raise HTTPException(status_code=500, detail={"error": str(exc)}) from exc
+            finally:
+                try:
+                    os.unlink(tmp.name)
+                except OSError:
+                    pass
+        finally:
+            _state["inflight"] -= 1
+            # Stamp exit time: measures idle from when work completed.
+            _state["last_activity"] = clock()
 
         if chapter_offset:
             changes = [

--- a/benchmarks/yamnet_applause/Dockerfile
+++ b/benchmarks/yamnet_applause/Dockerfile
@@ -29,12 +29,13 @@ RUN chmod 0555 /app/yamnet_applause.py /app/server.py
 ENV PYTHONDONTWRITEBYTECODE=1 \
     MODEL_CACHE_DIR=/model-cache \
     HOME=/tmp \
-    YAMNET_API_PORT=8081
+    YAMNET_API_PORT=8081 \
+    IDLE_TIMEOUT_SECONDS=900
 
 WORKDIR /app
 USER benchmark
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=15s --retries=3 \
     CMD curl -f http://localhost:${YAMNET_API_PORT:-8081}/health || exit 1
 
 ENTRYPOINT ["sh", "-c", "exec uvicorn server:app --host 0.0.0.0 --port ${YAMNET_API_PORT:-8081}"]

--- a/benchmarks/yamnet_applause/server.py
+++ b/benchmarks/yamnet_applause/server.py
@@ -3,25 +3,45 @@
 Exposes ``POST /detect`` accepting a WAV upload (multipart form) and an
 ``offset`` float. Applies the offset to every ``start`` and ``end`` timestamp
 before returning so the caller receives absolute session timestamps.
-The model is loaded once at startup via the ``lifespan`` context; a
-``model_loader`` callable can be injected for testing so no tflite/numpy
-import occurs during the unit test suite.
+
+The model is loaded **lazily** on the first inference request (not at startup).
+A concurrency lock ensures concurrent first-callers await a single load.
+A background watchdog task monitors ``last_activity`` and exits the process
+after ``IDLE_TIMEOUT_SECONDS`` of inactivity (compose ``restart: unless-stopped``
+relaunches the server light, without reloading the model).
+
+Set ``IDLE_TIMEOUT_SECONDS=0`` (or any negative integer) to disable the watchdog
+and keep the model resident once loaded (v1 behavior).
 
 Usage (production)::
 
     uvicorn server:app --host 0.0.0.0 --port ${YAMNET_API_PORT:-8081}
 
 For testing, use ``create_app(model_loader=...)`` to inject a stub.
+The ``clock``, ``sleep``, and ``exit_signal`` parameters are additional seams
+for unit tests that need deterministic timing without real sleeps.
+
+Note: this machinery is intentionally duplicated from the diarize-api server.
+Compose build contexts are isolated per directory; a shared module would require
+expanding both contexts to the repo root, rebuilding the whole repo into each
+image and breaking the trivial ``COPY server.py`` paths.
 """
 from __future__ import annotations
 
+import asyncio
+import csv
 import logging
 import os
+import signal
 import tempfile
+import time
 from contextlib import asynccontextmanager
 from typing import Annotated, Callable
 
 from fastapi import FastAPI, File, Form, HTTPException, UploadFile
+from fastapi.encoders import jsonable_encoder
+from fastapi.exceptions import RequestValidationError
+from fastapi.responses import JSONResponse
 
 logger = logging.getLogger(__name__)
 
@@ -32,10 +52,9 @@ def _default_model_loader() -> Callable[[str], list[dict]]:
     """Load the YAMNet TFLite model and return a callable inference function.
 
     This is the real production loader. It imports tflite_runtime, numpy and
-    soundfile only when called (at lifespan startup), so the module is
+    soundfile only when called (at first inference), so the module is
     importable without those deps present.
     """
-    import csv
     import os as _os
 
     import numpy as np
@@ -127,9 +146,50 @@ def _default_model_loader() -> Callable[[str], list[dict]]:
     return _run
 
 
+async def _watchdog_tick(
+    state: dict,
+    idle_timeout: int,
+    clock: Callable[[], float],
+    exit_signal: Callable[[], None],
+) -> None:
+    """Execute one watchdog check: exit if idle >= timeout and no requests in-flight.
+
+    Exposed as a module-level async function so tests can call one tick directly
+    without running the sleep loop.
+    """
+    now = clock()
+    elapsed = now - state["last_activity"]
+    if elapsed >= idle_timeout and state["inflight"] == 0:
+        logger.info(
+            "yamnet-api: idle %.0fs >= %ds, inflight=0 — exiting for restart",
+            elapsed,
+            idle_timeout,
+        )
+        exit_signal()
+
+
+async def _watchdog_loop(
+    state: dict,
+    idle_timeout: int,
+    watchdog_interval: float,
+    clock: Callable[[], float],
+    sleep: Callable,
+    exit_signal: Callable[[], None],
+) -> None:
+    """Background loop: sleep interval then call one watchdog tick."""
+    while True:
+        await sleep(watchdog_interval)
+        await _watchdog_tick(state, idle_timeout, clock, exit_signal)
+
+
 def create_app(
     *,
     model_loader: Callable[[], Callable[[str], list[dict]]] = _default_model_loader,
+    idle_timeout: int = int(os.environ.get("IDLE_TIMEOUT_SECONDS", "900")),
+    watchdog_interval: float = float(os.environ.get("WATCHDOG_INTERVAL_SECONDS", "30")),
+    clock: Callable[[], float] = time.monotonic,
+    sleep: Callable = asyncio.sleep,
+    exit_signal: Callable[[], None] | None = None,
 ) -> FastAPI:
     """Construct and return the FastAPI application.
 
@@ -137,21 +197,77 @@ def create_app(
         model_loader: Zero-argument callable that returns the inference
             function ``(wav_path: str) -> list[dict]``.  The default loads
             the real YAMNet TFLite model.  Pass a stub for tests.
+        idle_timeout: Seconds of inactivity before the watchdog exits the
+            process.  ``<= 0`` disables the watchdog entirely.
+        watchdog_interval: How often (seconds) the watchdog loop wakes up.
+        clock: Callable returning a monotonic timestamp (seam for tests).
+        sleep: Awaitable sleep function (seam for tests).
+        exit_signal: Callable invoked when the watchdog decides to exit.
+            Defaults to a flag on ``_state``; production binds
+            ``server.should_exit = True`` on the uvicorn Server instance.
     """
-    _state: dict = {}
+    _state: dict = {
+        "infer": None,
+        "load_lock": asyncio.Lock(),
+        "last_activity": clock(),
+        "inflight": 0,
+        "watchdog_task": None,
+    }
+
+    # Default exit_signal: send SIGTERM to own process so uvicorn's signal
+    # handler triggers a graceful shutdown (drains in-flight, runs lifespan
+    # cleanup, exits 0).  Tests inject a fake callable instead.
+    def _default_exit_signal() -> None:
+        _state["should_exit"] = True
+        os.kill(os.getpid(), signal.SIGTERM)
+
+    _exit_signal = exit_signal if exit_signal is not None else _default_exit_signal
 
     @asynccontextmanager
     async def lifespan(app: FastAPI):
-        logger.info("yamnet-api: loading model …")
-        _state["infer"] = model_loader()
-        logger.info("yamnet-api: model ready")
+        # Model is NOT loaded at startup — lazy load happens on first /detect.
+        if idle_timeout > 0:
+            _state["watchdog_task"] = asyncio.create_task(
+                _watchdog_loop(
+                    _state,
+                    idle_timeout,
+                    watchdog_interval,
+                    clock,
+                    sleep,
+                    _exit_signal,
+                )
+            )
+        else:
+            logger.info(
+                "yamnet-api: IDLE_TIMEOUT_SECONDS<=0 — sleep mode disabled, model stays resident"
+            )
         yield
+        # Cleanup: cancel watchdog on shutdown.
+        task = _state.get("watchdog_task")
+        if task is not None:
+            task.cancel()
+            try:
+                await task
+            except asyncio.CancelledError:
+                pass
         _state.clear()
 
     application = FastAPI(title="yamnet-api", lifespan=lifespan)
+    # Expose _state via app.extra so tests can inspect it.
+    application.extra["_state"] = _state
+
+    @application.exception_handler(RequestValidationError)
+    async def _stamp_on_validation_error(request, exc: RequestValidationError):
+        """Stamp last_activity for malformed inference POSTs (FastAPI raises before route body)."""
+        _state["last_activity"] = clock()
+        return JSONResponse(
+            status_code=422,
+            content={"detail": jsonable_encoder(exc.errors())},
+        )
 
     @application.get("/health")
     async def health():
+        # Intentionally untouched: no load, no stamp, no wake.
         return {"status": "ok"}
 
     @application.post("/detect")
@@ -159,29 +275,40 @@ def create_app(
         audio_file: Annotated[UploadFile, File(description="WAV audio bytes")],
         offset: Annotated[float, Form(description="Turn start offset in seconds")] = 0.0,
     ):
-        wav_bytes = await audio_file.read()
-
-        tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
+        # Stamp activity at entry (long inferences must not let the timer fire mid-run).
+        _state["last_activity"] = clock()
+        _state["inflight"] += 1
         try:
-            tmp.write(wav_bytes)
-            tmp.flush()
-            tmp.close()
+            # Lazy model load — only on the first request; lock prevents double-load.
+            if _state["infer"] is None:
+                async with _state["load_lock"]:
+                    if _state["infer"] is None:  # double-checked inside lock
+                        logger.info("yamnet-api: loading model …")
+                        t0 = clock()
+                        _state["infer"] = model_loader()
+                        logger.info("yamnet-api: model ready in %.1fs", clock() - t0)
 
-            infer = _state.get("infer")
-            if infer is None:
-                raise HTTPException(status_code=503, detail="model not loaded")
+            wav_bytes = await audio_file.read()
 
-            intervals: list[dict] = infer(tmp.name)
-        except HTTPException:
-            raise
-        except Exception as exc:
-            logger.exception("yamnet-api: inference failed")
-            raise HTTPException(status_code=500, detail={"error": str(exc)}) from exc
-        finally:
+            tmp = tempfile.NamedTemporaryFile(suffix=".wav", delete=False)
             try:
-                os.unlink(tmp.name)
-            except OSError:
-                pass
+                tmp.write(wav_bytes)
+                tmp.flush()
+                tmp.close()
+
+                intervals: list[dict] = _state["infer"](tmp.name)
+            except Exception as exc:
+                logger.exception("yamnet-api: inference failed")
+                raise HTTPException(status_code=500, detail={"error": str(exc)}) from exc
+            finally:
+                try:
+                    os.unlink(tmp.name)
+                except OSError:
+                    pass
+        finally:
+            _state["inflight"] -= 1
+            # Stamp exit time: measures idle from when work completed.
+            _state["last_activity"] = clock()
 
         if offset:
             intervals = [

--- a/docker-compose-ml-apis.yml
+++ b/docker-compose-ml-apis.yml
@@ -15,7 +15,10 @@ services:
     container_name: diarize-api
     restart: unless-stopped
     ports:
-      - "8080:8080"
+      # Host binding is debug-only (Airflow reaches diarize-api:8080 via
+      # ml_api_network DNS); localhost-only high port avoids NAS collisions
+      # with adminer (8080) and the Airflow dev webserver (8081).
+      - "127.0.0.1:18080:8080"
     environment:
       HF_TOKEN: "${HF_TOKEN}"
       HF_HOME: /model-cache
@@ -42,7 +45,8 @@ services:
     container_name: yamnet-api
     restart: unless-stopped
     ports:
-      - "8081:8081"
+      # Debug-only localhost binding; see diarize-api note above.
+      - "127.0.0.1:18081:8081"
     environment:
       MODEL_CACHE_DIR: /model-cache
       YAMNET_API_PORT: "8081"

--- a/docker-compose-ml-apis.yml
+++ b/docker-compose-ml-apis.yml
@@ -21,6 +21,7 @@ services:
       HF_HOME: /model-cache
       MODEL_CACHE_DIR: /model-cache
       DIARIZE_API_PORT: "8080"
+      IDLE_TIMEOUT_SECONDS: "${IDLE_TIMEOUT_SECONDS:-900}"
     volumes:
       - hf_home:/model-cache
     networks:
@@ -31,7 +32,7 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 120s
+      start_period: 30s
 
   yamnet-api:
     build:
@@ -45,6 +46,7 @@ services:
     environment:
       MODEL_CACHE_DIR: /model-cache
       YAMNET_API_PORT: "8081"
+      IDLE_TIMEOUT_SECONDS: "${IDLE_TIMEOUT_SECONDS:-900}"
     volumes:
       - yamnet_model_cache:/model-cache
     networks:
@@ -55,4 +57,4 @@ services:
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 60s
+      start_period: 15s

--- a/docs/ops/sidecar-model-apis.md
+++ b/docs/ops/sidecar-model-apis.md
@@ -6,20 +6,73 @@ bridge) and are reached by the Airflow scheduler via container-name DNS.
 
 ## Services
 
-| Service | Port | Memory | Purpose |
-|---------|------|--------|---------|
+| Service | Port | Memory (burst) | Purpose |
+|---------|------|----------------|---------|
 | `diarize-api` | 8080 | 6 g | Pyannote speaker diarization (CPU) |
 | `yamnet-api` | 8081 | 1 g | YAMNet TFLite applause detection (CPU) |
 
 ## RAM Prerequisites
 
-Check total free memory on the NAS before starting both sidecars alongside
-Airflow. Minimum reserved:
+The 6 g (`diarize-api`) and 1 g (`yamnet-api`) figures are **burst ceilings**
+during active inference. When idle, each sidecar is a lightweight FastAPI
+process holding no model in memory (see Sleep/Wake below). Plan for the
+burst ceiling if both are likely to run inference concurrently:
 
 - Airflow scheduler + webserver: ~2–3 g
-- `diarize-api` (pyannote CPU): 6 g
-- `yamnet-api` (TFLite): 1 g
-- **Total: at least 10 g free RAM**
+- `diarize-api` burst (pyannote CPU): 6 g
+- `yamnet-api` burst (TFLite): 1 g
+- **Total burst: at least 10 g free RAM**
+
+Under the default idle-exit policy (15 minutes), steady-state RAM while idle
+drops to ~200–300 MB per sidecar.
+
+## Sleep / Wake Lifecycle (idle-exit)
+
+Both sidecars use a lazy-load + idle-exit model (issue #113):
+
+1. **Start**: process starts without loading the model; `/health` responds immediately.
+2. **First inference**: model loads on demand (cold-start latency; see below).
+3. **Subsequent inferences**: model is cached in memory; no reload.
+4. **Idle timeout**: after `IDLE_TIMEOUT_SECONDS` of inactivity with no requests
+   in-flight, the watchdog exits the process with code 0.
+5. **Restart**: compose `restart: unless-stopped` relaunches the process light,
+   returning to step 1.
+
+The watchdog never exits while an inference request is in-flight. Existing
+`retries: 3` absorbs the brief restart window without marking the container unhealthy.
+
+### Cold-Start Latency
+
+After an idle-exit restart, the first inference call incurs a model-load delay:
+
+| Service | Cold-start estimate |
+|---------|---------------------|
+| `diarize-api` | 30–120 s (pyannote CPU, depends on NAS I/O) |
+| `yamnet-api` | 2–5 s (TFLite, small model) |
+
+Callers should use a read timeout ≥ 120 s for diarize-api, or retry with
+backoff if the NAS is under I/O load.
+
+### IDLE_TIMEOUT_SECONDS Tuning
+
+Set via environment variable (default: 900 seconds / 15 minutes):
+
+```bash
+# In .env or docker-compose override:
+IDLE_TIMEOUT_SECONDS=1800   # 30 minutes — reduce restart frequency
+IDLE_TIMEOUT_SECONDS=300    # 5 minutes — free RAM faster
+IDLE_TIMEOUT_SECONDS=0      # Disable watchdog; model stays resident once loaded (v1 behavior)
+```
+
+Pass it through compose (already wired in `docker-compose-ml-apis.yml`):
+
+```bash
+IDLE_TIMEOUT_SECONDS=1800 docker compose -f docker-compose-ml-apis.yml up -d
+```
+
+Setting `IDLE_TIMEOUT_SECONDS=0` or any negative value disables the watchdog
+entirely; the model stays in memory once loaded. Use this if cold-start latency
+is unacceptable or the NAS always has enough free RAM.
 
 ## HF_TOKEN Setup
 
@@ -97,3 +150,5 @@ Each PR is independently revertible:
   `speaker_turns_docker.py`; drop `ml_api_network` from compose files.
 - PR2 (yamnet-api): revert `feat(yamnet-api)` commit; restore
   `trim_proposals_docker.py`; remove yamnet-api from `docker-compose-ml-apis.yml`.
+- PR3 (idle-exit): revert this commit; servers return to eager-resident behavior
+  (#109 state), independently revertible without affecting PR1 or PR2.

--- a/tests/benchmarks/test_pyannote_diarization_server.py
+++ b/tests/benchmarks/test_pyannote_diarization_server.py
@@ -2,9 +2,18 @@
 
 Heavy deps (torch, pyannote) are never imported: the model-loader callable is
 injected so the test suite runs without GPU/model downloads.
+
+Covers:
+- Health endpoint (always-light: no model load, no last_activity stamp)
+- Lazy model load (first request loads; subsequent reuse; concurrent first-callers load once)
+- 422 validation error stamps last_activity even before route body runs
+- Watchdog: exits at idle threshold (inflight==0); blocked by in-flight; timer reset by activity
+- Watchdog disabled when idle_timeout <= 0
+- Lifespan: watchdog task created (enabled) / absent (disabled); model NOT loaded at startup
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import os
 
@@ -12,30 +21,65 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-def _make_client(inference_callable=None):
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(
+    inference_callable=None,
+    loader_call_count: list | None = None,
+    *,
+    idle_timeout: int = 900,
+    clock=None,
+    sleep=None,
+    exit_signal=None,
+):
     """Create a TestClient with an injectable inference callable.
 
-    The TestClient is used as a context manager so the FastAPI lifespan
-    (which loads the model into ``_state``) runs before any request.
-    Returns the entered context manager directly so callers use it like a
-    regular client.
+    Returns the entered TestClient so callers receive a ready client.
+    ``loader_call_count`` is an optional mutable list used to track how many
+    times the model_loader itself is called (as opposed to the inference fn).
     """
     if inference_callable is None:
         def inference_callable(wav_path: str) -> list[dict]:
             return []
 
+    if loader_call_count is None:
+        loader_call_count = []
+
+    def counting_loader():
+        loader_call_count.append(1)
+        return inference_callable
+
     import sys
-    # Ensure fresh import so each call gets its own _state dict.
     if "benchmarks.pyannote_diarization.server" in sys.modules:
         del sys.modules["benchmarks.pyannote_diarization.server"]
 
     import benchmarks.pyannote_diarization.server as srv
-    app = srv.create_app(model_loader=lambda: inference_callable)
-    # Enter the lifespan so _state["infer"] is populated before requests.
+
+    kwargs: dict = dict(
+        model_loader=counting_loader,
+        idle_timeout=idle_timeout,
+    )
+    if clock is not None:
+        kwargs["clock"] = clock
+    if sleep is not None:
+        kwargs["sleep"] = sleep
+    if exit_signal is not None:
+        kwargs["exit_signal"] = exit_signal
+
+    app = srv.create_app(**kwargs)
     client = TestClient(app)
     client.__enter__()
     return client
 
+
+_WAV_STUB = b"RIFF\x00\x00\x00\x00WAVEfmt "
+
+
+# ---------------------------------------------------------------------------
+# Existing tests (safety-net)
+# ---------------------------------------------------------------------------
 
 class TestHealthEndpoint:
     def test_health_returns_200(self):
@@ -72,10 +116,9 @@ class TestDiarizeEndpoint:
             }
         ]
         client = _make_client(self._stub_inference(changes))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/diarize",
-            files={"audio_file": ("chapter.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("chapter.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"chapter_offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -94,15 +137,13 @@ class TestDiarizeEndpoint:
             }
         ]
         client = _make_client(self._stub_inference(changes))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/diarize",
-            files={"audio_file": ("chapter.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("chapter.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"chapter_offset": "100.0"},
         )
         assert resp.status_code == 200
         body = resp.json()
-        # 10.0 + 100.0 = 110.0
         assert body["speaker_changes"][0]["start_seconds"] == pytest.approx(110.0)
 
     def test_zero_offset_leaves_start_seconds_unchanged(self):
@@ -115,10 +156,9 @@ class TestDiarizeEndpoint:
             }
         ]
         client = _make_client(self._stub_inference(changes))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/diarize",
-            files={"audio_file": ("chapter.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("chapter.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"chapter_offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -135,10 +175,9 @@ class TestDiarizeEndpoint:
             }
         ]
         client = _make_client(self._stub_inference(changes))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/diarize",
-            files={"audio_file": ("chapter.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("chapter.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"chapter_offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -174,8 +213,6 @@ class TestTempfileCleanup:
             }
         ]
 
-        import benchmarks.pyannote_diarization.server as srv
-        import importlib
         import sys
         if "benchmarks.pyannote_diarization.server" in sys.modules:
             del sys.modules["benchmarks.pyannote_diarization.server"]
@@ -186,14 +223,12 @@ class TestTempfileCleanup:
 
         app = srv.create_app(model_loader=lambda: stub_inference)
         client = TestClient(app)
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         client.post(
             "/diarize",
-            files={"audio_file": ("chapter.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("chapter.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"chapter_offset": "0.0"},
         )
 
-        # All created tempfiles must have been cleaned up
         for fpath in created_files:
             assert not os.path.exists(fpath), f"Tempfile not cleaned up: {fpath}"
 
@@ -221,12 +256,359 @@ class TestTempfileCleanup:
 
         app = srv.create_app(model_loader=lambda: failing_inference)
         client = TestClient(app, raise_server_exceptions=False)
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         client.post(
             "/diarize",
-            files={"audio_file": ("chapter.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("chapter.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"chapter_offset": "0.0"},
         )
 
         for fpath in created_files:
             assert not os.path.exists(fpath), f"Tempfile not cleaned after failure: {fpath}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 1 — NEW: Idle-exit / lazy-load tests (RED → GREEN after Phase 2)
+# ---------------------------------------------------------------------------
+
+class TestLazyLoad:
+    """Model must NOT be loaded at startup; loaded on first inference only."""
+
+    def test_health_never_loads_model(self):
+        """GET /health must not trigger the model loader."""
+        count: list[int] = []
+        client = _make_client(loader_call_count=count, idle_timeout=0)
+        client.get("/health")
+        client.get("/health")
+        assert count == [], "model_loader must not be called by /health"
+
+    def test_lifespan_does_not_load_model(self):
+        """After lifespan startup only, loader call count must be 0."""
+        count: list[int] = []
+        _make_client(loader_call_count=count, idle_timeout=0)
+        # client entered (lifespan ran) but no request issued yet
+        assert count == [], "model must not be loaded during lifespan startup"
+
+    def test_first_diarize_loads_model_once(self):
+        """First POST /diarize triggers exactly one model load."""
+        count: list[int] = []
+        client = _make_client(loader_call_count=count, idle_timeout=0)
+        client.post(
+            "/diarize",
+            files={"audio_file": ("c.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
+            data={"chapter_offset": "0.0"},
+        )
+        assert len(count) == 1, f"Expected exactly 1 load call, got {len(count)}"
+
+    def test_second_diarize_skips_load(self):
+        """Second POST /diarize must reuse cached model (loader not called again)."""
+        count: list[int] = []
+        client = _make_client(loader_call_count=count, idle_timeout=0)
+        for _ in range(2):
+            client.post(
+                "/diarize",
+                files={"audio_file": ("c.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
+                data={"chapter_offset": "0.0"},
+            )
+        assert len(count) == 1, f"Expected exactly 1 load call across 2 requests, got {len(count)}"
+
+    def test_concurrent_first_requests_load_model_once(self):
+        """N concurrent POST /diarize while model unloaded → model loaded exactly once."""
+        import threading
+
+        count: list[int] = []
+        load_started = threading.Event()
+        load_proceed = threading.Event()
+
+        def slow_inference(wav_path: str) -> list[dict]:
+            return []
+
+        def slow_loader():
+            load_started.set()
+            load_proceed.wait(timeout=5)
+            count.append(1)
+            return slow_inference
+
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+        app = srv.create_app(model_loader=slow_loader, idle_timeout=0)
+
+        results: list[int] = []
+
+        # All threads share ONE entered client (one lifespan context).
+        with TestClient(app) as client:
+            def make_request():
+                resp = client.post(
+                    "/diarize",
+                    files={"audio_file": ("c.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
+                    data={"chapter_offset": "0.0"},
+                )
+                results.append(resp.status_code)
+
+            threads = [threading.Thread(target=make_request) for _ in range(3)]
+            for t in threads:
+                t.start()
+            load_started.wait(timeout=5)
+            load_proceed.set()
+            for t in threads:
+                t.join(timeout=10)
+
+        assert all(s == 200 for s in results), f"Not all 200: {results}"
+        assert len(count) == 1, f"Expected 1 loader call, got {len(count)}"
+
+
+class TestActivityStamping:
+    """last_activity must be stamped by /diarize (entry+exit) and 422 handler; never by /health."""
+
+    def test_422_stamps_last_activity(self):
+        """Missing audio_file → HTTP 422 AND last_activity advances."""
+        clock_val: list[float] = [0.0]
+
+        def fake_clock() -> float:
+            return clock_val[0]
+
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=0, clock=fake_clock)
+        with TestClient(app) as client:
+            clock_val[0] = 42.0
+
+            resp = client.post("/diarize", data={"chapter_offset": "0.0"})
+            assert resp.status_code == 422
+            assert app.extra["_state"]["last_activity"] == 42.0
+
+    def test_health_does_not_stamp_last_activity(self):
+        """GET /health must not change last_activity; confirmed via watchdog not firing."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock() -> float:
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        # Timeout=900; if /health stamped, advancing clock by 500 wouldn't trigger exit.
+        # We test by driving one watchdog tick after /health and checking exit not fired.
+        app = srv.create_app(
+            model_loader=lambda: (lambda p: []),
+            idle_timeout=900,
+            clock=fake_clock,
+            exit_signal=fake_exit,
+        )
+        with TestClient(app) as client:
+            # Record initial last_activity (set at startup)
+            clock_val[0] = 1000.0  # advance past threshold from 0
+            # GET /health — must NOT stamp last_activity
+            client.get("/health")
+            # Now manually tick the watchdog: idle > 900s from startup, inflight=0
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(app.extra["_state"], 900, fake_clock, fake_exit)
+            )
+            # Should exit because /health didn't reset the timer
+            assert fired, "/health must not stamp last_activity (watchdog should fire)"
+
+
+class TestWatchdog:
+    """Watchdog tick behavior: exit on idle, block on inflight, reset on activity."""
+
+    def _make_app_and_state(self, idle_timeout: int, clock, exit_fn):
+        """Helper: create app + extract _state from app.extra."""
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        app = srv.create_app(
+            model_loader=lambda: (lambda p: []),
+            idle_timeout=idle_timeout,
+            clock=clock,
+            exit_signal=exit_fn,
+        )
+        return app, srv
+
+    def test_watchdog_exits_at_idle_threshold(self):
+        """Watchdog tick with now >= last_activity+timeout and inflight==0 → exit_signal called."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            # Set last_activity to 0.0, advance clock past threshold
+            state["last_activity"] = 0.0
+            state["inflight"] = 0
+            clock_val[0] = 900.0
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert fired, "exit_signal must be called when idle >= threshold and inflight==0"
+
+    def test_watchdog_blocked_by_inflight(self):
+        """Watchdog must NOT exit while inflight > 0, even past threshold."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["last_activity"] = 0.0
+            state["inflight"] = 1  # in-flight request
+            clock_val[0] = 1000.0  # past threshold
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert not fired, "exit_signal must NOT be called while inflight > 0"
+
+            # Now drain inflight and tick again
+            state["inflight"] = 0
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert fired, "exit_signal must be called after inflight drops to 0 past threshold"
+
+    def test_watchdog_activity_resets_timer(self):
+        """A new last_activity stamp resets the idle window; watchdog should not exit."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["inflight"] = 0
+
+            # Simulate: idle for 800s, then a new request stamps at t=800
+            state["last_activity"] = 800.0
+            clock_val[0] = 900.0  # only 100s elapsed since stamp → threshold not met
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert not fired, "watchdog must not exit when only 100s elapsed since last_activity"
+
+    def test_watchdog_does_not_exit_just_below_threshold(self):
+        """Clock at exactly last_activity + timeout - 1 → no exit."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["last_activity"] = 0.0
+            state["inflight"] = 0
+            clock_val[0] = 899.0  # one second short
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert not fired, "watchdog must not exit when elapsed < threshold"
+
+
+class TestWatchdogDisabled:
+    """idle_timeout <= 0 → no watchdog task created; sleep mode disabled."""
+
+    def test_watchdog_disabled_idle_timeout_zero(self):
+        """create_app(idle_timeout=0) → lifespan starts NO watchdog task."""
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=0)
+        with TestClient(app):
+            state = app.extra["_state"]
+            assert state.get("watchdog_task") is None, \
+                "watchdog_task must be None when idle_timeout=0"
+
+    def test_watchdog_disabled_idle_timeout_negative(self):
+        """create_app(idle_timeout=-1) → lifespan starts NO watchdog task."""
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=-1)
+        with TestClient(app):
+            state = app.extra["_state"]
+            assert state.get("watchdog_task") is None, \
+                "watchdog_task must be None when idle_timeout=-1"
+
+    def test_watchdog_disabled_logs_sleep_mode_disabled(self, caplog):
+        """When idle_timeout <= 0, log must contain 'sleep mode disabled'."""
+        import logging
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        with caplog.at_level(logging.INFO):
+            app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=0)
+            with TestClient(app):
+                pass
+
+        assert any("sleep mode disabled" in r.message for r in caplog.records), \
+            "Expected 'sleep mode disabled' log message when idle_timeout=0"
+
+
+class TestLifespanWatchdogEnabled:
+    """When idle_timeout > 0, lifespan must start a watchdog task but NOT load the model."""
+
+    def test_lifespan_starts_watchdog_loads_no_model(self):
+        """Enter lifespan with idle_timeout=900: watchdog_task created, loader uncalled."""
+        count: list[int] = []
+        import sys
+        if "benchmarks.pyannote_diarization.server" in sys.modules:
+            del sys.modules["benchmarks.pyannote_diarization.server"]
+        import benchmarks.pyannote_diarization.server as srv
+
+        def counting_loader():
+            count.append(1)
+            return lambda p: []
+
+        # Use a fake clock and a no-op sleep to avoid real 30s waits
+        app = srv.create_app(
+            model_loader=counting_loader,
+            idle_timeout=900,
+            clock=lambda: 0.0,
+            sleep=lambda _: asyncio.sleep(0),  # yield but don't wait
+        )
+        with TestClient(app):
+            state = app.extra["_state"]
+            assert count == [], "model must NOT be loaded during lifespan startup"
+            assert state.get("watchdog_task") is not None, \
+                "watchdog_task must be created when idle_timeout > 0"

--- a/tests/benchmarks/test_yamnet_applause_server.py
+++ b/tests/benchmarks/test_yamnet_applause_server.py
@@ -2,9 +2,18 @@
 
 Heavy deps (tflite, soundfile, numpy) are never imported: the inference callable
 is injected so the test suite runs without model downloads.
+
+Covers:
+- Health endpoint (always-light: no model load, no last_activity stamp)
+- Lazy model load (first request loads; subsequent reuse; concurrent first-callers load once)
+- 422 validation error stamps last_activity even before route body runs
+- Watchdog: exits at idle threshold (inflight==0); blocked by in-flight; timer reset by activity
+- Watchdog disabled when idle_timeout <= 0
+- Lifespan: watchdog task created (enabled) / absent (disabled); model NOT loaded at startup
 """
 from __future__ import annotations
 
+import asyncio
 import io
 import os
 
@@ -12,26 +21,65 @@ import pytest
 from fastapi.testclient import TestClient
 
 
-def _make_client(inference_callable=None):
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_client(
+    inference_callable=None,
+    loader_call_count: list | None = None,
+    *,
+    idle_timeout: int = 900,
+    clock=None,
+    sleep=None,
+    exit_signal=None,
+):
     """Create a TestClient with an injectable inference callable.
 
-    The TestClient is entered as a context manager so the FastAPI lifespan
-    (which populates ``_state``) runs before any request.
+    Returns the entered TestClient so callers receive a ready client.
+    ``loader_call_count`` is an optional mutable list used to track how many
+    times the model_loader itself is called.
     """
     if inference_callable is None:
         def inference_callable(wav_path: str) -> list[dict]:
             return []
+
+    if loader_call_count is None:
+        loader_call_count = []
+
+    def counting_loader():
+        loader_call_count.append(1)
+        return inference_callable
 
     import sys
     if "benchmarks.yamnet_applause.server" in sys.modules:
         del sys.modules["benchmarks.yamnet_applause.server"]
 
     import benchmarks.yamnet_applause.server as srv
-    app = srv.create_app(model_loader=lambda: inference_callable)
+
+    kwargs: dict = dict(
+        model_loader=counting_loader,
+        idle_timeout=idle_timeout,
+    )
+    if clock is not None:
+        kwargs["clock"] = clock
+    if sleep is not None:
+        kwargs["sleep"] = sleep
+    if exit_signal is not None:
+        kwargs["exit_signal"] = exit_signal
+
+    app = srv.create_app(**kwargs)
     client = TestClient(app)
     client.__enter__()
     return client
 
+
+_WAV_STUB = b"RIFF\x00\x00\x00\x00WAVEfmt "
+
+
+# ---------------------------------------------------------------------------
+# Existing tests (safety-net)
+# ---------------------------------------------------------------------------
 
 class TestHealthEndpoint:
     def test_health_returns_200(self):
@@ -59,10 +107,9 @@ class TestDetectEndpoint:
     def test_happy_path_returns_200_with_applause_intervals(self):
         intervals = [{"start": 5.0, "end": 20.0, "max_score": 0.88}]
         client = _make_client(self._stub_inference(intervals))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/detect",
-            files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -73,26 +120,23 @@ class TestDetectEndpoint:
     def test_offset_is_added_to_start_and_end(self):
         intervals = [{"start": 5.0, "end": 20.0, "max_score": 0.75}]
         client = _make_client(self._stub_inference(intervals))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/detect",
-            files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"offset": "100.0"},
         )
         assert resp.status_code == 200
         body = resp.json()
         iv = body["applause_intervals"][0]
-        # 5.0 + 100.0 = 105.0; 20.0 + 100.0 = 120.0
         assert iv["start"] == pytest.approx(105.0)
         assert iv["end"] == pytest.approx(120.0)
 
     def test_zero_offset_leaves_intervals_unchanged(self):
         intervals = [{"start": 3.0, "end": 8.0, "max_score": 0.6}]
         client = _make_client(self._stub_inference(intervals))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/detect",
-            files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -104,10 +148,9 @@ class TestDetectEndpoint:
     def test_max_score_field_preserved(self):
         intervals = [{"start": 0.0, "end": 10.0, "max_score": 0.95}]
         client = _make_client(self._stub_inference(intervals))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/detect",
-            files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -117,10 +160,9 @@ class TestDetectEndpoint:
 
     def test_empty_intervals_returns_empty_list(self):
         client = _make_client(self._stub_inference([]))
-        wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
         resp = client.post(
             "/detect",
-            files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+            files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
             data={"offset": "0.0"},
         )
         assert resp.status_code == 200
@@ -154,10 +196,9 @@ class TestTempfileCleanup:
         app = srv.create_app(model_loader=lambda: stub)
         client = TestClient(app)
         with client:
-            wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
             client.post(
                 "/detect",
-                files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+                files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
                 data={"offset": "0.0"},
             )
 
@@ -188,12 +229,345 @@ class TestTempfileCleanup:
         app = srv.create_app(model_loader=lambda: failing_inference)
         client = TestClient(app, raise_server_exceptions=False)
         with client:
-            wav_bytes = b"RIFF\x00\x00\x00\x00WAVEfmt "
             client.post(
                 "/detect",
-                files={"audio_file": ("turn.wav", io.BytesIO(wav_bytes), "audio/wav")},
+                files={"audio_file": ("turn.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
                 data={"offset": "0.0"},
             )
 
         for fpath in created_files:
             assert not os.path.exists(fpath), f"Tempfile not cleaned after failure: {fpath}"
+
+
+# ---------------------------------------------------------------------------
+# Phase 4 — NEW: Idle-exit / lazy-load tests (mirror of diarize tests)
+# ---------------------------------------------------------------------------
+
+class TestLazyLoad:
+    """Model must NOT be loaded at startup; loaded on first inference only."""
+
+    def test_health_never_loads_model(self):
+        """GET /health must not trigger the model loader."""
+        count: list[int] = []
+        client = _make_client(loader_call_count=count, idle_timeout=0)
+        client.get("/health")
+        client.get("/health")
+        assert count == [], "model_loader must not be called by /health"
+
+    def test_lifespan_does_not_load_model(self):
+        """After lifespan startup only, loader call count must be 0."""
+        count: list[int] = []
+        _make_client(loader_call_count=count, idle_timeout=0)
+        assert count == [], "model must not be loaded during lifespan startup"
+
+    def test_first_detect_loads_model_once(self):
+        """First POST /detect triggers exactly one model load."""
+        count: list[int] = []
+        client = _make_client(loader_call_count=count, idle_timeout=0)
+        client.post(
+            "/detect",
+            files={"audio_file": ("t.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
+            data={"offset": "0.0"},
+        )
+        assert len(count) == 1, f"Expected exactly 1 load call, got {len(count)}"
+
+    def test_second_detect_skips_load(self):
+        """Second POST /detect must reuse cached model (loader not called again)."""
+        count: list[int] = []
+        client = _make_client(loader_call_count=count, idle_timeout=0)
+        for _ in range(2):
+            client.post(
+                "/detect",
+                files={"audio_file": ("t.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
+                data={"offset": "0.0"},
+            )
+        assert len(count) == 1, f"Expected exactly 1 load call across 2 requests, got {len(count)}"
+
+    def test_concurrent_first_requests_load_model_once(self):
+        """N concurrent POST /detect while model unloaded → model loaded exactly once."""
+        import threading
+
+        count: list[int] = []
+        load_started = threading.Event()
+        load_proceed = threading.Event()
+
+        def slow_inference(wav_path: str) -> list[dict]:
+            return []
+
+        def slow_loader():
+            load_started.set()
+            load_proceed.wait(timeout=5)
+            count.append(1)
+            return slow_inference
+
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+        app = srv.create_app(model_loader=slow_loader, idle_timeout=0)
+
+        results: list[int] = []
+
+        # All threads share ONE entered client (one lifespan context).
+        with TestClient(app) as client:
+            def make_request():
+                resp = client.post(
+                    "/detect",
+                    files={"audio_file": ("t.wav", io.BytesIO(_WAV_STUB), "audio/wav")},
+                    data={"offset": "0.0"},
+                )
+                results.append(resp.status_code)
+
+            threads = [threading.Thread(target=make_request) for _ in range(3)]
+            for t in threads:
+                t.start()
+            load_started.wait(timeout=5)
+            load_proceed.set()
+            for t in threads:
+                t.join(timeout=10)
+
+        assert all(s == 200 for s in results), f"Not all 200: {results}"
+        assert len(count) == 1, f"Expected 1 loader call, got {len(count)}"
+
+
+class TestActivityStamping:
+    """last_activity must be stamped by /detect (entry+exit) and 422 handler; never by /health."""
+
+    def test_422_stamps_last_activity(self):
+        """Missing audio_file → HTTP 422 AND last_activity advances."""
+        clock_val: list[float] = [0.0]
+
+        def fake_clock() -> float:
+            return clock_val[0]
+
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=0, clock=fake_clock)
+        with TestClient(app) as client:
+            clock_val[0] = 42.0
+            resp = client.post("/detect", data={"offset": "0.0"})
+            assert resp.status_code == 422
+            assert app.extra["_state"]["last_activity"] == 42.0
+
+    def test_health_does_not_stamp_last_activity(self):
+        """GET /health must not change last_activity; confirmed via watchdog firing."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock() -> float:
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        app = srv.create_app(
+            model_loader=lambda: (lambda p: []),
+            idle_timeout=900,
+            clock=fake_clock,
+            exit_signal=fake_exit,
+        )
+        with TestClient(app) as client:
+            clock_val[0] = 1000.0
+            client.get("/health")
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(app.extra["_state"], 900, fake_clock, fake_exit)
+            )
+            assert fired, "/health must not stamp last_activity (watchdog should fire)"
+
+
+class TestWatchdog:
+    """Watchdog tick behavior: exit on idle, block on inflight, reset on activity."""
+
+    def _make_app_and_state(self, idle_timeout: int, clock, exit_fn):
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        app = srv.create_app(
+            model_loader=lambda: (lambda p: []),
+            idle_timeout=idle_timeout,
+            clock=clock,
+            exit_signal=exit_fn,
+        )
+        return app, srv
+
+    def test_watchdog_exits_at_idle_threshold(self):
+        """Watchdog tick with now >= last_activity+timeout and inflight==0 → exit_signal called."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["last_activity"] = 0.0
+            state["inflight"] = 0
+            clock_val[0] = 900.0
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert fired, "exit_signal must be called when idle >= threshold and inflight==0"
+
+    def test_watchdog_blocked_by_inflight(self):
+        """Watchdog must NOT exit while inflight > 0, even past threshold."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["last_activity"] = 0.0
+            state["inflight"] = 1
+            clock_val[0] = 1000.0
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert not fired, "exit_signal must NOT be called while inflight > 0"
+
+            state["inflight"] = 0
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert fired, "exit_signal must be called after inflight drops to 0 past threshold"
+
+    def test_watchdog_activity_resets_timer(self):
+        """A new last_activity stamp resets the idle window; watchdog should not exit."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["inflight"] = 0
+            state["last_activity"] = 800.0
+            clock_val[0] = 900.0  # only 100s elapsed since stamp
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert not fired, "watchdog must not exit when only 100s elapsed since last_activity"
+
+    def test_watchdog_does_not_exit_just_below_threshold(self):
+        """Clock at exactly last_activity + timeout - 1 → no exit."""
+        fired: list[bool] = []
+        clock_val: list[float] = [0.0]
+
+        def fake_clock():
+            return clock_val[0]
+
+        def fake_exit():
+            fired.append(True)
+
+        app, srv = self._make_app_and_state(900, fake_clock, fake_exit)
+        with TestClient(app):
+            state = app.extra["_state"]
+            state["last_activity"] = 0.0
+            state["inflight"] = 0
+            clock_val[0] = 899.0
+
+            asyncio.get_event_loop().run_until_complete(
+                srv._watchdog_tick(state, 900, fake_clock, fake_exit)
+            )
+            assert not fired, "watchdog must not exit when elapsed < threshold"
+
+
+class TestWatchdogDisabled:
+    """idle_timeout <= 0 → no watchdog task created; sleep mode disabled."""
+
+    def test_watchdog_disabled_idle_timeout_zero(self):
+        """create_app(idle_timeout=0) → lifespan starts NO watchdog task."""
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=0)
+        with TestClient(app):
+            state = app.extra["_state"]
+            assert state.get("watchdog_task") is None, \
+                "watchdog_task must be None when idle_timeout=0"
+
+    def test_watchdog_disabled_idle_timeout_negative(self):
+        """create_app(idle_timeout=-1) → lifespan starts NO watchdog task."""
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=-1)
+        with TestClient(app):
+            state = app.extra["_state"]
+            assert state.get("watchdog_task") is None, \
+                "watchdog_task must be None when idle_timeout=-1"
+
+    def test_watchdog_disabled_logs_sleep_mode_disabled(self, caplog):
+        """When idle_timeout <= 0, log must contain 'sleep mode disabled'."""
+        import logging
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        with caplog.at_level(logging.INFO):
+            app = srv.create_app(model_loader=lambda: (lambda p: []), idle_timeout=0)
+            with TestClient(app):
+                pass
+
+        assert any("sleep mode disabled" in r.message for r in caplog.records), \
+            "Expected 'sleep mode disabled' log message when idle_timeout=0"
+
+
+class TestLifespanWatchdogEnabled:
+    """When idle_timeout > 0, lifespan must start a watchdog task but NOT load the model."""
+
+    def test_lifespan_starts_watchdog_loads_no_model(self):
+        """Enter lifespan with idle_timeout=900: watchdog_task created, loader uncalled."""
+        count: list[int] = []
+        import sys
+        if "benchmarks.yamnet_applause.server" in sys.modules:
+            del sys.modules["benchmarks.yamnet_applause.server"]
+        import benchmarks.yamnet_applause.server as srv
+
+        def counting_loader():
+            count.append(1)
+            return lambda p: []
+
+        app = srv.create_app(
+            model_loader=counting_loader,
+            idle_timeout=900,
+            clock=lambda: 0.0,
+            sleep=lambda _: asyncio.sleep(0),
+        )
+        with TestClient(app):
+            state = app.extra["_state"]
+            assert count == [], "model must NOT be loaded during lifespan startup"
+            assert state.get("watchdog_task") is not None, \
+                "watchdog_task must be created when idle_timeout > 0"


### PR DESCRIPTION
Slice **PR3** de la cadena #109 · **Base: `feat/issue-109-sidecar-pr2` (PR #112), NO dev** · depende de que PR2 mergee primero. Cierra #113.

`size:exception` aprobado: ~1300 líneas contadas, dominadas por tests espejados (los dos servers duplican la maquinaria deliberadamente — cada build context de Docker no puede alcanzar un módulo compartido).

## Qué hace (PR3 — modo dormido)
Los sidecars dejan de mantener el modelo residente 24/7 (pyannote ~4-6 GB en el NAS):

1. **Arranque liviano**: sin modelo; `GET /health` responde `{"status":"ok"}` sin cargarlo jamás.
2. **Carga perezosa**: el modelo se carga en la primera inferencia (lock — llamadas concurrentes esperan una sola carga).
3. **Idle-exit**: watchdog asyncio; tras `IDLE_TIMEOUT_SECONDS` (default 900, `<=0` desactiva) sin inferencias y con cero peticiones en vuelo, el proceso sale limpio (SIGTERM-a-sí-mismo tras `exec uvicorn` = PID 1 → drenado graceful, exit 0).
4. **Relanzamiento**: el `restart: unless-stopped` existente lo levanta fresco y liviano — la RAM vuelve garantizada al SO.

Detalles de contrato: la actividad la estampan solo las inferencias (los 422 también, vía handler de `RequestValidationError` — `/health` estructuralmente no puede); primera petición tras dormir paga ~30-60 s de carga (los wrappers ya toleran 6 h de timeout).

## Cambios
| Archivo | Cambio |
|---------|--------|
| `benchmarks/pyannote_diarization/server.py` | Lazy-load + lock + contador in-flight + watchdog + handler 422 + seams inyectables (`clock`/`sleep`/`exit_signal`) |
| `benchmarks/yamnet_applause/server.py` | Maquinaria espejada |
| `benchmarks/*/Dockerfile` | `ENV IDLE_TIMEOUT_SECONDS=900`; `start_period` 120→30 s (diarize) y 60→15 s (yamnet) — el boot liviano es rápido |
| `docker-compose-ml-apis.yml` | Env threading + start_period alineados |
| `docs/ops/sidecar-model-apis.md` | RAM pasa a ser burst-only; ciclo sleep/wake; nota de cold-start; guía de tuning |
| `tests/benchmarks/test_*_server.py` | 30 tests nuevos espejados (lazy load, stamping, watchdog, disable, lifespan) |

## Test plan
- [x] `uv run pytest -n auto` → 2389 passed, 1 skipped, cobertura 86.96%
- [x] Tests focalizados de ambos servers: 49/49
- [x] e2e Docker: `list-import-errors` vacío
- [x] Sin cambios en Airflow/wrappers/DAGs (scope guard verificado: solo 8 archivos permitidos)

## Encadenado
#111 → #112 → este PR. Al mergear cada padre, re-apuntar el hijo antes de borrar ramas (⚠️ `--delete-branch` auto-cierra el hijo).