### PR TITLE
fix(analytics): use API-supported metrics for video_analytics

### DIFF
--- a/congress_videos/config/analytics_config.py
+++ b/congress_videos/config/analytics_config.py
@@ -22,10 +22,28 @@ MAX_WINDOW_HOURS: int = 2160
 
 # Ordered list of metric field names expected in every snapshot JSONB payload.
 # Matches the columnHeaders returned by the YouTube Analytics API reports.query.
+#
+# Every name below is a metric the YouTube Analytics API actually supports for a
+# per-video channel report (ids=channel==MINE, filters=video==ID, no dimensions,
+# read-only scope). They can all be requested in a single query.
+#
+# Deliberately NOT included, because the YouTube Analytics API does not expose
+# them for channel reports and adding them makes the whole query fail with
+# "Unknown identifier ... given in field parameters.metrics":
+#   - impressions / impressionClickThroughRate: thumbnail impressions and CTR
+#     live only in the YouTube Studio UI; there is no public API for them.
+#     (adImpressions is AD impressions — a different metric, monetary-scope only.)
+#   - watchTimeMinutes: not a real metric name; watch time is estimatedMinutesWatched.
+#   - revenue/ad metrics (estimatedRevenue, cpm, ...): unsupported in channel reports.
 METRIC_FIELDS: list[str] = [
     "views",
-    "impressions",
-    "impressionClickThroughRate",
+    "estimatedMinutesWatched",
     "averageViewDuration",
-    "watchTimeMinutes",
+    "averageViewPercentage",
+    "likes",
+    "dislikes",
+    "comments",
+    "shares",
+    "subscribersGained",
+    "subscribersLost",
 ]

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1486,15 +1486,17 @@ class CongressionalVideoDB:
     ) -> None:
         """Persist one analytics snapshot row (ON CONFLICT DO NOTHING).
 
-        Writes exactly the five JSONB metric fields. Does NOT write action_taken
-        (reserved NULL placeholder for issue #102).
+        Writes the METRIC_FIELDS metrics as a JSONB blob. Does NOT write
+        action_taken (reserved NULL placeholder for issue #102).
 
         Args:
             chapter_id: FK to video_chapters.chapter_id.
             youtube_video_id: YouTube video ID string.
             checkpoint: One of '24h','48h','7d','30d','90d'.
-            metrics: Dict with keys views, impressions, impressionClickThroughRate,
-                averageViewDuration, watchTimeMinutes.
+            metrics: Dict keyed by config.analytics_config.METRIC_FIELDS (views,
+                estimatedMinutesWatched, averageViewDuration,
+                averageViewPercentage, likes, dislikes, comments, shares,
+                subscribersGained, subscribersLost).
         """
         snapshots_table = self.pg_conn.get_qualified_table("video_analytics_snapshots")
         with self.pg_conn.get_connection() as conn:

--- a/congress_videos/modules/video_analytics.py
+++ b/congress_videos/modules/video_analytics.py
@@ -79,16 +79,18 @@ def parse_analytics_response(resp: dict[str, Any]) -> dict[str, Any | None]:
     """Map a YouTube Analytics API response to a flat metrics dict.
 
     Reads 'columnHeaders' and 'rows' from the API response. Returns a dict
-    with exactly the five METRIC_FIELDS keys. Missing columns or an empty
+    with exactly the METRIC_FIELDS keys. Missing columns or an empty
     rows list yield None for the missing field.
 
     Args:
         resp: Raw dict from ``reports.query().execute()``.
 
     Returns:
-        Dict with keys: views, impressions, impressionClickThroughRate,
-        averageViewDuration, watchTimeMinutes. Value is None when the API
-        did not return that column or returned no rows.
+        Dict keyed by every name in ``METRIC_FIELDS`` (views,
+        estimatedMinutesWatched, averageViewDuration, averageViewPercentage,
+        likes, dislikes, comments, shares, subscribersGained,
+        subscribersLost). Value is None when the API did not return that
+        column or returned no rows.
     """
     headers = [h["name"] for h in resp.get("columnHeaders", [])]
     rows = resp.get("rows", [])

