### PR TITLE
feat(upload): dual-queue uploader — turns first, chapter fallback (#117 PR2/3)

### DIFF
--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1220,6 +1220,61 @@ class CongressionalVideoDB:
                 result = cur.fetchone()
                 return result['count'] if result else 0
 
+    def get_uploadable_turns(self, limit: int = 1) -> List[Dict]:
+        """Get speaker turn videos eligible for YouTube upload.
+
+        Args:
+            limit: Maximum number of turns to return (default: 1).
+
+        Returns:
+            List of turn records from the uploadable_turns view.
+        """
+        uploadable_turns_view = self.pg_conn.get_qualified_table('uploadable_turns')
+
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT * FROM {uploadable_turns_view} LIMIT %s",
+                    (limit,),
+                )
+                turns = cur.fetchall()
+                logger.info(f"Retrieved {len(turns)} uploadable turns (limit={limit})")
+                return turns
+
+    def mark_turns_uploaded(self, turn_id: int, youtube_video_id: str) -> None:
+        """Mark a speaker turn video as uploaded to YouTube.
+
+        Sets is_uploaded_to_youtube=TRUE, youtube_video_id, and
+        youtube_upload_date=NOW() for the given turn_id.
+
+        Args:
+            turn_id: Database ID of the speaker turn.
+            youtube_video_id: YouTube video ID of the uploaded turn video.
+        """
+        stv_table = self.pg_conn.get_qualified_table('speaker_turn_videos')
+
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"""
+                    UPDATE {stv_table} SET
+                        is_uploaded_to_youtube = TRUE,
+                        youtube_video_id = %s,
+                        youtube_upload_date = NOW()
+                    WHERE turn_id = %s
+                    """,
+                    (youtube_video_id, turn_id),
+                )
+                logger.info(
+                    f"Marked turn {turn_id} as uploaded to YouTube: {youtube_video_id}"
+                )
+
+    def count_pending_uploadable_turns(self) -> int:
+        """Returns the count of speaker turn videos pending upload."""
+        count = self._count_records('uploadable_turns')
+        logger.info(f"Pending uploadable turns: {count}")
+        return count
+
     def count_chapters_uploaded_today(self) -> int:
         """Returns the number of chapters uploaded to YouTube today (UTC date)."""
         count = self._count_records('video_chapters', 'youtube_upload_date >= CURRENT_DATE')

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1281,6 +1281,12 @@ class CongressionalVideoDB:
         logger.info(f"Chapters uploaded today: {count}")
         return count
 
+    def count_turns_uploaded_today(self) -> int:
+        """Returns the number of speaker turn videos uploaded to YouTube today (UTC date)."""
+        count = self._count_records('speaker_turn_videos', 'youtube_upload_date >= CURRENT_DATE')
+        logger.info(f"Turns uploaded today: {count}")
+        return count
+
     def count_pending_uploadable_chapters(self, min_relevance_score: int = 2) -> int:
         """Returns the number of chapters pending upload in the uploadable queue."""
         count = self._count_records('uploadable_chapters', 'relevance_score >= %s', (min_relevance_score,))

--- a/congress_videos/modules/postgres_operators.py
+++ b/congress_videos/modules/postgres_operators.py
@@ -368,12 +368,14 @@ class PostgreSQLOperator(BaseOperator):
 
             uploads_today = db.count_chapters_uploaded_today()
             queue_size = db.count_pending_uploadable_chapters(min_relevance_score)
+            turns_pending = db.count_pending_uploadable_turns()
 
             result = {
                 "uploads_today": uploads_today,
                 "queue_size": queue_size,
+                "turns_pending": turns_pending,
             }
-            print(f"✅ Upload quota: {uploads_today} today, {queue_size} in queue")
+            print(f"✅ Upload quota: {uploads_today} today, {queue_size} chapters in queue, {turns_pending} turns pending")
 
         elif self.operation == 'get_uploadable_chapters':
             min_relevance_score = context["params"].get("min_relevance_score", 2)
@@ -466,6 +468,59 @@ class PostgreSQLOperator(BaseOperator):
                     'details': details
                 }
                 print(f"✅ Updated {updated_count} chapters, {failed_count} failed, {recorded_failures} failures recorded")
+
+        elif self.operation == 'get_uploadable_turns':
+            result = db.get_uploadable_turns(limit=1)
+            print(f"✅ Retrieved {len(result)} uploadable turns")
+
+        elif self.operation == 'mark_turns_uploaded':
+            """Mark speaker turn videos as uploaded to YouTube after successful upload."""
+            upload_results = ti.xcom_pull(key=self.xcom_keys.get('upload_results', 'upload_results'))
+
+            if not upload_results or not upload_results.get('upload_details'):
+                print("No turn upload results to process")
+                result = {'updated_turns': 0, 'failed_updates': 0, 'details': []}
+            else:
+                updated_count = 0
+                failed_count = 0
+                details = []
+
+                for upload_detail in upload_results['upload_details']:
+                    turn_id = upload_detail.get('turn_id')
+                    youtube_video_id = upload_detail.get('youtube_video_id')
+                    success = upload_detail.get('success', False)
+
+                    if success and turn_id and youtube_video_id:
+                        try:
+                            db.mark_turns_uploaded(turn_id=turn_id, youtube_video_id=youtube_video_id)
+                            updated_count += 1
+                            details.append({
+                                'turn_id': turn_id,
+                                'youtube_video_id': youtube_video_id,
+                                'status': 'updated',
+                            })
+                            print(f"✅ Marked turn {turn_id} as uploaded: {youtube_video_id}")
+                        except Exception as e:
+                            failed_count += 1
+                            details.append({
+                                'turn_id': turn_id,
+                                'status': 'failed',
+                                'error': str(e),
+                            })
+                            print(f"❌ Failed to mark turn {turn_id}: {e}")
+                    else:
+                        details.append({
+                            'turn_id': turn_id,
+                            'status': 'skipped',
+                            'reason': 'upload_failed_or_missing_fields',
+                        })
+
+                result = {
+                    'updated_turns': updated_count,
+                    'failed_updates': failed_count,
+                    'details': details,
+                }
+                print(f"✅ Marked {updated_count} turns uploaded, {failed_count} failed")
 
         elif self.operation == 'get_chapters_for_shorts':
             """Get video chapters eligible for Reap Shorts processing"""

--- a/congress_videos/modules/postgres_operators.py
+++ b/congress_videos/modules/postgres_operators.py
@@ -366,16 +366,20 @@ class PostgreSQLOperator(BaseOperator):
         elif self.operation == 'check_upload_quota':
             min_relevance_score = context["params"].get("min_relevance_score", 2)
 
-            uploads_today = db.count_chapters_uploaded_today()
-            queue_size = db.count_pending_uploadable_chapters(min_relevance_score)
+            chapters_uploaded_today = db.count_chapters_uploaded_today()
+            turns_uploaded_today = db.count_turns_uploaded_today()
+            uploads_today = chapters_uploaded_today + turns_uploaded_today
+
+            chapters_pending = db.count_pending_uploadable_chapters(min_relevance_score)
             turns_pending = db.count_pending_uploadable_turns()
+            queue_size = chapters_pending + turns_pending
 
             result = {
                 "uploads_today": uploads_today,
                 "queue_size": queue_size,
                 "turns_pending": turns_pending,
             }
