### PR TITLE
fix(speaker_turns): qualify table with app schema (prod fix)

### DIFF
--- a/congress_videos/modules/speaker_turns.py
+++ b/congress_videos/modules/speaker_turns.py
@@ -464,7 +464,9 @@ def detect_turns(
 # ---------------------------------------------------------------------------
 
 
-def _upsert_turns(cursor, chapter_id: int, turns: list[Turn]) -> None:
+def _upsert_turns(
+    cursor, chapter_id: int, turns: list[Turn], table: str = "speaker_turns"
+) -> None:
     """Upsert Turn records into the speaker_turns table.
 
     Each Turn is inserted; conflicts on (chapter_id, start_seconds) update
@@ -475,12 +477,18 @@ def _upsert_turns(cursor, chapter_id: int, turns: list[Turn]) -> None:
         cursor: DB cursor with an execute() method.
         chapter_id: chapter_id FK value for all turns.
         turns: Turns to persist.
+        table: Target table name. Callers with a live connection MUST pass the
+            schema-qualified name (``pg.get_qualified_table("speaker_turns")``)
+            because the app does not set a search_path — an unqualified name
+            only resolves when the role's default schema happens to match
+            (works in dev, fails in prod). Defaults to the bare name so pure
+            unit tests need no connection.
     """
     if not turns:
         return
 
-    sql = """
-        INSERT INTO speaker_turns
+    sql = f"""
+        INSERT INTO {table}
             (chapter_id, start_seconds, end_seconds, speaker_label, resolved_name,
              confidence, source, updated_at)
         VALUES (%s, %s, %s, %s, %s, %s, %s, NOW())

--- a/congress_videos/speaker_turns_dag.py
+++ b/congress_videos/speaker_turns_dag.py
@@ -81,6 +81,7 @@ def run_chapter_turns(
     *,
     diarize_fn=api_diarize_fn,
     name_resolver=lookup_participant_fuzzy,
+    turns_table: str = "speaker_turns",
 ) -> dict:
     """Detect and persist speaker turns for a single chapter.
 
@@ -88,6 +89,9 @@ def run_chapter_turns(
     run), extracts the chapter-window WAV, loads the window's SRT blocks (or
     runs acoustic-only when the SRT is missing), detects turns, and upserts
     them via the caller-provided cursor. Returns a status dict.
+
+    ``turns_table`` is forwarded to :func:`_upsert_turns`; the DAG passes the
+    schema-qualified name so persistence targets the right schema in prod.
     """
     chapter_id = chapter["chapter_id"]
     video_id = chapter["video_id"]
@@ -129,7 +133,7 @@ def run_chapter_turns(
         chapter["_chapter_offset_seconds"] = start_secs
 
         turns = detect_turns(chapter, srt_blocks, diarize_fn, name_resolver)
-        _upsert_turns(cursor, chapter_id, turns)
+        _upsert_turns(cursor, chapter_id, turns, table=turns_table)
         return {"status": "ok", "chapter_id": chapter_id, "turns": len(turns)}
     finally:
         if os.path.exists(wav_path):
@@ -152,11 +156,12 @@ def _process_task(**context) -> dict:
     chapters = context["ti"].xcom_pull(key="chapters", task_ids="select_chapters") or []
     summary = {"processed": 0, "skipped": 0, "turns": 0}
     pg = PostgresConnection()
+    turns_table = pg.get_qualified_table("speaker_turns")
     with pg.get_connection() as conn:
         with conn.cursor() as cur:
             for chapter in chapters:
                 try:
-                    result = run_chapter_turns(chapter, cur)
+                    result = run_chapter_turns(chapter, cur, turns_table=turns_table)
                 except Exception:  # noqa: BLE001 — one bad chapter must not sink the run
                     logger.exception(
                         "chapter %s failed — skipping", chapter.get("chapter_id")

--- a/tests/congress_videos/modules/test_speaker_turns.py
+++ b/tests/congress_videos/modules/test_speaker_turns.py
@@ -672,3 +672,27 @@ class TestUpsertTurns:
         cursor = MagicMock()
         _upsert_turns(cursor, chapter_id=42, turns=[])
         cursor.execute.assert_not_called()
+
+    def test_upsert_uses_qualified_table_when_provided(self):
+        """A schema-qualified table name must land in the INSERT target.
+
+        Regression: the app sets no search_path, so an unqualified name only
+        resolves when the role's default schema matches (works in dev, fails
+        in prod with 'relation "speaker_turns" does not exist').
+        """
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        _upsert_turns(
+            cursor, chapter_id=42, turns=self._make_turns(1),
+            table="production.speaker_turns",
+        )
+        sql_arg = cursor.execute.call_args[0][0]
+        assert "INSERT INTO production.speaker_turns" in sql_arg
+
+    def test_upsert_defaults_to_bare_table_name(self):
+        """Default keeps the bare name so pure unit tests need no connection."""
+        from congress_videos.modules.speaker_turns import _upsert_turns
+        cursor = MagicMock()
+        _upsert_turns(cursor, chapter_id=42, turns=self._make_turns(1))
+        sql_arg = cursor.execute.call_args[0][0]
+        assert "INSERT INTO speaker_turns" in sql_arg

--- a/tests/congress_videos/test_speaker_turns_dag.py
+++ b/tests/congress_videos/test_speaker_turns_dag.py
@@ -80,7 +80,9 @@ class TestRunChapterTurns:
         assert result["status"] == "ok"
         assert result["turns"] == 2
         detect.assert_called_once()
-        upsert.assert_called_once_with(cursor, 7, turns)
+        # Default table name flows through when no qualified name is supplied;
+        # _process_task passes pg.get_qualified_table("speaker_turns") in prod.
+        upsert.assert_called_once_with(cursor, 7, turns, table="speaker_turns")
 
     def test_missing_srt_runs_acoustic_only(self, monkeypatch):
         mod = _fresh()


### PR DESCRIPTION
Promotes PR #121: fixes `relation "speaker_turns" does not exist` in prod by schema-qualifying the speaker_turns upsert. Full suite green (2498 passed).