--- a/congress_videos/sql/migrations/026_create_video_analytics_snapshots.sql
+++ b/congress_videos/sql/migrations/026_create_video_analytics_snapshots.sql
@@ -17,7 +17,7 @@ CREATE TABLE IF NOT EXISTS video_analytics_snapshots (
     chapter_id        INTEGER      NOT NULL REFERENCES video_chapters(chapter_id) ON DELETE CASCADE,
     youtube_video_id  VARCHAR(50)  NOT NULL,
     checkpoint        TEXT         NOT NULL,          -- '24h'|'48h'|'7d'|'30d'|'90d'
-    metrics           JSONB        NOT NULL,          -- {views, impressions, impressionClickThroughRate, averageViewDuration, watchTimeMinutes}
+    metrics           JSONB        NOT NULL,          -- config.analytics_config.METRIC_FIELDS: {views, estimatedMinutesWatched, averageViewDuration, averageViewPercentage, likes, dislikes, comments, shares, subscribersGained, subscribersLost}
     action_taken      TEXT,                           -- reserved NULL placeholder for #102; never written by this change
     collected_at      TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
     CONSTRAINT uq_video_analytics_snapshot UNIQUE (youtube_video_id, checkpoint)

--- a/congress_videos/video_analytics_dag.py
+++ b/congress_videos/video_analytics_dag.py
@@ -69,7 +69,7 @@ def _fetch_analytics(ti, **context) -> list:
 
     Returns the list of collected items (also pushed to XCom 'collected').
     """
-    from congress_videos.config.analytics_config import CHECKPOINTS
+    from congress_videos.config.analytics_config import CHECKPOINTS, METRIC_FIELDS
     from congress_videos.modules.video_analytics import (
         parse_analytics_response,
         pending_checkpoints,
@@ -151,15 +151,7 @@ def _fetch_analytics(ti, **context) -> list:
                     ids=f"channel==MINE",
                     startDate=start_date,
                     endDate=end_date,
-                    metrics=",".join(
-                        [
-                            "views",
-                            "impressions",
-                            "impressionClickThroughRate",
-                            "averageViewDuration",
-                            "watchTimeMinutes",
-                        ]
-                    ),
+                    metrics=",".join(METRIC_FIELDS),
                     filters=f"video=={yt_id}",
                 )
                 .execute()

--- a/tests/congress_videos/config/test_analytics_config.py
+++ b/tests/congress_videos/config/test_analytics_config.py
@@ -3,7 +3,7 @@
 Verifies:
 - CHECKPOINTS is a plain dict with exactly five keys and the correct hour values
 - MAX_WINDOW_HOURS equals 2160 (90 days in hours)
-- METRIC_FIELDS is a list of exactly five field names
+- METRIC_FIELDS is a list of the ten API-supported metric names
 - No Airflow imports leak into this module (import succeeds in isolation)
 """
 
@@ -74,29 +74,38 @@ class TestMaxWindowHours:
 
 class TestMetricFields:
 
-    def test_metric_fields_has_exactly_five_entries(self):
-        cfg = _load()
-        assert len(cfg.METRIC_FIELDS) == 5
+    # Every name here must be a metric the YouTube Analytics API accepts for a
+    # per-video channel report; impressions/impressionClickThroughRate/
+    # watchTimeMinutes are intentionally absent (unsupported by the API).
+    _EXPECTED_METRICS = [
+        "views",
+        "estimatedMinutesWatched",
+        "averageViewDuration",
+        "averageViewPercentage",
+        "likes",
+        "dislikes",
+        "comments",
+        "shares",
+        "subscribersGained",
+        "subscribersLost",
+    ]
 
-    def test_metric_fields_contains_views(self):
+    def test_metric_fields_matches_supported_set(self):
         cfg = _load()
-        assert "views" in cfg.METRIC_FIELDS
+        assert cfg.METRIC_FIELDS == self._EXPECTED_METRICS
 
-    def test_metric_fields_contains_impressions(self):
+    def test_metric_fields_has_ten_entries(self):
         cfg = _load()
-        assert "impressions" in cfg.METRIC_FIELDS
+        assert len(cfg.METRIC_FIELDS) == 10
 
-    def test_metric_fields_contains_impression_ctr(self):
+    def test_metric_fields_excludes_unsupported_metrics(self):
         cfg = _load()
-        assert "impressionClickThroughRate" in cfg.METRIC_FIELDS
-
-    def test_metric_fields_contains_average_view_duration(self):
-        cfg = _load()
-        assert "averageViewDuration" in cfg.METRIC_FIELDS
-
-    def test_metric_fields_contains_watch_time_minutes(self):
-        cfg = _load()
-        assert "watchTimeMinutes" in cfg.METRIC_FIELDS
+        for unsupported in (
+            "impressions",
+            "impressionClickThroughRate",
+            "watchTimeMinutes",
+        ):
+            assert unsupported not in cfg.METRIC_FIELDS
 
     def test_metric_fields_is_a_list(self):
         cfg = _load()

--- a/tests/congress_videos/modules/test_postgres_operators.py
+++ b/tests/congress_videos/modules/test_postgres_operators.py
@@ -577,10 +577,8 @@ class TestExecuteRecordAnalyticsSnapshots:
                 "chapter_id": 1,
                 "youtube_video_id": "abc",
                 "checkpoint": "24h",
-                "metrics": {"views": 100, "impressions": 400,
-                            "impressionClickThroughRate": 0.04,
-                            "averageViewDuration": 30.0,
-                            "watchTimeMinutes": 50.0},
+                "metrics": {"views": 100, "estimatedMinutesWatched": 50.0,
+                            "averageViewDuration": 30.0, "likes": 12},
             }
         ]
         mock_task_instance.xcom_store["collected"] = collected