-            print(f"✅ Upload quota: {uploads_today} today, {queue_size} chapters in queue, {turns_pending} turns pending")
+            print(f"✅ Upload quota: {uploads_today} today ({chapters_uploaded_today} chapters + {turns_uploaded_today} turns), {chapters_pending} chapters + {turns_pending} turns in queue")
 
         elif self.operation == 'get_uploadable_chapters':
             min_relevance_score = context["params"].get("min_relevance_score", 2)

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -449,34 +449,48 @@ with (
         python_callable=should_upload,
     )
 
-    # Step 2: Get uploadable chapters (limit=1 per run)
-    # Ordered by: session_date DESC, relevance_score DESC, created_at DESC
-    t1_db = PostgreSQLOperator(
-        task_id="get_uploadable_chapters",
-        operation="get_uploadable_chapters",
-        output_xcom_key="uploadable_chapters",
-    )
+    # Step 2: Dual-queue item selection — turns first, chapters as fallback (limit=1 per run)
+    def _run_get_uploadable_item_task(ti):
+        """Select upload item from turn queue first; fall back to chapter queue.
+
+        Pushes 'uploadable_item' XCom key with dict:
+          {'item': <row dict>, 'item_type': 'turn' | 'chapter'}
+        or {'item': None, 'item_type': None} when both queues are empty.
+        """
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        db = CongressionalVideoDB()
+        result = _run_get_uploadable_item(db)
+        if result is None:
+            result = {"item": None, "item_type": None}
+        ti.xcom_push(key="uploadable_item", value=result)
+        logging.info(
+            "Selected uploadable item: item_type=%s, item=%s",
+            result.get("item_type"),
+            result.get("item", {}).get("chapter_id") if result.get("item") else None,
+        )
 
     def _generate_youtube_metadata(ti):
         from congress_videos.modules.youtube import youtube_ai
 
+        uploadable = ti.xcom_pull(key="uploadable_item") or {}
+        item = uploadable.get("item") or {}
+        # Pass a single-item list matching the chapter-list contract expected by youtube_ai
+        items = [item] if item else []
         return xcom_task(
             ti,
-            lambda: youtube_ai.generate_youtube_metadata_for_selected_videos(
-                ti.xcom_pull(key="uploadable_chapters")
-            ),
+            lambda: youtube_ai.generate_youtube_metadata_for_selected_videos(items),
             "youtube_metadata_results",
         )
 
     def _run_prepare_thumbnail_config(ti):
-        """Resolve speaker name and build thumbnail config struct for the chapter."""
+        """Resolve speaker name and build thumbnail config struct for the item (turn or chapter)."""
         from congress_videos.modules.database import CongressionalVideoDB
 
-        chapters = ti.xcom_pull(key="uploadable_chapters") or []
-        # Uploader processes exactly 1 chapter per run
-        chapter = chapters[0] if chapters else {}
+        uploadable = ti.xcom_pull(key="uploadable_item") or {}
+        item = uploadable.get("item") or {}
         db = CongressionalVideoDB()
-        result = _prepare_thumbnail_config(chapter, db)
+        result = _prepare_thumbnail_config(item, db)
         ti.xcom_push(key="thumbnail_config", value=result)
 
     def _run_generate_thumbnail(ti):
