### PR TITLE
feat(storage): canonical orador path helpers (Slice 1 of #133)

### DIFF
--- a/congress_videos/config/paths.py
+++ b/congress_videos/config/paths.py
@@ -224,6 +224,77 @@ def get_turn_video_path(date: str, video_id: str, turn_id: int) -> str:
     return f"{get_download_video_path(date, video_id)}/turns/{turn_id}/turn_video.mp4"
 
 
+# ---------------------------------------------------------------------------
+# Canonical per-channel speaker-turn artifact layout
+# {PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/{artifact}
+# See epic #133 for storage layout specification.
+#
+# NOTE: DEFAULT_CHANNEL is resolved via a function-local import of
+# congress_videos.config.youtube_channels.DEFAULT_CHANNEL at call time.
+# A top-level import would create a circular dependency because
+# youtube_channels.py imports YOUTUBE_TOKEN_FILE and YOUTUBE_TOKENS_DIR
+# from this module (paths.py).
+# ---------------------------------------------------------------------------
+
+
+def get_orador_video_dir(
+    source_video_id: str,
+    chapter_id: int,
+    output_turn_id: int,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the oradores turn directory path (no side effects, no mkdir).
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        output_turn_id:  Database turn ID for the output video (e.g. ``42``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to ``{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/
+        video_chapters/{chapter_id}/oradores/{output_turn_id}/``.
+    """
+    if channel_slug is None:
+        # Function-local import avoids paths <-> youtube_channels circular dependency.
+        from congress_videos.config.youtube_channels import DEFAULT_CHANNEL  # noqa: PLC0415
+        channel_slug = DEFAULT_CHANNEL
+    return Path(
+        f"{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}"
+        f"/video_chapters/{chapter_id}/oradores/{output_turn_id}"
+    )
+
+
+def get_orador_artifact_path(
+    source_video_id: str,
+    chapter_id: int,
+    output_turn_id: int,
+    filename: str,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the path to a named artifact inside the orador turn directory.
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        output_turn_id:  Database turn ID for the output video (e.g. ``42``).
+        filename:        Artifact filename (e.g. ``"video.mp4"``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to the artifact file inside the orador turn directory.
+    """
+    return get_orador_video_dir(
+        source_video_id, chapter_id, output_turn_id, channel_slug
+    ) / filename
+
+
 # -------------------------
 # Path Validation
 # -------------------------

--- a/tests/congress_videos/config/test_paths.py
+++ b/tests/congress_videos/config/test_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +23,8 @@ from congress_videos.config.paths import (
     get_download_date_path,
     get_download_file_path,
     get_download_video_path,
+    get_orador_artifact_path,
+    get_orador_video_dir,
     get_session_path,
     get_topic_path,
     get_video_path,
@@ -246,3 +249,110 @@ class TestEnsureDirectoryExists:
         result = ensure_directory_exists(nested)
         assert os.path.isdir(nested)
         assert result == nested
+
+
+# ---------------------------------------------------------------------------
+# get_orador_video_dir — T1
+# ---------------------------------------------------------------------------
+
+class TestGetOradorVideoDir:
+    """Tests for get_orador_video_dir helper (canonical speaker-turn layout)."""
+
+    def test_default_channel_slug(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        assert result == Path(f"{PROJECT_DATA_DIR}/congreso-es-tv/abc123/video_chapters/7/oradores/42")
+
+    def test_custom_channel_slug(self):
+        result = get_orador_video_dir("abc123", 7, 42, channel_slug="otro-canal")
+        assert result == Path(f"{PROJECT_DATA_DIR}/otro-canal/abc123/video_chapters/7/oradores/42")
+
+    def test_integer_ids_coerce_to_string_form(self):
+        result = get_orador_video_dir("vid1", 10, 99)
+        path_str = str(result)
+        assert "/10/" in path_str
+        assert path_str.endswith("/99")
+
+    def test_string_ids_identical_to_integer_ids(self):
+        assert get_orador_video_dir("vid1", "10", "99") == get_orador_video_dir("vid1", 10, 99)
+
+    def test_no_directory_created(self, tmp_path):
+        result = get_orador_video_dir("nosuchvid", 1, 1)
+        assert not result.exists()
+
+    def test_return_type_is_path(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        assert isinstance(result, Path)
+
+    def test_exact_segment_sequence(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        parts = result.parts
+        # Verify canonical order in the trailing segments
+        idx = parts.index("congreso-es-tv")
+        assert parts[idx] == "congreso-es-tv"
+        assert parts[idx + 1] == "abc123"
+        assert parts[idx + 2] == "video_chapters"
+        assert parts[idx + 3] == "7"
+        assert parts[idx + 4] == "oradores"
+        assert parts[idx + 5] == "42"
+
+
+# ---------------------------------------------------------------------------
+# get_orador_artifact_path — T2
+# ---------------------------------------------------------------------------
+
+class TestGetOradorArtifactPath:
+    """Tests for get_orador_artifact_path helper."""
+
+    def test_video_artifact_path(self):
+        result = get_orador_artifact_path("abc123", 7, 42, "video.mp4")
+        assert result == get_orador_video_dir("abc123", 7, 42) / "video.mp4"
+
+    @pytest.mark.parametrize("filename", [
+        "video.mp4",
+        "subtitles.srt",
+        "thumbnail.png",
+        "title.txt",
+        "description.txt",
+    ])
+    def test_all_five_artifact_filenames(self, filename: str):
+        result = get_orador_artifact_path("abc123", 7, 42, filename)
+        assert result.name == filename
+        assert result.parent == get_orador_video_dir("abc123", 7, 42)
+
+    def test_composition_via_get_orador_video_dir(self):
+        src, chap, turn, name = "somevid", 3, 17, "thumbnail.png"
+        result = get_orador_artifact_path(src, chap, turn, name)
+        assert result == get_orador_video_dir(src, chap, turn) / name
+
+    def test_no_directory_created(self):
+        result = get_orador_artifact_path("nosuchvid", 1, 1, "video.mp4")
+        assert not result.parent.exists()
+
+    def test_return_type_is_path(self):
+        result = get_orador_artifact_path("abc123", 7, 42, "title.txt")
+        assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# TestOradorHelpersImportPurity — T3
+# ---------------------------------------------------------------------------
+
+class TestOradorHelpersImportPurity:
+    """Tests that helpers are pure, deterministic, and importable without Airflow."""
+
+    def test_deterministic_video_dir(self):
+        args = ("myvid", 5, 10)
+        assert get_orador_video_dir(*args) == get_orador_video_dir(*args)
+
+    def test_deterministic_artifact_path(self):
+        args = ("myvid", 5, 10, "video.mp4")
+        assert get_orador_artifact_path(*args) == get_orador_artifact_path(*args)
+
+    def test_import_requires_only_pathlib_and_config(self):
+        # Re-import inside the test body to confirm no Airflow/DB dependency at import time.
+        from congress_videos.config.paths import (  # noqa: PLC0415
+            get_orador_artifact_path as _a,
+            get_orador_video_dir as _v,
+        )
+        assert callable(_v)
+        assert callable(_a)


### PR DESCRIPTION
## Slice 1 of epic #133 — per-channel artifact hierarchy

Foundation slice: two **pure, additive** helpers in `congress_videos/config/paths.py` that build the canonical artifact layout. **Zero callers changed, no DB migration** — this only adds the path vocabulary that Slices 2–7 will wire up.

### Canonical layout
```
{PROJECT_DATA_DIR}/congreso-es-tv/{source_video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/{artifact}
```
Artifacts co-located: `video.mp4`, `subtitles.srt`, `thumbnail.png`, `title.txt`, `description.txt`.

### New helpers
- `get_orador_video_dir(source_video_id, chapter_id, output_turn_id, channel_slug=None) -> Path` — the `oradores/{output_turn_id}/` directory.
- `get_orador_artifact_path(..., filename, channel_slug=None) -> Path` — a specific artifact within it (DRY: composes the dir helper).

Both mirror `get_thumbnail_dir`: return `Path`, **no mkdir**, pure/deterministic.

### Design note — circular import
`config/youtube_channels.py` already imports from `config/paths.py`, so a top-level `from ...youtube_channels import DEFAULT_CHANNEL` in `paths.py` would cycle. Resolved with a **function-local import** + `channel_slug=None` sentinel: default calls still yield `congreso-es-tv`, single source of truth, no cycle, no duplicated literal.

### Tests
- 19 new tests in `tests/congress_videos/config/test_paths.py` covering all 14 spec scenarios (segment order, int→str coercion, all 5 artifact filenames, default/custom slug, no-mkdir, purity, import-without-cycle).
- Full suite: **2621 passed, 1 skipped, 86.18% coverage**.

### Scope
`+181` lines across 2 files (`paths.py`, `test_paths.py`). Within the 400-line review budget.

Part of #133 (epic — do not auto-close).