@@ -611,10 +609,8 @@ class TestExecuteRecordAnalyticsSnapshots:
                 "chapter_id": 5,
                 "youtube_video_id": "zzz",
                 "checkpoint": "7d",
-                "metrics": {"views": 1, "impressions": 1,
-                            "impressionClickThroughRate": 0.0,
-                            "averageViewDuration": 0.0,
-                            "watchTimeMinutes": 0.1},
+                "metrics": {"views": 1, "estimatedMinutesWatched": 0.1,
+                            "averageViewDuration": 0.0, "likes": 0},
             }
         ]
 

--- a/tests/congress_videos/modules/test_video_analytics.py
+++ b/tests/congress_videos/modules/test_video_analytics.py
@@ -191,37 +191,32 @@ class TestParseAnalyticsResponse:
     """Spec: Snapshot Persistence Shape."""
 
     def _sample_response(self, values: list) -> dict:
-        """Build a minimal Analytics API response with the five standard fields."""
+        """Build a minimal Analytics API response covering all METRIC_FIELDS."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
+
         return {
-            "columnHeaders": [
-                {"name": "views"},
-                {"name": "impressions"},
-                {"name": "impressionClickThroughRate"},
-                {"name": "averageViewDuration"},
-                {"name": "watchTimeMinutes"},
-            ],
+            "columnHeaders": [{"name": name} for name in METRIC_FIELDS],
             "rows": [values],
         }
 
-    def test_five_fields_are_mapped(self):
+    def test_all_fields_are_mapped(self):
         """GIVEN a full Analytics response with one row
         WHEN parse_analytics_response is called
-        THEN a dict with all five metric keys is returned."""
+        THEN each METRIC_FIELDS key maps to its column value."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import parse_analytics_response
 
-        resp = self._sample_response([120, 500, 0.05, 45.3, 90.6])
-        result = parse_analytics_response(resp)
+        values = list(range(len(METRIC_FIELDS)))
+        result = parse_analytics_response(self._sample_response(values))
 
-        assert result["views"] == 120
-        assert result["impressions"] == 500
-        assert result["impressionClickThroughRate"] == 0.05
-        assert result["averageViewDuration"] == 45.3
-        assert result["watchTimeMinutes"] == 90.6
+        for field, value in zip(METRIC_FIELDS, values):
+            assert result[field] == value
 
     def test_missing_column_returns_none(self):
         """GIVEN a response that lacks some columns
         WHEN parse_analytics_response is called
         THEN missing columns map to None."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import parse_analytics_response
 
         # Only 'views' present
@@ -232,49 +227,34 @@ class TestParseAnalyticsResponse:
         result = parse_analytics_response(resp)
 
         assert result["views"] == 42
-        assert result["impressions"] is None
-        assert result["impressionClickThroughRate"] is None
-        assert result["averageViewDuration"] is None
-        assert result["watchTimeMinutes"] is None
+        for field in METRIC_FIELDS:
+            if field != "views":
+                assert result[field] is None
 
     def test_empty_rows_returns_all_none(self):
         """GIVEN an Analytics response with no rows
         WHEN parse_analytics_response is called
-        THEN all five fields are None."""
+        THEN every metric field is None."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import parse_analytics_response
 
         resp = {
-            "columnHeaders": [
-                {"name": "views"},
-                {"name": "impressions"},
-                {"name": "impressionClickThroughRate"},
-                {"name": "averageViewDuration"},
-                {"name": "watchTimeMinutes"},
-            ],
+            "columnHeaders": [{"name": name} for name in METRIC_FIELDS],
             "rows": [],
         }
         result = parse_analytics_response(resp)
 
-        assert result["views"] is None
-        assert result["impressions"] is None
-        assert result["impressionClickThroughRate"] is None
-        assert result["averageViewDuration"] is None
-        assert result["watchTimeMinutes"] is None
+        assert all(result[field] is None for field in METRIC_FIELDS)
 
-    def test_result_has_exactly_five_keys(self):
-        """Result dict must contain exactly the five METRIC_FIELDS keys."""
+    def test_result_keys_match_metric_fields(self):
+        """Result dict must contain exactly the METRIC_FIELDS keys."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import parse_analytics_response
 
-        resp = self._sample_response([1, 2, 3.0, 4.0, 5.0])
-        result = parse_analytics_response(resp)
+        values = list(range(len(METRIC_FIELDS)))
+        result = parse_analytics_response(self._sample_response(values))
 
-        assert set(result.keys()) == {
-            "views",
-            "impressions",
-            "impressionClickThroughRate",
-            "averageViewDuration",
-            "watchTimeMinutes",
-        }
+        assert set(result.keys()) == set(METRIC_FIELDS)
 
 
 # ---------------------------------------------------------------------------
@@ -289,60 +269,42 @@ class TestShouldPersist:
         """GIVEN all metrics are None
         WHEN should_persist is called
         THEN it returns False (skip-and-retry)."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import should_persist
 
