### PR TITLE
feat(monitor): fire-and-forget refinement chain trigger after saving chapters (#117 PR3/3)

### DIFF
--- a/congress_videos/youtube_channel_monitor_dag.py
+++ b/congress_videos/youtube_channel_monitor_dag.py
@@ -23,6 +23,7 @@ import os
 from datetime import datetime, timedelta
 
 from airflow import DAG
+from airflow.api.common.trigger_dag import trigger_dag as trigger_dag_api
 from airflow.operators.python import BranchPythonOperator, PythonOperator, ShortCircuitOperator
 
 from congress_videos.config.constants import (
@@ -55,6 +56,42 @@ default_args = {
     'retries': 2,
     'retry_delay': timedelta(minutes=5),
 }
+
+def _trigger_refinement(ti, **_context) -> None:
+    """Fire-and-forget trigger for speaker_turns_dag after successful chapter save.
+
+    Reads db_save_results XCom from save_chapters_to_db to determine whether any
+    chapters were actually saved. When total_chapters_saved == 0 or the XCom is
+    absent, the trigger is skipped. Any exception from trigger_dag_api is caught
+    and logged — it must never fail the monitor DAG run.
+    """
+    db_save_results = ti.xcom_pull(key="db_save_results") or {}
+    total_chapters_saved = db_save_results.get("total_chapters_saved", 0)
+
+    if not total_chapters_saved:
+        logging.info(
+            "_trigger_refinement: 0 chapters saved — skipping speaker_turns_dag trigger"
+        )
+        return
+
+    try:
+        trigger_dag_api(
+            dag_id="speaker_turns_dag",
+            conf={},
+            run_id=f"monitor_trigger_{datetime.utcnow().strftime('%Y%m%dT%H%M%S')}",
+        )
+        logging.info(
+            "_trigger_refinement: triggered speaker_turns_dag "
+            "(total_chapters_saved=%d)",
+            total_chapters_saved,
+        )
+    except Exception as exc:
+        logging.warning(
+            "_trigger_refinement: could not trigger speaker_turns_dag: %s — "
+            "continuing (fire-and-forget)",
+            exc,
+        )
+
 
 with DAG(
     'congress_youtube_channel_monitor',
@@ -637,6 +674,16 @@ with DAG(
         trigger_rule="all_done",
     )
 
+    # Step 11: Fire-and-forget trigger for speaker_turns_dag.
+    # Runs after normalize_speakers (all_done so it fires even when normalization
+    # short-circuits). Exception from trigger_dag_api is caught inside the callable
+    # and never propagates — the monitor DAG always succeeds.
+    t_trigger_refinement = PythonOperator(
+        task_id="trigger_refinement",
+        python_callable=_trigger_refinement,
+        trigger_rule="all_done",
+    )
+
     # Task dependencies
 
     # Start: Branch based on test mode
@@ -717,3 +764,7 @@ with DAG(
     # After saving chapters, normalize speaker names (best-effort; all_done so a
     # partial save never blocks normalization)
     t9_db >> t_normalize_speakers
+
+    # After normalization, fire-and-forget trigger for speaker_turns_dag.
+    # all_done: runs even when normalize_speakers short-circuits.
+    t_normalize_speakers >> t_trigger_refinement

--- a/tests/congress_videos/modules/test_postgres_operators.py
+++ b/tests/congress_videos/modules/test_postgres_operators.py
@@ -432,11 +432,8 @@ class TestExecuteCheckUploadQuota:
     def test_result_contains_queue_size_and_uploads_today(
         self, mock_db, mock_task_instance, make_context
     ):
-        """check_upload_quota result must contain at least queue_size and uploads_today (REQ-QUOTA-01).
-
-        turns_pending is also included in the result dict as an informational field.
-        uploads_today = chapters_uploaded_today + turns_uploaded_today (combined cap).
-        queue_size = chapters_pending + turns_pending (combined queue).
+        """check_upload_quota result contains queue_size, uploads_today, and turns_pending
+        (REQ-QUOTA-01; combined cap: uploads_today = chapters + turns; queue_size = chapters + turns).
         """
         from congress_videos.modules.postgres_operators import PostgreSQLOperator
 
@@ -451,9 +448,8 @@ class TestExecuteCheckUploadQuota:
 
         assert result["uploads_today"] == 2
         assert result["queue_size"] == 30
-        # turns_pending is now included as an informational key alongside queue_size/uploads_today
-        assert "queue_size" in result
-        assert "uploads_today" in result
+        assert "turns_pending" in result
+        assert {"uploads_today", "queue_size", "turns_pending"}.issubset(result.keys())
 
 
 # --------------------------------------------------------------------------- #

--- a/tests/congress_videos/test_youtube_channel_monitor_dag.py
+++ b/tests/congress_videos/test_youtube_channel_monitor_dag.py
@@ -210,3 +210,135 @@ class TestNormalizeSpeakersTask:
         assert normalize.task_id in downstream_ids, (
             "'normalize_speakers' must be a direct downstream of 'save_chapters_to_db'"
         )
+
+
+# ---------------------------------------------------------------------------
+# Monitor fire-and-forget trigger for speaker_turns_dag (issue #117)
+# ---------------------------------------------------------------------------
+
+def _make_ti_monitor(xcom_store: dict | None = None):
+    """Return a TaskInstance double with an in-memory XCom store."""
+    from unittest.mock import MagicMock
+    store: dict = xcom_store or {}
+    ti = MagicMock(name="TaskInstance")
+    ti.xcom_store = store
+
+    def _push(key, value, **_kw):
+        store[key] = value
+
+    def _pull(key=None, **_kw):
+        if key is None:
+            return None
+        return store.get(key)
+
+    ti.xcom_push.side_effect = _push
+    ti.xcom_pull.side_effect = _pull
+    return ti
+
+
+class TestMonitorTriggerRefinementTask:
+    """t_trigger_refinement topology tests (structural, no DB)."""
+
+    def test_trigger_refinement_task_exists(self):
+        """trigger_refinement task must exist in the monitor DAG."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        task_ids = {t.task_id for t in dag.tasks}
+        assert "trigger_refinement" in task_ids, (
+            "Expected task_id 'trigger_refinement' in monitor DAG tasks"
+        )
+
+    def test_trigger_refinement_is_downstream_of_normalize_speakers(self):
+        """trigger_refinement must be wired after normalize_speakers."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+
+        normalize = tasks_by_id["normalize_speakers"]
+        trigger = tasks_by_id["trigger_refinement"]
+
+        downstream_ids = {t.task_id for t in normalize.downstream_list}
+        assert trigger.task_id in downstream_ids, (
+            "'trigger_refinement' must be a direct downstream of 'normalize_speakers'"
+        )
+
+    def test_trigger_refinement_trigger_rule_is_all_done(self):
+        """trigger_refinement must use trigger_rule='all_done' so it runs even when
+        normalize_speakers short-circuits."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        tasks_by_id = {t.task_id: t for t in dag.tasks}
+        t = tasks_by_id["trigger_refinement"]
+        assert str(t.trigger_rule) == "all_done", (
+            f"Expected trigger_rule='all_done', got {t.trigger_rule!r}"
+        )
+
+    def test_dag_import_is_clean(self):
+        """DAG must import without errors after adding trigger_dag_api import."""
+        from congress_videos.youtube_channel_monitor_dag import dag
+        assert dag is not None
+        assert dag.dag_id == "congress_youtube_channel_monitor"
+
+
+class TestMonitorTriggerRefinementCallable:
+    """Callable unit tests: fire-and-forget, error swallowing, zero-chapters skip."""
+
+    def test_trigger_called_when_chapters_saved(self, mocker):
+        """trigger_dag_api called when db_save_results.total_chapters_saved > 0."""
+        from congress_videos.youtube_channel_monitor_dag import _trigger_refinement
+
+        mock_trigger = mocker.patch(
+            "congress_videos.youtube_channel_monitor_dag.trigger_dag_api"
+        )
+        ti = _make_ti_monitor(
+            {"db_save_results": {"total_chapters_saved": 3, "total_videos_saved": 1}}
+        )
+
+        _trigger_refinement(ti=ti)
+
+        mock_trigger.assert_called_once()
+        call_kwargs = mock_trigger.call_args
+        # Must target speaker_turns_dag
+        assert call_kwargs[1].get("dag_id") == "speaker_turns_dag" or (
+            len(call_kwargs[0]) > 0 and call_kwargs[0][0] == "speaker_turns_dag"
+        )
+
+    def test_trigger_not_called_when_zero_chapters_saved(self, mocker):
+        """trigger_dag_api NOT called when total_chapters_saved == 0."""
+        from congress_videos.youtube_channel_monitor_dag import _trigger_refinement
+
+        mock_trigger = mocker.patch(
+            "congress_videos.youtube_channel_monitor_dag.trigger_dag_api"
+        )
+        ti = _make_ti_monitor(
+            {"db_save_results": {"total_chapters_saved": 0, "total_videos_saved": 0}}
+        )
+
+        _trigger_refinement(ti=ti)
+
+        mock_trigger.assert_not_called()
+
+    def test_trigger_not_called_when_no_db_save_results(self, mocker):
+        """trigger_dag_api NOT called when db_save_results XCom is absent."""
+        from congress_videos.youtube_channel_monitor_dag import _trigger_refinement
+
+        mock_trigger = mocker.patch(
+            "congress_videos.youtube_channel_monitor_dag.trigger_dag_api"
+        )
+        ti = _make_ti_monitor({})  # no db_save_results key
+
+        _trigger_refinement(ti=ti)
+
+        mock_trigger.assert_not_called()
+
+    def test_trigger_exception_is_swallowed(self, mocker):
+        """trigger_dag_api raising an exception must NOT propagate — task succeeds."""
+        from congress_videos.youtube_channel_monitor_dag import _trigger_refinement
+
+        mocker.patch(
+            "congress_videos.youtube_channel_monitor_dag.trigger_dag_api",
+            side_effect=Exception("Network error"),
+        )
+        ti = _make_ti_monitor(
+            {"db_save_results": {"total_chapters_saved": 2, "total_videos_saved": 1}}
+        )
+
+        # Must not raise — fire-and-forget
+        _trigger_refinement(ti=ti)


### PR DESCRIPTION
Part of #117 (epic #16). **PR 3 of 3** — stacked on #126 (PR2). Merge order: #125 → #126 → this.

Closes #117.

## What

- **`youtube_channel_monitor_dag.py`**: new fire-and-forget task triggers `speaker_turns_dag` via `trigger_dag_api` after `save_chapters_to_db` (import added — previously only in the uploader DAG). Suppressed entirely when zero chapters were saved; any trigger failure is swallowed and never fails the monitor run.

This closes the loop: `monitor → capítulos → speaker_turns → trim_proposals → speaker_turn_videos → uploader`, with the speaker turn as publication unit and the chapter queue as transitional fallback (removal of the fallback is the Phase 2 follow-up, out of scope here).

## Test plan

- [x] `uv run pytest` — 2579 passed, 1 skipped (86.16% cov)
- [x] Trigger-suppression and error-swallowing covered in `test_youtube_channel_monitor_dag.py`
- [x] Docker e2e smoke — PASS
- [ ] Ops before prod: diarize-api/yamnet-api sidecars reachable + `nas_ffmpeg` pool provisioned on prod

## Chain

1. PR1 #125: migration + view → `dev`
2. PR2 #126: dual-queue uploader
3. **PR3 (this)**: monitor trigger