### PR TITLE
fix(materialization): coerce Decimal seconds to float at plan boundary

### DIFF
--- a/congress_videos/modules/materialization.py
+++ b/congress_videos/modules/materialization.py
@@ -90,6 +90,19 @@ class MaterializationPlan:
 # ---------------------------------------------------------------------------
 
 
+def _with_float_seconds(row: dict) -> dict:
+    """Return a copy of ``row`` with second fields coerced to float.
+
+    Postgres NUMERIC columns are delivered as ``decimal.Decimal`` by
+    psycopg2; mixing them with float tolerances raises TypeError.
+    """
+    return {
+        **row,
+        "start_seconds": float(row["start_seconds"]),
+        "end_seconds": float(row["end_seconds"]),
+    }
+
+
 def _compute_keep_intervals(
     turn_start: float,
     turn_end: float,
@@ -173,6 +186,11 @@ def plan_turn_materialization(
     Returns:
         Ordered list of ``MaterializationPlan`` records, one per output video.
     """
+    # Postgres NUMERIC columns arrive as decimal.Decimal; coerce every
+    # second field to float on copies so interval math never mixes types.
+    turns = [_with_float_seconds(t) for t in turns]
+    approved_trims = [_with_float_seconds(t) for t in approved_trims]
+
     # Filter to only approved + voice-free proposals, indexed by turn_id
     effective_trims: dict[int, list[dict]] = {}
     for trim in approved_trims:

--- a/tests/congress_videos/modules/test_materialization.py
+++ b/tests/congress_videos/modules/test_materialization.py
@@ -14,6 +14,7 @@ All tests are pure: no ffmpeg, no DB, no Airflow imports.
 from __future__ import annotations
 
 import dataclasses
+from decimal import Decimal
 
 import pytest
 
@@ -403,3 +404,49 @@ class TestModuleConstants:
     def test_group_gap_tolerance_secs_value(self):
         """GROUP_GAP_TOLERANCE_SECS must be 0.5."""
         assert GROUP_GAP_TOLERANCE_SECS == 0.5
+
+
+class TestDecimalInputs:
+    """Postgres NUMERIC columns arrive as decimal.Decimal via psycopg2.
+
+    Regression for the prod-shaped crash: consecutive short turns with
+    Decimal seconds hit ``Decimal + float`` in the group-gap comparison
+    (TypeError). All second fields must be coerced to float at the
+    function boundary without mutating caller dicts.
+    """
+
+    def test_short_turn_grouping_accepts_decimal_seconds(self):
+        """Consecutive short Decimal turns must group without TypeError."""
+        turns = [
+            _turn(1, 410, Decimal("21195.0"), Decimal("21196.0")),
+            _turn(2, 410, Decimal("21196.0"), Decimal("21197.0")),
+        ]
+
+        plans = plan_turn_materialization(turns, [])
+
+        assert len(plans) == 1
+        assert plans[0].turn_ids == (1, 2)
+
+    def test_long_turn_with_decimal_trim_yields_float_intervals(self):
+        """Decimal turn bounds and trims must produce float KeepIntervals."""
+        turns = [_turn(1, 410, Decimal("0"), Decimal("400.0"))]
+        trims = [_trim(1, Decimal("10.0"), Decimal("20.0"))]
+
+        plans = plan_turn_materialization(turns, trims)
+
+        assert len(plans) == 1
+        keep = plans[0].keep_intervals
+        assert keep == (KeepInterval(0.0, 10.0), KeepInterval(20.0, 400.0))
+        assert all(
+            isinstance(iv.start, float) and isinstance(iv.end, float)
+            for iv in keep
+        )
+
+    def test_input_dicts_are_not_mutated(self):
+        """Coercion must copy rows, never mutate the caller's dicts."""
+        turn = _turn(1, 410, Decimal("21195.0"), Decimal("21196.0"))
+
+        plan_turn_materialization([turn], [])
+
+        assert isinstance(turn["start_seconds"], Decimal)
+        assert isinstance(turn["end_seconds"], Decimal)


### PR DESCRIPTION
Found during the live dev validation of #117's chain (chapter 410, video QQIRmbU7UJ0).

## Bug

`speaker_turn_videos` failed with `TypeError: unsupported operand type(s) for +: 'decimal.Decimal' and 'float'` at `plan_turn_materialization` — the short-turn group-gap comparison (`prev["end_seconds"] + GROUP_GAP_TOLERANCE_SECS`) mixes Postgres NUMERIC values (delivered as `decimal.Decimal` by psycopg2) with a float tolerance. Latent since #88: the Aug-18 e2e only exercised long turns, which never enter the grouping branch; chapter 410 has 1-second turns.

## Fix

Coerce `start_seconds`/`end_seconds` to `float` on row copies at the `plan_turn_materialization` boundary (turns AND trims) — covers duration math, grouping, and keep-interval inversion for every caller. Input dicts are not mutated.

## Test plan

- [x] TDD: `TestDecimalInputs` (3 tests) reproduced the TypeError RED, now GREEN
- [x] `uv run pytest` — 2582 passed, 1 skipped
- [ ] Re-run `speaker_turn_videos` for chapter 410 on dev after merge (live validation continues)