-        metrics = {
-            "views": None,
-            "impressions": None,
-            "impressionClickThroughRate": None,
-            "averageViewDuration": None,
-            "watchTimeMinutes": None,
-        }
+        metrics = {field: None for field in METRIC_FIELDS}
         assert should_persist(metrics) is False
 
     def test_all_zero_returns_false(self):
         """GIVEN all metrics are 0 / 0.0
         WHEN should_persist is called
         THEN it returns False (analytics lag, retry next hour)."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import should_persist
 
-        metrics = {
-            "views": 0,
-            "impressions": 0,
-            "impressionClickThroughRate": 0.0,
-            "averageViewDuration": 0.0,
-            "watchTimeMinutes": 0.0,
-        }
+        metrics = {field: 0 for field in METRIC_FIELDS}
         assert should_persist(metrics) is False
 
     def test_one_nonzero_returns_true(self):
         """GIVEN at least one nonzero metric
         WHEN should_persist is called
         THEN it returns True."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import should_persist
 
-        metrics = {
-            "views": 1,
-            "impressions": 0,
-            "impressionClickThroughRate": 0.0,
-            "averageViewDuration": 0.0,
-            "watchTimeMinutes": 0.0,
-        }
+        metrics = {field: 0 for field in METRIC_FIELDS}
+        metrics["views"] = 1
         assert should_persist(metrics) is True
 
     def test_mixed_none_and_nonzero_returns_true(self):
         """GIVEN some None values but at least one nonzero value
         WHEN should_persist is called
         THEN it returns True."""
+        from congress_videos.config.analytics_config import METRIC_FIELDS
         from congress_videos.modules.video_analytics import should_persist
 
-        metrics = {
-            "views": None,
-            "impressions": None,
-            "impressionClickThroughRate": None,
-            "averageViewDuration": None,
-            "watchTimeMinutes": 90.6,
-        }
+        metrics = {field: None for field in METRIC_FIELDS}
+        metrics["estimatedMinutesWatched"] = 90.6
         assert should_persist(metrics) is True
 
 
@@ -450,10 +412,15 @@ class TestRecordAnalyticsSnapshot:
     def _metrics(self) -> dict:
         return {
             "views": 120,
-            "impressions": 500,
-            "impressionClickThroughRate": 0.05,
+            "estimatedMinutesWatched": 90.6,
             "averageViewDuration": 45.3,
-            "watchTimeMinutes": 90.6,
+            "averageViewPercentage": 52.1,
+            "likes": 40,
+            "dislikes": 2,
+            "comments": 8,
+            "shares": 5,
+            "subscribersGained": 3,
+            "subscribersLost": 1,
         }
 
     def test_insert_uses_on_conflict_do_nothing(self):


### PR DESCRIPTION
## Problem

Running `video_analytics` in dev failed on every checkpoint with:

> `HttpError 400 ... "Unknown identifier (impressions) given in field parameters.metrics."`

The DAG requested `impressions`, `impressionClickThroughRate` and `watchTimeMinutes`. None are valid metrics for a per-video channel report:

- **impressions / impressionClickThroughRate** — thumbnail impressions and CTR live only in the YouTube Studio UI; there is **no public API** for them. `adImpressions` is a different (ad, monetary-scope) metric.
- **watchTimeMinutes** — not a real metric name; watch time is `estimatedMinutesWatched`.

The API validates metrics left-to-right and rejects the entire query on the first unknown one, so collection produced zero snapshots.

## Fix

Replace `METRIC_FIELDS` with the **10 metrics the API supports together** for a per-video channel report (`ids=channel==MINE`, `filters=video==ID`, no dimensions, read-only scope):

`views`, `estimatedMinutesWatched`, `averageViewDuration`, `averageViewPercentage`, `likes`, `dislikes`, `comments`, `shares`, `subscribersGained`, `subscribersLost`.

Also:
- DAG query now derives its metric list from `METRIC_FIELDS` instead of a duplicated hardcoded list (single source of truth).
- Documented in `analytics_config.py` *why* impressions/CTR/revenue are excluded, so they don't get re-added.
- Updated `parse_analytics_response` / `record_analytics_snapshot` docstrings, migration 026 shape comment, and affected tests. JSONB payload is schema-less, so no DB migration needed.

## Test plan

- [x] `uv run pytest -n auto` — 2496 passed, 1 skipped, coverage 86.13%
- [ ] Re-run `video_analytics` DAG in dev and confirm snapshots persist without API 400s