@@ -484,16 +498,47 @@ with (
         return trigger_thumbnail_generation(ti, run_id=ti.run_id)
 
     def _extract_chapter_videos(ti):
+        """Extract chapter video via ffmpeg, or use the pre-materialized turn video path."""
         from congress_videos.modules import video_splitter
 
-        return xcom_task(
-            ti,
-            lambda: video_splitter.extract_chapters_from_video(
-                ti.xcom_pull(key="uploadable_chapters"),
-                ti.xcom_pull(key="data_directory_path"),
-            ),
-            "chapter_extraction_results",
-        )
+        uploadable = ti.xcom_pull(key="uploadable_item") or {}
+        item = uploadable.get("item") or {}
+        item_type = uploadable.get("item_type")
+
+        if item_type == "turn":
+            # Turn video already exists at output_path — no ffmpeg extraction needed.
+            output_path = item.get("output_path")
+            success = bool(output_path)
+            result = {
+                "total_chapters": 1,
+                "successful_extractions": 1 if success else 0,
+                "failed_extractions": 0 if success else 1,
+                "results": [
+                    {
+                        "chapter_id": item.get("chapter_id"),
+                        "turn_id": item.get("turn_id"),
+                        "video_id": item.get("video_id"),
+                        "success": success,
+                        "output_path": output_path,
+                        "file_size_mb": None,
+                        "duration_seconds": None,
+                        "error": None if success else "turn output_path missing",
+                    }
+                ],
+            }
+            ti.xcom_push(key="chapter_extraction_results", value=result)
+            return result
+        else:
+            # Chapter: call video_splitter (ffmpeg-based extraction)
+            chapters = [item] if item else []
+            return xcom_task(
+                ti,
+                lambda: video_splitter.extract_chapters_from_video(
+                    chapters,
+                    ti.xcom_pull(key="data_directory_path"),
+                ),
+                "chapter_extraction_results",
+            )
 
     def _prepare_upload_config(ti, **context):
         from congress_videos.modules.youtube import prepare_chapter_upload_config
@@ -513,7 +558,12 @@ with (
         """Back-fill youtube_video_id in video_thumbnails after upload completes."""
         _backfill_thumbnail_video_id(ti)
 
-    # Step 2: Generate YouTube metadata for chapters
+    t1_item = PythonOperator(
+        task_id="get_uploadable_item",
+        python_callable=_run_get_uploadable_item_task,
+    )
+
+    # Step 2: Generate YouTube metadata for the selected item (turn or chapter)
     t2 = PythonOperator(
         task_id="generate_youtube_metadata",
         python_callable=_generate_youtube_metadata,
@@ -531,7 +581,7 @@ with (
         python_callable=_run_generate_thumbnail,
     )
 
-    # Step 5: Extract chapter videos from source YouTube videos using ffmpeg
+    # Step 5: Extract video — turn path reused directly; chapter extracted via ffmpeg
     t5 = PythonOperator(
         task_id="extract_chapter_videos",
         python_callable=_extract_chapter_videos,
@@ -655,6 +705,14 @@ with (
         output_xcom_key="chapter_upload_updates",
     )
 
+    # Step 8c: Mark turn videos as uploaded (runs in parallel with mark_chapters_uploaded)
+    t8_turns = PostgreSQLOperator(
+        task_id="mark_turns_uploaded",
+        operation="mark_turns_uploaded",
+        xcom_keys={"upload_results": "upload_results"},
+        output_xcom_key="turn_upload_updates",
+    )
+
     # Step 8b: Back-fill youtube_video_id in video_thumbnails
     t8_backfill = PythonOperator(
         task_id="backfill_thumbnail_video_id",
@@ -667,20 +725,20 @@ with (
         python_callable=_check_upload_failures,
     )
 
-    # Task dependencies (13 tasks total)
-    # t0 > t1_quota > t1_skip > t1_db > t2 > t3_prepare > t4_generate > t5 > t6 > t7 > t8_db > t8_backfill > t9
+    # Task dependencies (14 tasks total)
+    # t0 > t1_quota > t1_skip > t1_item > t2 > t3_prepare > t4_generate > t5 > t6 > t7 > [t8_db, t8_turns] > t8_backfill > t9
     (
         t0
         >> t1_quota
         >> t1_skip
-        >> t1_db
+        >> t1_item
         >> t2
         >> t3_prepare
         >> t4_generate
         >> t5
         >> t6
         >> t7
-        >> t8_db
+        >> [t8_db, t8_turns]
         >> t8_backfill
         >> t9
     )

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -129,20 +129,25 @@ def _resolve_speaker_name(chapter: dict) -> str | None:
 
 
 def _prepare_thumbnail_config(chapter: dict, db) -> dict:
-    """Build the thumbnail-generation config dict for a single chapter.
+    """Build the thumbnail-generation config dict for a single chapter or turn.
 
-    Resolves the raw speaker at the boundary and stores the participant slug
-    before assembling the fields
-    expected by the generic thumbnail pipeline.
+    Handles two row types:
+    - Chapter rows (from uploadable_chapters view): use key_speakers list, resolved_participant_slug,
+      and SRT window from start_time/end_time strings.
+    - Turn rows (from uploadable_turns view, identified by presence of 'turn_id'): anchor
+      key_speakers to [resolved_name], use resolved_name for slug lookup, and use start_seconds/
+      end_seconds (float seconds) for the SRT window.
 
     Args:
-        chapter: Chapter row from the uploadable_chapters view.
+        chapter: Chapter or turn row from the database view.
         db: CongressionalVideoDB instance (kept for task-call compatibility).
 
     Returns:
         Dict with keys: chapter_id, debate_summary, domain, session,
-        slug (may be None on fallback).
+        slug (may be None on fallback), key_speakers, optionally srt_fragment.
     """
+    is_turn = "turn_id" in chapter
+
     chapter_id = chapter.get("chapter_id")
     title = chapter.get("chapter_title", "")
     description = chapter.get("description", "")
@@ -158,24 +163,46 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     else:
         session = str(session_date) if session_date else None
 
-    # Prefer the authoritative slug written by speaker normalization (fuzzy or
-    # institutional-role resolution). Fall back to a raw-speaker fuzzy match only
-    # when the chapter was never resolved. Fuzzy matching stays confined to this
-    # boundary; downstream thumbnail code receives only the stable slug.
-    slug = chapter.get("resolved_participant_slug") or None
-    if not slug:
-        try:
-            raw_speaker = _resolve_speaker_name(chapter)
-            participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
-            slug = participant.get("slug") if participant else None
-        except Exception as exc:
-            logging.warning(
-                "_prepare_thumbnail_config: speaker resolution failed for "
-                "chapter_id=%s: %s — setting slug=None",
-                chapter_id,
-                exc,
-            )
-            slug = None
+    if is_turn:
+        # Turn path: anchor key_speakers to the turn's own speaker (resolved_name).
+        # Use resolved_name directly for the fuzzy slug lookup.
+        resolved_name = chapter.get("resolved_name") or ""
+        key_speakers = [resolved_name] if resolved_name else []
+        slug = None
+        if resolved_name:
+            try:
+                participant = lookup_participant_fuzzy(resolved_name)
+                slug = participant.get("slug") if participant else None
+            except Exception as exc:
+                logging.warning(
+                    "_prepare_thumbnail_config: turn speaker resolution failed for "
+                    "turn_id=%s resolved_name=%r: %s — setting slug=None",
+                    chapter.get("turn_id"),
+                    resolved_name,
+                    exc,
+                )
+                slug = None
+    else:
+        # Chapter path: preserve existing behaviour.
+        # Prefer the authoritative slug written by speaker normalization (fuzzy or
+        # institutional-role resolution). Fall back to a raw-speaker fuzzy match only
+        # when the chapter was never resolved. Fuzzy matching stays confined to this
+        # boundary; downstream thumbnail code receives only the stable slug.
+        key_speakers = chapter.get("key_speakers") or []
+        slug = chapter.get("resolved_participant_slug") or None
+        if not slug:
+            try:
+                raw_speaker = _resolve_speaker_name(chapter)
+                participant = lookup_participant_fuzzy(raw_speaker) if raw_speaker else None
+                slug = participant.get("slug") if participant else None
+            except Exception as exc:
+                logging.warning(
+                    "_prepare_thumbnail_config: speaker resolution failed for "
+                    "chapter_id=%s: %s — setting slug=None",
+                    chapter_id,
+                    exc,
+                )
+                slug = None
 
     config = {
         "chapter_id": chapter_id,
@@ -183,7 +210,7 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
         "domain": "congreso",
         "session": session,
         "slug": slug,
-        "key_speakers": chapter.get("key_speakers") or [],
+        "key_speakers": key_speakers,
     }
 
     # Resolve SRT fragment for lapidary quote extraction (issue #57).
@@ -195,18 +222,42 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
     )
     if srt_path is not None:
         blocks = _parse_srt_blocks(srt_path)
-        # Convert chapter time-window boundaries (SRT-format strings) to seconds.
-        chapter_start_secs = _srt_timestamp_to_seconds(chapter.get("start_time", "00:00:00,000"))
-        chapter_end_secs = _srt_timestamp_to_seconds(chapter.get("end_time", "99:59:59,999"))
+        if is_turn:
+            # Turn: use integer seconds directly from the turn row.
+            window_start_secs = float(chapter.get("start_seconds", 0))
+            window_end_secs = float(chapter.get("end_seconds", 99 * 3600))
+        else:
+            # Chapter: convert SRT-format timestamp strings to seconds.
+            window_start_secs = _srt_timestamp_to_seconds(chapter.get("start_time", "00:00:00,000"))
+            window_end_secs = _srt_timestamp_to_seconds(chapter.get("end_time", "99:59:59,999"))
         window_texts = [
             b["text"]
             for b in blocks
-            if b["start_secs"] >= chapter_start_secs and b["end_secs"] <= chapter_end_secs
+            if b["start_secs"] >= window_start_secs and b["end_secs"] <= window_end_secs
         ]
         joined = " ".join(window_texts)
         config["srt_fragment"] = joined[:10_000]
 
     return config
+
+
+def _run_get_uploadable_item(db) -> dict | None:
+    """Try the turn queue first; fall back to the chapter queue.
+
+    Returns a dict with keys:
+      - 'item': the row dict (turn or chapter)
+      - 'item_type': 'turn' or 'chapter'
+    Returns None when both queues are empty.
+    """
+    turns = db.get_uploadable_turns(limit=1)
+    if turns:
+        return {"item": turns[0], "item_type": "turn"}
+
+    chapters = db.get_uploadable_chapters(limit=1, min_relevance_score=2)
+    if chapters:
+        return {"item": chapters[0], "item_type": "chapter"}
+
+    return None
 
 
 def _thumbnail_failure(chapter_id: int | None) -> dict:

--- a/tests/congress_videos/modules/test_database_turns.py
+++ b/tests/congress_videos/modules/test_database_turns.py
@@ -1,0 +1,235 @@
+"""Tests for turn upload queue DB methods in CongressionalVideoDB.
+
+Tests:
+- get_uploadable_turns(limit) returns rows up to limit
+- mark_turns_uploaded(turn_id, youtube_video_id) sets all three tracking cols
+- count_pending_uploadable_turns() counts unuploaded turns
+- count_chapters_uploaded_today still counts chapters only (not turns)
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+
+def _make_conn(rows=None, scalar=None):
+    """Return a fake pg_conn context-manager whose cursor returns rows or scalar."""
+    cursor = MagicMock()
+    cursor.fetchall.return_value = rows or []
+    cursor.fetchone.return_value = {"count": scalar} if scalar is not None else None
+    cursor.__enter__ = lambda s: s
+    cursor.__exit__ = MagicMock(return_value=False)
+
+    conn = MagicMock()
+    conn.__enter__ = lambda s: s
+    conn.__exit__ = MagicMock(return_value=False)
+    conn.cursor.return_value = cursor
+
+    pg_conn_mock = MagicMock()
+    pg_conn_mock.get_connection.return_value = conn
+    pg_conn_mock.get_qualified_table.side_effect = lambda name: name
+
+    return pg_conn_mock, cursor
+
+
+class TestGetUploadableTurns:
+    """get_uploadable_turns(limit) fetches from uploadable_turns view."""
+
+    def test_returns_rows_from_view(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        fake_rows = [
+            {"turn_id": 1, "output_path": "/path/turn1.mp4", "resolved_name": "Ana García"},
+            {"turn_id": 2, "output_path": "/path/turn2.mp4", "resolved_name": "Pedro López"},
+        ]
+        pg_mock, cursor = _make_conn(rows=fake_rows)
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            result = db.get_uploadable_turns(limit=2)
+
+        assert result == fake_rows
+
+    def test_respects_limit_parameter(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(rows=[])
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.get_uploadable_turns(limit=1)
+
+        # The SQL executed must contain LIMIT
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].upper()
+        assert "LIMIT" in query
+
+    def test_passes_limit_value_to_query(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(rows=[])
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.get_uploadable_turns(limit=3)
+
+        call_args = cursor.execute.call_args
+        # Limit value passed as parameter or inline
+        assert 3 in call_args[0][1] or "3" in call_args[0][0]
+
+    def test_default_limit_is_one(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(rows=[])
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.get_uploadable_turns()  # no limit arg
+
+        call_args = cursor.execute.call_args
+        # Default limit = 1
+        assert 1 in call_args[0][1] or "1" in call_args[0][0]
+
+    def test_queries_uploadable_turns_view(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(rows=[])
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.get_uploadable_turns(limit=1)
+
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].lower()
+        assert "uploadable_turns" in query
+
+
+class TestMarkTurnsUploaded:
+    """mark_turns_uploaded sets all three tracking columns."""
+
+    def test_sets_is_uploaded_to_youtube_true(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn()
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.mark_turns_uploaded(turn_id=42, youtube_video_id="abc123")
+
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].upper()
+        assert "IS_UPLOADED_TO_YOUTUBE" in query
+        assert "TRUE" in query
+
+    def test_sets_youtube_video_id(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn()
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.mark_turns_uploaded(turn_id=42, youtube_video_id="abc123")
+
+        call_args = cursor.execute.call_args
+        params = call_args[0][1]
+        assert "abc123" in params
+
+    def test_sets_youtube_upload_date_to_now(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn()
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.mark_turns_uploaded(turn_id=42, youtube_video_id="abc123")
+
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].upper()
+        assert "YOUTUBE_UPLOAD_DATE" in query
+        # now() or CURRENT_TIMESTAMP
+        assert "NOW()" in query or "CURRENT_TIMESTAMP" in query
+
+    def test_targets_correct_turn_id(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn()
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.mark_turns_uploaded(turn_id=99, youtube_video_id="xyz")
+
+        call_args = cursor.execute.call_args
+        params = call_args[0][1]
+        assert 99 in params
+
+    def test_updates_speaker_turn_videos_table(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn()
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.mark_turns_uploaded(turn_id=1, youtube_video_id="v1")
+
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].upper()
+        assert "SPEAKER_TURN_VIDEOS" in query
+
+
+class TestCountPendingUploadableTurns:
+    """count_pending_uploadable_turns returns count from uploadable_turns view."""
+
+    def test_returns_count_of_unuploaded_turns(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(scalar=5)
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            result = db.count_pending_uploadable_turns()
+
+        assert result == 5
+
+    def test_returns_zero_when_all_uploaded(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(scalar=0)
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            result = db.count_pending_uploadable_turns()
+
+        assert result == 0
+
+    def test_queries_uploadable_turns_view(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(scalar=2)
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            db.count_pending_uploadable_turns()
+
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].lower()
+        assert "uploadable_turns" in query
+
+
+class TestCountChaptersUploadedTodayUnchanged:
+    """count_chapters_uploaded_today must still count chapters only (not turns)."""
+
+    def test_counts_chapters_not_turns(self):
+        from congress_videos.modules.database import CongressionalVideoDB
+
+        pg_mock, cursor = _make_conn(scalar=3)
+
+        with patch("congress_videos.modules.database.PostgresConnection", return_value=pg_mock):
+            db = CongressionalVideoDB()
+            result = db.count_chapters_uploaded_today()
+
+        assert result == 3
+        # Must query video_chapters table, not speaker_turn_videos
+        call_args = cursor.execute.call_args
+        query = call_args[0][0].lower()
+        assert "video_chapters" in query
+        assert "speaker_turn_videos" not in query

--- a/tests/congress_videos/modules/test_postgres_operators.py
+++ b/tests/congress_videos/modules/test_postgres_operators.py
@@ -31,8 +31,15 @@ def set_pg_env(monkeypatch):
 
 @pytest.fixture
 def mock_db(mocker):
-    """Patch CongressionalVideoDB and return the mock instance."""
+    """Patch CongressionalVideoDB and return the mock instance.
+
+    Default return values for turn-related methods are set to 0 so existing
+    tests that only configure chapter methods still produce valid integer sums
+    in check_upload_quota (combined uploads_today = chapters + turns).
+    """
     mock_instance = MagicMock()
+    mock_instance.count_turns_uploaded_today.return_value = 0
+    mock_instance.count_pending_uploadable_turns.return_value = 0
     mocker.patch(
         "congress_videos.modules.postgres_operators.CongressionalVideoDB",
         return_value=mock_instance,
@@ -422,14 +429,21 @@ class TestExecuteCheckUploadQuota:
 
         assert "remaining_quota" not in result
 
-    def test_result_contains_only_queue_size_and_uploads_today(
+    def test_result_contains_queue_size_and_uploads_today(
         self, mock_db, mock_task_instance, make_context
     ):
-        """check_upload_quota result contains exactly queue_size and uploads_today (REQ-QUOTA-01)."""
+        """check_upload_quota result must contain at least queue_size and uploads_today (REQ-QUOTA-01).
+
+        turns_pending is also included in the result dict as an informational field.
+        uploads_today = chapters_uploaded_today + turns_uploaded_today (combined cap).
+        queue_size = chapters_pending + turns_pending (combined queue).
+        """
         from congress_videos.modules.postgres_operators import PostgreSQLOperator
 
         mock_db.count_chapters_uploaded_today.return_value = 2
+        mock_db.count_turns_uploaded_today.return_value = 0
         mock_db.count_pending_uploadable_chapters.return_value = 30
+        mock_db.count_pending_uploadable_turns.return_value = 0
 
         op = PostgreSQLOperator(task_id="t", operation="check_upload_quota")
         ctx = make_context(params={"min_relevance_score": 2}, ti=mock_task_instance)
@@ -437,7 +451,9 @@ class TestExecuteCheckUploadQuota:
 
         assert result["uploads_today"] == 2
         assert result["queue_size"] == 30
-        assert set(result.keys()) == {"uploads_today", "queue_size"}
+        # turns_pending is now included as an informational key alongside queue_size/uploads_today
+        assert "queue_size" in result
+        assert "uploads_today" in result
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/congress_videos/modules/test_postgres_operators_turns.py
+++ b/tests/congress_videos/modules/test_postgres_operators_turns.py
@@ -1,0 +1,225 @@
+"""Tests for turn-related operations in PostgreSQLOperator.
+
+Tests:
+- operation='get_uploadable_turns': returns turn rows via output_xcom_key
+- operation='mark_turns_uploaded': reads upload_results xcom and calls db.mark_turns_uploaded
+- operation='check_upload_quota': extended — now includes turns_pending count
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def set_pg_env(monkeypatch):
+    monkeypatch.setenv("POSTGRES_HOST", "localhost")
+    monkeypatch.setenv("POSTGRES_PORT", "5432")
+    monkeypatch.setenv("POSTGRES_DB", "testdb")
+    monkeypatch.setenv("POSTGRES_USER", "testuser")
+    monkeypatch.setenv("POSTGRES_PASSWORD", "testpass")
+    monkeypatch.setenv("POSTGRES_SCHEMA", "public")
+
+
+@pytest.fixture
+def mock_db(mocker):
+    mock_instance = MagicMock()
+    mocker.patch(
+        "congress_videos.modules.postgres_operators.CongressionalVideoDB",
+        return_value=mock_instance,
+    )
+    return mock_instance
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_context(ti, params=None):
+    return {"ti": ti, "params": params or {}}
+
+
+# ---------------------------------------------------------------------------
+# get_uploadable_turns
+# ---------------------------------------------------------------------------
+
+
+class TestGetUploadableTurns:
+    """operation='get_uploadable_turns' fetches turns and pushes them via output_xcom_key."""
+
+    def test_calls_get_uploadable_turns_with_limit_1(
+        self, mock_db, mock_task_instance
+    ):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db.get_uploadable_turns.return_value = []
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="get_uploadable_turns",
+            output_xcom_key="uploadable_turns",
+        )
+        op.execute(_make_context(mock_task_instance))
+
+        mock_db.get_uploadable_turns.assert_called_once_with(limit=1)
+
+    def test_returns_turn_rows(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        fake_turns = [
+            {"turn_id": 1, "output_path": "/path/t1.mp4", "resolved_name": "Ana G."}
+        ]
+        mock_db.get_uploadable_turns.return_value = fake_turns
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="get_uploadable_turns",
+            output_xcom_key="uploadable_turns",
+        )
+        result = op.execute(_make_context(mock_task_instance))
+
+        assert result == fake_turns
+
+    def test_xcom_push_with_output_key(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        fake_turns = [{"turn_id": 5}]
+        mock_db.get_uploadable_turns.return_value = fake_turns
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="get_uploadable_turns",
+            output_xcom_key="uploadable_turns",
+        )
+        op.execute(_make_context(mock_task_instance))
+
+        assert mock_task_instance.xcom_store.get("uploadable_turns") == fake_turns
+
+
+# ---------------------------------------------------------------------------
+# mark_turns_uploaded
+# ---------------------------------------------------------------------------
+
+
+class TestMarkTurnsUploaded:
+    """operation='mark_turns_uploaded' reads upload_results xcom and marks each turn."""
+
+    def test_calls_mark_turns_uploaded_per_entry(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["upload_results"] = {
+            "upload_details": [
+                {"turn_id": 1, "youtube_video_id": "abc", "success": True},
+                {"turn_id": 2, "youtube_video_id": "xyz", "success": True},
+            ]
+        }
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="mark_turns_uploaded",
+            xcom_keys={"upload_results": "upload_results"},
+            output_xcom_key="turn_upload_updates",
+        )
+        op.execute(_make_context(mock_task_instance))
+
+        assert mock_db.mark_turns_uploaded.call_count == 2
+        mock_db.mark_turns_uploaded.assert_any_call(turn_id=1, youtube_video_id="abc")
+        mock_db.mark_turns_uploaded.assert_any_call(turn_id=2, youtube_video_id="xyz")
+
+    def test_skips_failed_uploads(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["upload_results"] = {
+            "upload_details": [
+                {"turn_id": 1, "youtube_video_id": None, "success": False},
+            ]
+        }
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="mark_turns_uploaded",
+            xcom_keys={"upload_results": "upload_results"},
+            output_xcom_key="turn_upload_updates",
+        )
+        op.execute(_make_context(mock_task_instance))
+
+        mock_db.mark_turns_uploaded.assert_not_called()
+
+    def test_handles_empty_upload_results(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_task_instance.xcom_store["upload_results"] = None
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="mark_turns_uploaded",
+            xcom_keys={"upload_results": "upload_results"},
+            output_xcom_key="turn_upload_updates",
+        )
+        result = op.execute(_make_context(mock_task_instance))
+
+        mock_db.mark_turns_uploaded.assert_not_called()
+        assert result is not None  # returns a result dict
+
+
+# ---------------------------------------------------------------------------
+# check_upload_quota — extended with turns_pending
+# ---------------------------------------------------------------------------
+
+
+class TestCheckUploadQuotaExtended:
+    """check_upload_quota now includes turns_pending in the result dict."""
+
+    def test_includes_turns_pending_in_result(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db.count_chapters_uploaded_today.return_value = 0
+        mock_db.count_pending_uploadable_chapters.return_value = 3
+        mock_db.count_pending_uploadable_turns.return_value = 2
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        result = op.execute(_make_context(mock_task_instance, params={"min_relevance_score": 2}))
+
+        assert "turns_pending" in result
+        assert result["turns_pending"] == 2
+
+    def test_calls_count_pending_uploadable_turns(self, mock_db, mock_task_instance):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db.count_chapters_uploaded_today.return_value = 0
+        mock_db.count_pending_uploadable_chapters.return_value = 0
+        mock_db.count_pending_uploadable_turns.return_value = 0
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        op.execute(_make_context(mock_task_instance, params={"min_relevance_score": 2}))
+
+        mock_db.count_pending_uploadable_turns.assert_called_once()
+
+    def test_uploads_today_still_from_count_chapters_uploaded_today(
+        self, mock_db, mock_task_instance
+    ):
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db.count_chapters_uploaded_today.return_value = 1
+        mock_db.count_pending_uploadable_chapters.return_value = 5
+        mock_db.count_pending_uploadable_turns.return_value = 0
+
+        op = PostgreSQLOperator(
+            task_id="t",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        result = op.execute(_make_context(mock_task_instance, params={"min_relevance_score": 2}))
+
+        assert result["uploads_today"] == 1
+        mock_db.count_chapters_uploaded_today.assert_called_once()

--- a/tests/congress_videos/modules/test_postgres_operators_turns.py
+++ b/tests/congress_videos/modules/test_postgres_operators_turns.py
@@ -26,6 +26,9 @@ def set_pg_env(monkeypatch):
 @pytest.fixture
 def mock_db(mocker):
     mock_instance = MagicMock()
+    # Default turn-related counts to 0 so combined arithmetic stays valid
+    mock_instance.count_turns_uploaded_today.return_value = 0
+    mock_instance.count_pending_uploadable_turns.return_value = 0
     mocker.patch(
         "congress_videos.modules.postgres_operators.CongressionalVideoDB",
         return_value=mock_instance,
@@ -205,12 +208,18 @@ class TestCheckUploadQuotaExtended:
 
         mock_db.count_pending_uploadable_turns.assert_called_once()
 
-    def test_uploads_today_still_from_count_chapters_uploaded_today(
+    def test_uploads_today_combines_chapters_and_turns(
         self, mock_db, mock_task_instance
     ):
+        """uploads_today must equal chapters_uploaded_today + turns_uploaded_today (CRITICAL-2).
+
+        When only chapters were uploaded (turns=0), uploads_today must equal the chapter count.
+        Both count methods must be called.
+        """
         from congress_videos.modules.postgres_operators import PostgreSQLOperator
 
         mock_db.count_chapters_uploaded_today.return_value = 1
+        mock_db.count_turns_uploaded_today.return_value = 0
         mock_db.count_pending_uploadable_chapters.return_value = 5
         mock_db.count_pending_uploadable_turns.return_value = 0
 
@@ -223,3 +232,4 @@ class TestCheckUploadQuotaExtended:
 
         assert result["uploads_today"] == 1
         mock_db.count_chapters_uploaded_today.assert_called_once()
+        mock_db.count_turns_uploaded_today.assert_called_once()

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -1183,3 +1183,212 @@ class TestTriggerThumbnailGenerationForwardsKeySpeakers:
         assert len(captured_confs) == 1
         assert "key_speakers" in captured_confs[0]
         assert captured_confs[0]["key_speakers"] == []
+
+
+# ---------------------------------------------------------------------------
+# Dual-queue: turn queue tried first, chapter fallback when turns empty
+# ---------------------------------------------------------------------------
+
+
+def _make_turn_row(
+    turn_id: int = 1,
+    output_path: str = "/data/turn1.mp4",
+    resolved_name: str = "Ana García",
+    start_seconds: float = 120.0,
+    end_seconds: float = 240.0,
+    chapter_id: int = 42,
+    key_speakers: list | None = None,
+    session_number: int = 80,
+    session_date: str = "2025-06-10",
+) -> dict:
+    return {
+        "turn_id": turn_id,
+        "output_path": output_path,
+        "resolved_name": resolved_name,
+        "start_seconds": start_seconds,
+        "end_seconds": end_seconds,
+        "chapter_id": chapter_id,
+        "key_speakers": key_speakers if key_speakers is not None else ["Ana García", "Pedro López"],
+        "session_number": session_number,
+        "session_date": session_date,
+        "chapter_title": "Un capítulo de prueba",
+        "description": "Descripción del capítulo",
+        "relevance_score": 4,
+    }
+
+
+class TestPrepareThumbnailConfigForTurn:
+    """_prepare_thumbnail_config anchors key_speakers to turn speaker and uses SRT window."""
+
+    def test_key_speakers_anchored_to_resolved_name(self):
+        """Turn config: key_speakers must be [resolved_name] ignoring chapter's key_speakers."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(
+            turn_id=1,
+            resolved_name="Ana García",
+        )
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value={"slug": "garcia-ana"},
+        ):
+            result = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert result["key_speakers"] == ["Ana García"]
+
+    def test_slug_resolved_from_resolved_name_not_key_speakers(self):
+        """Turn config: slug is derived from resolved_name (turn speaker), not chapter's speakers."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(
+            resolved_name="Pedro López",
+        )
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value={"slug": "lopez-pedro"},
+        ) as lookup:
+            result = _prepare_thumbnail_config(turn, MagicMock())
+
+        lookup.assert_called_once_with("Pedro López")
+        assert result["slug"] == "lopez-pedro"
+
+    def test_srt_fragment_bounded_by_start_end_seconds(self, tmp_path, mocker):
+        """Turn config: SRT fragment must be limited to [start_seconds, end_seconds]."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        # SRT content: block 1 within window, block 2 after window
+        srt_content = (
+            "1\n00:01:00,000 --> 00:02:00,000\nDentro del turno.\n\n"
+            "2\n00:04:00,000 --> 00:05:00,000\nFuera del turno.\n\n"
+        )
+        srt_path = tmp_path / "test.srt"
+        srt_path.write_text(srt_content, encoding="utf-8")
+
+        turn = _make_turn_row(
+            turn_id=1,
+            start_seconds=60.0,   # 00:01:00
+            end_seconds=180.0,    # 00:03:00 — block 2 is at 240s, outside window
+        )
+        turn["video_id"] = "video123"
+        turn["session_date"] = "2025-06-10"
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+            return_value=str(srt_path),
+        )
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value={"slug": "garcia-ana"},
+        )
+
+        result = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert "srt_fragment" in result
+        assert "Dentro del turno" in result["srt_fragment"]
+        assert "Fuera del turno" not in result["srt_fragment"]
+
+    def test_chapter_id_preserved_in_config(self):
+        """Turn config: chapter_id must be preserved for thumbnail identity."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(turn_id=5, chapter_id=42)
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value=None,
+        ):
+            result = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert result["chapter_id"] == 42
+
+    def test_session_derived_from_session_number(self):
+        """Turn config: session label derived from session_number."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(session_number=80)
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value=None,
+        ):
+            result = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert "80" in result["session"]
+
+
+class TestDualQueueBehavior:
+    """Dual-queue: turn queue has priority; chapter fallback used when turns empty."""
+
+    def test_uploader_selects_turn_when_available(self, mocker):
+        """When get_uploadable_turns returns a turn, _run_get_uploadable_item returns it."""
+        from congress_videos.youtube_upload_dag import _run_get_uploadable_item
+
+        fake_turn = _make_turn_row()
+        mock_db = MagicMock()
+        mock_db.get_uploadable_turns.return_value = [fake_turn]
+        mock_db.get_uploadable_chapters.return_value = []
+
+        result = _run_get_uploadable_item(mock_db)
+
+        assert result["item"] == fake_turn
+        assert result["item_type"] == "turn"
+        mock_db.get_uploadable_chapters.assert_not_called()
+
+    def test_uploader_falls_back_to_chapter_when_turns_empty(self, mocker):
+        """When turns empty, _run_get_uploadable_item falls back to chapters."""
+        from congress_videos.youtube_upload_dag import _run_get_uploadable_item
+
+        fake_chapter = {"chapter_id": 99, "title": "Cap 99"}
+        mock_db = MagicMock()
+        mock_db.get_uploadable_turns.return_value = []
+        mock_db.get_uploadable_chapters.return_value = [fake_chapter]
+
+        result = _run_get_uploadable_item(mock_db)
+
+        assert result["item"] == fake_chapter
+        assert result["item_type"] == "chapter"
+        mock_db.get_uploadable_chapters.assert_called_once()
+
+    def test_uploader_returns_none_when_both_queues_empty(self):
+        """When both queues empty, _run_get_uploadable_item returns None."""
+        from congress_videos.youtube_upload_dag import _run_get_uploadable_item
+
+        mock_db = MagicMock()
+        mock_db.get_uploadable_turns.return_value = []
+        mock_db.get_uploadable_chapters.return_value = []
+
+        result = _run_get_uploadable_item(mock_db)
+
+        assert result is None
+
+
+class TestGuardAAndGuardB:
+    """View-level guards: Guard A (chapter excluded when turn uploaded),
+    Guard B (turn excluded when chapter uploaded). Both enforced in the SQL
+    view — these tests verify the uploader passes the right rows through."""
+
+    def test_guard_b_turn_excluded_by_empty_view(self):
+        """Guard B: when uploadable_turns is empty (chapter already uploaded),
+        uploader falls back to chapter queue."""
+        from congress_videos.youtube_upload_dag import _run_get_uploadable_item
+
+        mock_db = MagicMock()
+        mock_db.get_uploadable_turns.return_value = []  # Guard B filtered them out
+        mock_db.get_uploadable_chapters.return_value = []
+
+        result = _run_get_uploadable_item(mock_db)
+        assert result is None
+
+    def test_guard_a_chapter_excluded_by_empty_view(self):
+        """Guard A: when chapter fallback returns empty (turn already uploaded),
+        uploader has nothing to upload."""
+        from congress_videos.youtube_upload_dag import _run_get_uploadable_item
+
+        mock_db = MagicMock()
+        mock_db.get_uploadable_turns.return_value = []
+        mock_db.get_uploadable_chapters.return_value = []  # Guard A filtered chapter out
+
+        result = _run_get_uploadable_item(mock_db)
+        assert result is None

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -38,11 +38,12 @@ class TestYoutubeUploadDagLoads:
         assert dag is not None
         assert dag.dag_id == "congress_youtube_chapter_uploader"
 
-    def test_dag_has_thirteen_tasks(self):
-        """DAG must have 13 tasks after replacing t3/t4 with 3 new tasks (net +1)."""
+    def test_dag_has_fourteen_tasks(self):
+        """DAG must have 14 tasks: 13 original (t1_db replaced by get_uploadable_item PythonOperator)
+        plus mark_turns_uploaded task."""
         from congress_videos.youtube_upload_dag import dag
 
-        assert len(dag.tasks) == 13
+        assert len(dag.tasks) == 14
 
     def test_expected_task_ids_present(self):
         """New task IDs present; legacy Pillow task IDs absent."""
@@ -1392,3 +1393,292 @@ class TestGuardAAndGuardB:
 
         result = _run_get_uploadable_item(mock_db)
         assert result is None
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-1: Dual-queue wired into DAG task graph (not dead code)
+# ---------------------------------------------------------------------------
+
+
+class TestDualQueueWiredIntoDag:
+    """Verify that the DAG task graph actually invokes dual-queue logic
+    rather than calling get_uploadable_chapters directly."""
+
+    def test_dag_has_get_uploadable_item_task_not_static_chapters_op(self):
+        """DAG must have a 'get_uploadable_item' task (PythonOperator), not a
+        PostgreSQLOperator with operation='get_uploadable_chapters'."""
+        from congress_videos.youtube_upload_dag import dag
+
+        task_ids = {t.task_id for t in dag.tasks}
+        # The wired task must exist
+        assert "get_uploadable_item" in task_ids, (
+            "DAG must have a get_uploadable_item task (dual-queue wired)"
+        )
+
+    def test_get_uploadable_item_task_is_python_operator(self):
+        """The get_uploadable_item task must be a PythonOperator (not PostgreSQLOperator)."""
+        from airflow.operators.python import PythonOperator
+        from congress_videos.youtube_upload_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        task = tasks_by_id.get("get_uploadable_item")
+        assert task is not None, "get_uploadable_item task must exist"
+        assert isinstance(task, PythonOperator), (
+            "get_uploadable_item must be a PythonOperator, not a PostgreSQLOperator"
+        )
+
+    def test_get_uploadable_item_is_downstream_of_skip_if_quota_reached(self):
+        """get_uploadable_item must be downstream of skip_if_quota_reached."""
+        from congress_videos.youtube_upload_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        skip_task = tasks_by_id["skip_if_quota_reached"]
+        item_task = tasks_by_id.get("get_uploadable_item")
+        assert item_task is not None, "get_uploadable_item task must exist"
+        downstream_ids = {t.task_id for t in skip_task.downstream_list}
+        assert item_task.task_id in downstream_ids, (
+            "get_uploadable_item must be downstream of skip_if_quota_reached"
+        )
+
+    def test_generate_metadata_is_downstream_of_get_uploadable_item(self):
+        """generate_youtube_metadata must be downstream of get_uploadable_item."""
+        from congress_videos.youtube_upload_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        item_task = tasks_by_id.get("get_uploadable_item")
+        meta_task = tasks_by_id["generate_youtube_metadata"]
+        assert item_task is not None, "get_uploadable_item task must exist"
+        upstream_ids = {t.task_id for t in meta_task.upstream_list}
+        assert item_task.task_id in upstream_ids, (
+            "generate_youtube_metadata must be downstream of get_uploadable_item"
+        )
+
+    def test_dag_task_count_updated_for_wired_dual_queue(self):
+        """DAG must have 14 tasks after replacing t1_db with get_uploadable_item and adding mark_turns_uploaded."""
+        from congress_videos.youtube_upload_dag import dag
+
+        assert len(dag.tasks) == 14, (
+            f"Expected 14 tasks (13 original tasks, t1_db replaced by get_uploadable_item PythonOperator, "
+            f"plus mark_turns_uploaded), got {len(dag.tasks)}"
+        )
+
+    def test_mark_turns_uploaded_task_exists(self):
+        """DAG must have a mark_turns_uploaded task (CRITICAL-3)."""
+        from congress_videos.youtube_upload_dag import dag
+
+        task_ids = {t.task_id for t in dag.tasks}
+        assert "mark_turns_uploaded" in task_ids, (
+            "DAG must have a mark_turns_uploaded task after upload"
+        )
+
+    def test_mark_turns_uploaded_is_downstream_of_trigger_youtube_upload(self):
+        """mark_turns_uploaded must be downstream of trigger_youtube_upload."""
+        from congress_videos.youtube_upload_dag import dag
+
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        upload_task = tasks_by_id["trigger_youtube_upload"]
+        mark_turns = tasks_by_id.get("mark_turns_uploaded")
+        assert mark_turns is not None, "mark_turns_uploaded task must exist"
+        downstream_ids = {t.task_id for t in upload_task.downstream_list}
+        assert mark_turns.task_id in downstream_ids, (
+            "mark_turns_uploaded must be downstream of trigger_youtube_upload"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CRITICAL-2: Combined daily cap (turns + chapters in uploads_today)
+# ---------------------------------------------------------------------------
+
+
+class TestCombinedDailyCap:
+    """check_upload_quota must count turns uploaded today + chapters uploaded today."""
+
+    def test_uploads_today_includes_turns_and_chapters(self, mocker):
+        """When 1 turn and 1 chapter were uploaded today, uploads_today must be 2."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db = MagicMock()
+        mock_db.count_chapters_uploaded_today.return_value = 1
+        mock_db.count_turns_uploaded_today.return_value = 1
+        mock_db.count_pending_uploadable_chapters.return_value = 3
+        mock_db.count_pending_uploadable_turns.return_value = 2
+
+        mocker.patch(
+            "congress_videos.modules.postgres_operators.CongressionalVideoDB",
+            return_value=mock_db,
+        )
+        mocker.patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DB": "testdb",
+                "POSTGRES_USER": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+                "POSTGRES_SCHEMA": "public",
+            },
+        )
+
+        op = PostgreSQLOperator(
+            task_id="check_upload_quota",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        ti = MagicMock()
+        ti.xcom_store = {}
+        ti.xcom_push.side_effect = lambda key, value, **kw: ti.xcom_store.update({key: value})
+        context = {"params": {}, "ti": ti}
+
+        op.execute(context)
+
+        result = ti.xcom_store.get("upload_quota")
+        assert result is not None, "upload_quota must be pushed to XCom"
+        assert result["uploads_today"] == 2, (
+            f"uploads_today must be turns (1) + chapters (1) = 2, got {result['uploads_today']}"
+        )
+
+    def test_uploads_today_zero_when_nothing_uploaded(self, mocker):
+        """When no turns and no chapters uploaded today, uploads_today must be 0."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db = MagicMock()
+        mock_db.count_chapters_uploaded_today.return_value = 0
+        mock_db.count_turns_uploaded_today.return_value = 0
+        mock_db.count_pending_uploadable_chapters.return_value = 5
+        mock_db.count_pending_uploadable_turns.return_value = 2
+
+        mocker.patch(
+            "congress_videos.modules.postgres_operators.CongressionalVideoDB",
+            return_value=mock_db,
+        )
+        mocker.patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DB": "testdb",
+                "POSTGRES_USER": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+                "POSTGRES_SCHEMA": "public",
+            },
+        )
+
+        op = PostgreSQLOperator(
+            task_id="check_upload_quota",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        ti = MagicMock()
+        ti.xcom_store = {}
+        ti.xcom_push.side_effect = lambda key, value, **kw: ti.xcom_store.update({key: value})
+        context = {"params": {}, "ti": ti}
+
+        op.execute(context)
+
+        result = ti.xcom_store.get("upload_quota")
+        assert result["uploads_today"] == 0
+
+    def test_uploads_today_chapter_only_when_no_turns_uploaded(self, mocker):
+        """When only chapters uploaded today, uploads_today = chapter count."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db = MagicMock()
+        mock_db.count_chapters_uploaded_today.return_value = 1
+        mock_db.count_turns_uploaded_today.return_value = 0
+        mock_db.count_pending_uploadable_chapters.return_value = 2
+        mock_db.count_pending_uploadable_turns.return_value = 0
+
+        mocker.patch(
+            "congress_videos.modules.postgres_operators.CongressionalVideoDB",
+            return_value=mock_db,
+        )
+        mocker.patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DB": "testdb",
+                "POSTGRES_USER": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+                "POSTGRES_SCHEMA": "public",
+            },
+        )
+
+        op = PostgreSQLOperator(
+            task_id="check_upload_quota",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        ti = MagicMock()
+        ti.xcom_store = {}
+        ti.xcom_push.side_effect = lambda key, value, **kw: ti.xcom_store.update({key: value})
+        context = {"params": {}, "ti": ti}
+
+        op.execute(context)
+
+        result = ti.xcom_store.get("upload_quota")
+        assert result["uploads_today"] == 1
+
+
+# ---------------------------------------------------------------------------
+# WARNING-1: queue_size includes turns_pending in should_upload gate
+# ---------------------------------------------------------------------------
+
+
+class TestQueueSizeIncludesTurns:
+    """should_upload must gate on combined queue size (turns + chapters)."""
+
+    def test_queue_size_with_only_turns_pending_allows_upload(self):
+        """When only turns are pending (queue_size=0 for chapters), gate on combined."""
+        from congress_videos.youtube_upload_dag import should_upload
+
+        # Simulate quota xcom: chapter queue empty but turns pending
+        # queue_size must already include turns for the gate to work.
+        # This test verifies the combined queue_size is what should_upload sees.
+        ctx = _make_context_for_should_upload(queue_size=1, hour=19, uploads_today=0)
+        # queue_size=1 represents turns_pending=1 counted in combined queue_size
+        assert should_upload(**ctx) is True
+
+    def test_combined_queue_size_in_check_upload_quota(self, mocker):
+        """check_upload_quota queue_size must include turns_pending + chapters pending."""
+        from congress_videos.modules.postgres_operators import PostgreSQLOperator
+
+        mock_db = MagicMock()
+        mock_db.count_chapters_uploaded_today.return_value = 0
+        mock_db.count_turns_uploaded_today.return_value = 0
+        mock_db.count_pending_uploadable_chapters.return_value = 2
+        mock_db.count_pending_uploadable_turns.return_value = 3  # 3 turns pending
+
+        mocker.patch(
+            "congress_videos.modules.postgres_operators.CongressionalVideoDB",
+            return_value=mock_db,
+        )
+        mocker.patch.dict(
+            "os.environ",
+            {
+                "POSTGRES_HOST": "localhost",
+                "POSTGRES_PORT": "5432",
+                "POSTGRES_DB": "testdb",
+                "POSTGRES_USER": "testuser",
+                "POSTGRES_PASSWORD": "testpass",
+                "POSTGRES_SCHEMA": "public",
+            },
+        )
+
+        op = PostgreSQLOperator(
+            task_id="check_upload_quota",
+            operation="check_upload_quota",
+            output_xcom_key="upload_quota",
+        )
+        ti = MagicMock()
+        ti.xcom_store = {}
+        ti.xcom_push.side_effect = lambda key, value, **kw: ti.xcom_store.update({key: value})
+        context = {"params": {}, "ti": ti}
+
+        op.execute(context)
+
+        result = ti.xcom_store.get("upload_quota")
+        # queue_size must be chapters(2) + turns(3) = 5
+        assert result["queue_size"] == 5, (
+            f"queue_size must be chapters_pending(2) + turns_pending(3) = 5, got {result['queue_size']}"
+        )


### PR DESCRIPTION
Part of #117 (epic #16). **PR 2 of 3** — stacked on #125 (PR1). Merge #125 first, then retarget/merge this.

## What

The uploader now consumes refined speaker turns first and falls back to raw chapters to drain the existing backlog (additive dual-queue transition, no hard cutover):

- **`database.py`**: `get_uploadable_turns()`, `mark_turns_uploaded()`, `count_pending_uploadable_turns()`, `count_turns_uploaded_today()`.
- **`postgres_operators.py`**: turn operations + `check_upload_quota` extended — `uploads_today` and `queue_size` now aggregate **turns + chapters** against the single daily cap.
- **`youtube_upload_dag.py`**: `get_uploadable_item` PythonOperator replaces the chapter-only retrieval task (DAG 13 → 14 tasks); turns-first/chapter-fallback selection with double-upload guards in both directions; `mark_turns_uploaded` task added (no-op for chapter uploads); thumbnail/title config anchored to the turn's real speaker with windowed SRT.
- Approval gate unchanged: trim approval gates **trims only**, never upload eligibility (voice always prevails).

## Test plan

- [x] `uv run pytest` — 2579 passed, 1 skipped (86.16% cov); strict TDD (RED→GREEN per work unit)
- [x] `TestDualQueueWiredIntoDag`, `TestCombinedDailyCap`, `TestQueueSizeIncludesTurns` cover the task-graph wiring
- [x] Docker e2e smoke — PASS

## Chain

1. PR1 #125: migration + view → `dev`
2. **PR2 (this)**: dual-queue uploader
3. PR3: monitor fire-and-forget refinement trigger