### PR TITLE
chore: sync main→dev (trim_proposals schema fix #123)

### DIFF
--- a/congress_videos/modules/trim_proposals.py
+++ b/congress_videos/modules/trim_proposals.py
@@ -294,7 +294,11 @@ def generate_trim_proposals(
 # ---------------------------------------------------------------------------
 
 
-def _upsert_proposals(cursor, proposals: list[TrimProposal]) -> int:
+def _upsert_proposals(
+    cursor,
+    proposals: list[TrimProposal],
+    table: str = "speaker_turn_trim_proposals",
+) -> int:
     """Upsert TrimProposal records into the speaker_turn_trim_proposals table.
 
     Uses ``ON CONFLICT (turn_id, start_seconds, tipo) DO UPDATE`` to update
@@ -308,6 +312,12 @@ def _upsert_proposals(cursor, proposals: list[TrimProposal]) -> int:
     Args:
         cursor:    An open DB cursor (psycopg2-compatible, ``execute()`` method).
         proposals: Proposals to persist.
+        table:     Target table name. Callers with a live connection MUST pass
+            the schema-qualified name
+            (``pg.get_qualified_table("speaker_turn_trim_proposals")``) — the
+            app sets no search_path, so an unqualified name only resolves when
+            the role's default schema matches (works in dev, fails in prod).
+            Defaults to the bare name so pure unit tests need no connection.
 
     Returns:
         Number of proposals processed (same as len(proposals)).
@@ -315,8 +325,8 @@ def _upsert_proposals(cursor, proposals: list[TrimProposal]) -> int:
     if not proposals:
         return 0
 
-    sql = """
-        INSERT INTO speaker_turn_trim_proposals
+    sql = f"""
+        INSERT INTO {table}
             (turn_id, start_seconds, end_seconds, tipo, score, source, is_voice_free, updated_at)
         VALUES (%s, %s, %s, %s, %s, %s, %s, NOW())
         ON CONFLICT (turn_id, start_seconds, tipo) DO UPDATE SET

--- a/congress_videos/trim_proposals_dag.py
+++ b/congress_videos/trim_proposals_dag.py
@@ -146,6 +146,7 @@ def run_turn_proposals(
     *,
     vad_fn=_webrtc_vad_fn,
     yamnet_fn=api_yamnet_fn,
+    proposals_table: str = "speaker_turn_trim_proposals",
 ) -> dict:
     """Generate and persist trim proposals for a single speaker turn.
 
@@ -190,7 +191,7 @@ def run_turn_proposals(
         proposals = generate_trim_proposals(
             turn, wav_path, vad_fn, yamnet_fn
         )
-        count = _upsert_proposals(cursor, proposals)
+        count = _upsert_proposals(cursor, proposals, table=proposals_table)
         logger.info(
             "turn %s: %d proposal(s) upserted", turn_id, count
         )
@@ -221,11 +222,14 @@ def _process_task(**context) -> dict:
     turns = context["ti"].xcom_pull(key="turns", task_ids="select_turns") or []
     summary = {"processed": 0, "skipped": 0, "proposals": 0}
     pg = PostgresConnection()
+    proposals_table = pg.get_qualified_table("speaker_turn_trim_proposals")
     with pg.get_connection() as conn:
         with conn.cursor() as cur:
             for turn in turns:
                 try:
-                    result = run_turn_proposals(turn, cur)
+                    result = run_turn_proposals(
+                        turn, cur, proposals_table=proposals_table
+                    )
                 except Exception:  # noqa: BLE001 — one bad turn must not sink the run
                     logger.exception(
                         "turn %s failed — skipping", turn.get("turn_id")

--- a/tests/congress_videos/modules/test_trim_proposals.py
+++ b/tests/congress_videos/modules/test_trim_proposals.py
@@ -456,6 +456,32 @@ class TestUpsertProposals:
         assert "SCORE" in sql_arg
         assert "SOURCE" in sql_arg
 
+    def test_upsert_uses_qualified_table_when_provided(self):
+        """A schema-qualified table name must land in the INSERT target.
+
+        Regression: the app sets no search_path, so an unqualified name only
+        resolves when the role's default schema matches (works in dev, fails
+        in prod with 'relation "speaker_turn_trim_proposals" does not exist').
+        """
+        cursor = MagicMock()
+
+        _upsert_proposals(
+            cursor, [self._make_proposal()],
+            table="production.speaker_turn_trim_proposals",
+        )
+
+        sql_arg = cursor.execute.call_args[0][0]
+        assert "INSERT INTO production.speaker_turn_trim_proposals" in sql_arg
+
+    def test_upsert_defaults_to_bare_table_name(self):
+        """Default keeps the bare name so pure unit tests need no connection."""
+        cursor = MagicMock()
+
+        _upsert_proposals(cursor, [self._make_proposal()])
+
+        sql_arg = cursor.execute.call_args[0][0]
+        assert "INSERT INTO speaker_turn_trim_proposals" in sql_arg
+
 
 # ---------------------------------------------------------------------------
 # generate_trim_proposals — exception handling (coverage for warning paths)

--- a/tests/congress_videos/test_trim_proposals_dag.py
+++ b/tests/congress_videos/test_trim_proposals_dag.py
@@ -86,7 +86,11 @@ class TestRunTurnProposals:
         assert result["status"] == "ok"
         assert result["proposals"] == 2
         generate.assert_called_once()
-        upsert.assert_called_once_with(cursor, proposals)
+        # Default table name flows through when no qualified name is supplied;
+        # _process_task passes pg.get_qualified_table(...) in prod.
+        upsert.assert_called_once_with(
+            cursor, proposals, table="speaker_turn_trim_proposals"
+        )
 
     def test_wav_is_cleaned_up_after_processing(self, monkeypatch, tmp_path):
         mod = _fresh()


### PR DESCRIPTION
Back-merge PR #123 so dev keeps parity with main after the direct-to-main hotfix.