### PR TITLE
feat(storage): materialize turn videos at canonical orador path (Slice 2 of #133)

### DIFF
--- a/congress_videos/config/paths.py
+++ b/congress_videos/config/paths.py
@@ -224,6 +224,77 @@ def get_turn_video_path(date: str, video_id: str, turn_id: int) -> str:
     return f"{get_download_video_path(date, video_id)}/turns/{turn_id}/turn_video.mp4"
 
 
+# ---------------------------------------------------------------------------
+# Canonical per-channel speaker-turn artifact layout
+# {PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/{artifact}
+# See epic #133 for storage layout specification.
+#
+# NOTE: DEFAULT_CHANNEL is resolved via a function-local import of
+# congress_videos.config.youtube_channels.DEFAULT_CHANNEL at call time.
+# A top-level import would create a circular dependency because
+# youtube_channels.py imports YOUTUBE_TOKEN_FILE and YOUTUBE_TOKENS_DIR
+# from this module (paths.py).
+# ---------------------------------------------------------------------------
+
+
+def get_orador_video_dir(
+    source_video_id: str,
+    chapter_id: int,
+    output_turn_id: int,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the oradores turn directory path (no side effects, no mkdir).
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        output_turn_id:  Database turn ID for the output video (e.g. ``42``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to ``{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/
+        video_chapters/{chapter_id}/oradores/{output_turn_id}/``.
+    """
+    if channel_slug is None:
+        # Function-local import avoids paths <-> youtube_channels circular dependency.
+        from congress_videos.config.youtube_channels import DEFAULT_CHANNEL  # noqa: PLC0415
+        channel_slug = DEFAULT_CHANNEL
+    return Path(
+        f"{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}"
+        f"/video_chapters/{chapter_id}/oradores/{output_turn_id}"
+    )
+
+
+def get_orador_artifact_path(
+    source_video_id: str,
+    chapter_id: int,
+    output_turn_id: int,
+    filename: str,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the path to a named artifact inside the orador turn directory.
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        output_turn_id:  Database turn ID for the output video (e.g. ``42``).
+        filename:        Artifact filename (e.g. ``"video.mp4"``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to the artifact file inside the orador turn directory.
+    """
+    return get_orador_video_dir(
+        source_video_id, chapter_id, output_turn_id, channel_slug
+    ) / filename
+
+
 # -------------------------
 # Path Validation
 # -------------------------

--- a/congress_videos/speaker_turn_videos_dag.py
+++ b/congress_videos/speaker_turn_videos_dag.py
@@ -42,7 +42,7 @@ from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 
-from congress_videos.config.paths import DOWNLOADS_DIR, get_turn_video_path
+from congress_videos.config.paths import DOWNLOADS_DIR, get_orador_video_dir
 from congress_videos.modules.materialization import plan_turn_materialization
 from congress_videos.modules.materialization_executor import execute_plan
 from utils.codec_detection import get_cached_codec
@@ -196,13 +196,13 @@ def _materialize_task(**context) -> dict:
                 summary["skipped"] += len(plan.turn_ids)
                 continue
 
-            # Recording date is not stored in the DB; derive it from the folder
-            # the source video was found in, for the canonical output path.
-            session_date = _date_from_source_path(source_path)
-
-            # Derive output path using first (naming) turn_id
-            output_path = get_turn_video_path(
-                session_date, video_id, plan.output_turn_id
+            # Canonical date-free output path keyed on stable DB identifiers.
+            # chapter_id is typed int (non-optional dataclass field) and is
+            # always populated by plan_turn_materialization from the DB column;
+            # no None guard is needed.
+            output_path = str(
+                get_orador_video_dir(video_id, plan.chapter_id, plan.output_turn_id)
+                / "video.mp4"
             )
 
             try:

--- a/tests/congress_videos/config/test_paths.py
+++ b/tests/congress_videos/config/test_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +23,8 @@ from congress_videos.config.paths import (
     get_download_date_path,
     get_download_file_path,
     get_download_video_path,
+    get_orador_artifact_path,
+    get_orador_video_dir,
     get_session_path,
     get_topic_path,
     get_video_path,
@@ -246,3 +249,110 @@ class TestEnsureDirectoryExists:
         result = ensure_directory_exists(nested)
         assert os.path.isdir(nested)
         assert result == nested
+
+
+# ---------------------------------------------------------------------------
+# get_orador_video_dir — T1
+# ---------------------------------------------------------------------------
+
+class TestGetOradorVideoDir:
+    """Tests for get_orador_video_dir helper (canonical speaker-turn layout)."""
+
+    def test_default_channel_slug(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        assert result == Path(f"{PROJECT_DATA_DIR}/congreso-es-tv/abc123/video_chapters/7/oradores/42")
+
+    def test_custom_channel_slug(self):
+        result = get_orador_video_dir("abc123", 7, 42, channel_slug="otro-canal")
+        assert result == Path(f"{PROJECT_DATA_DIR}/otro-canal/abc123/video_chapters/7/oradores/42")
+
+    def test_integer_ids_coerce_to_string_form(self):
+        result = get_orador_video_dir("vid1", 10, 99)
+        path_str = str(result)
+        assert "/10/" in path_str
+        assert path_str.endswith("/99")
+
+    def test_string_ids_identical_to_integer_ids(self):
+        assert get_orador_video_dir("vid1", "10", "99") == get_orador_video_dir("vid1", 10, 99)
+
+    def test_no_directory_created(self, tmp_path):
+        result = get_orador_video_dir("nosuchvid", 1, 1)
+        assert not result.exists()
+
+    def test_return_type_is_path(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        assert isinstance(result, Path)
+
+    def test_exact_segment_sequence(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        parts = result.parts
+        # Verify canonical order in the trailing segments
+        idx = parts.index("congreso-es-tv")
+        assert parts[idx] == "congreso-es-tv"
+        assert parts[idx + 1] == "abc123"
+        assert parts[idx + 2] == "video_chapters"
+        assert parts[idx + 3] == "7"
+        assert parts[idx + 4] == "oradores"
+        assert parts[idx + 5] == "42"
+
+
+# ---------------------------------------------------------------------------
+# get_orador_artifact_path — T2
+# ---------------------------------------------------------------------------
+
+class TestGetOradorArtifactPath:
+    """Tests for get_orador_artifact_path helper."""
+
+    def test_video_artifact_path(self):
+        result = get_orador_artifact_path("abc123", 7, 42, "video.mp4")
+        assert result == get_orador_video_dir("abc123", 7, 42) / "video.mp4"
+
+    @pytest.mark.parametrize("filename", [
+        "video.mp4",
+        "subtitles.srt",
+        "thumbnail.png",
+        "title.txt",
+        "description.txt",
+    ])
+    def test_all_five_artifact_filenames(self, filename: str):
+        result = get_orador_artifact_path("abc123", 7, 42, filename)
+        assert result.name == filename
+        assert result.parent == get_orador_video_dir("abc123", 7, 42)
+
+    def test_composition_via_get_orador_video_dir(self):
+        src, chap, turn, name = "somevid", 3, 17, "thumbnail.png"
+        result = get_orador_artifact_path(src, chap, turn, name)
+        assert result == get_orador_video_dir(src, chap, turn) / name
+
+    def test_no_directory_created(self):
+        result = get_orador_artifact_path("nosuchvid", 1, 1, "video.mp4")
+        assert not result.parent.exists()
+
+    def test_return_type_is_path(self):
+        result = get_orador_artifact_path("abc123", 7, 42, "title.txt")
+        assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# TestOradorHelpersImportPurity — T3
+# ---------------------------------------------------------------------------
+
+class TestOradorHelpersImportPurity:
+    """Tests that helpers are pure, deterministic, and importable without Airflow."""
+
+    def test_deterministic_video_dir(self):
+        args = ("myvid", 5, 10)
+        assert get_orador_video_dir(*args) == get_orador_video_dir(*args)
+
+    def test_deterministic_artifact_path(self):
+        args = ("myvid", 5, 10, "video.mp4")
+        assert get_orador_artifact_path(*args) == get_orador_artifact_path(*args)
+
+    def test_import_requires_only_pathlib_and_config(self):
+        # Re-import inside the test body to confirm no Airflow/DB dependency at import time.
+        from congress_videos.config.paths import (  # noqa: PLC0415
+            get_orador_artifact_path as _a,
+            get_orador_video_dir as _v,
+        )
+        assert callable(_v)
+        assert callable(_a)

--- a/tests/congress_videos/test_speaker_turn_videos_dag.py
+++ b/tests/congress_videos/test_speaker_turn_videos_dag.py
@@ -12,6 +12,7 @@ Test organisation:
 from __future__ import annotations
 
 import importlib
+import re
 import sys
 from datetime import date
 from unittest.mock import MagicMock, call
@@ -178,6 +179,79 @@ class TestMaterializeTurns:
             "end_seconds": end,
         }
 
+    def test_canonical_path_in_insert(self, monkeypatch):
+        """TDD RED→GREEN: _materialize_task must store a canonical date-free path.
+
+        Asserts:
+        1. The INSERT output_path contains the canonical layout
+           /congreso-es-tv/{video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/video.mp4
+        2. output_path does NOT contain '/turns/'
+        3. output_path does NOT contain a YYYY-MM-DD date segment
+        4. The same output_path value is passed to execute_plan (wiring assertion)
+        """
+        mod = _fresh()
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: "/data/src.mp4")
+
+        plan_mock = MagicMock()
+        plan_mock.turn_ids = (7,)
+        plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
+        plan_mock.needs_reencode = False
+        plan_mock.output_turn_id = 7
+        plan_mock.chapter_id = 3
+
+        execute_plan_mock = MagicMock()
+        monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
+        monkeypatch.setattr(mod, "execute_plan", execute_plan_mock)
+        monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
+
+        pg = MagicMock()
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        cur.description = [("turn_id",), ("start_seconds",), ("end_seconds",),
+                           ("is_approved",), ("is_voice_free",)]
+        conn.cursor.return_value.__enter__.return_value = cur
+        pg.get_connection.return_value.__enter__.return_value = conn
+        pg.get_qualified_table.side_effect = lambda n: f"test.{n}"
+        monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = [self._turn(video_id="abc123", chapter_id=3)]
+
+        mod._materialize_task(ti=ti, dag_run=MagicMock(conf={}))
+
+        # Capture INSERT call args
+        all_calls = cur.execute.call_args_list
+        insert_calls = [c for c in all_calls if "INSERT" in str(c).upper()]
+        assert len(insert_calls) >= 1, f"Expected INSERT call; got: {all_calls}"
+
+        # The second positional arg in the INSERT VALUES tuple is output_path
+        insert_args = insert_calls[0].args
+        # args[1] is the params tuple: (tid, output_path)
+        output_path = insert_args[1][1]
+
+        # Assertion 1: canonical path shape
+        assert "/congreso-es-tv/abc123/video_chapters/3/oradores/7/video.mp4" in output_path, (
+            f"Expected canonical path in INSERT output_path; got: {output_path}"
+        )
+
+        # Assertion 2: no legacy /turns/ segment
+        assert "/turns/" not in output_path, (
+            f"output_path must not contain '/turns/'; got: {output_path}"
+        )
+
+        # Assertion 3: no date segment
+        assert re.search(r"\d{4}-\d{2}-\d{2}", output_path) is None, (
+            f"output_path must not contain a date segment; got: {output_path}"
+        )
+
+        # Assertion 4: wiring — same value passed to execute_plan
+        execute_plan_positional_output_path = execute_plan_mock.call_args.args[2]
+        assert execute_plan_positional_output_path == output_path, (
+            f"execute_plan received different output_path than INSERT: "
+            f"execute_plan={execute_plan_positional_output_path!r} vs INSERT={output_path!r}"
+        )
+
     def test_missing_source_video_skips_without_ffmpeg(self, monkeypatch):
         mod = _fresh()
         monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: None)
@@ -209,6 +283,7 @@ class TestMaterializeTurns:
         plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
         plan_mock.needs_reencode = False
         plan_mock.output_turn_id = 7
+        plan_mock.chapter_id = 3
 
         monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
         monkeypatch.setattr(mod, "execute_plan", lambda *a, **kw: None)
@@ -216,7 +291,8 @@ class TestMaterializeTurns:
             "congress_videos.modules.materialization_executor.get_cached_codec",
             lambda path, cache: "h264",
         )
-        monkeypatch.setattr(mod, "get_turn_video_path", lambda date, vid, tid: f"/out/{tid}.mp4")
+        from pathlib import Path
+        monkeypatch.setattr(mod, "get_orador_video_dir", lambda vid, chid, tid: Path(f"/out/{tid}"))
         monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
 
         pg = MagicMock()
@@ -251,10 +327,12 @@ class TestMaterializeTurns:
         plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
         plan_mock.needs_reencode = False
         plan_mock.output_turn_id = 7
+        plan_mock.chapter_id = 3
 
         monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
         monkeypatch.setattr(mod, "execute_plan", MagicMock(side_effect=RuntimeError("ffmpeg boom")))
-        monkeypatch.setattr(mod, "get_turn_video_path", lambda date, vid, tid: f"/out/{tid}.mp4")
+        from pathlib import Path
+        monkeypatch.setattr(mod, "get_orador_video_dir", lambda vid, chid, tid: Path(f"/out/{tid}"))
         monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
 
         pg = MagicMock()


### PR DESCRIPTION
## Slice 2 of epic #133 — per-channel artifact hierarchy

**Stacked on #134 (Slice 1).** Targets the Slice 1 branch; retarget to `dev` once #134 merges.

Switches the speaker-turn video write path in `_materialize_task` from the legacy date-keyed scheme to the canonical helper introduced in Slice 1.

### The change (surgical)
```python
# before: downloads/{date}/{video_id}/turns/{turn_id}/turn_video.mp4
output_path = get_turn_video_path(session_date, video_id, plan.output_turn_id)
# after: .../congreso-es-tv/{video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/video.mp4
output_path = str(get_orador_video_dir(video_id, plan.chapter_id, plan.output_turn_id) / "video.mp4")
```
The single computed `output_path` flows to **both** `execute_plan` and the `speaker_turn_videos` INSERT — no divergence. `execute_plan` already `makedirs`, so no callsite mkdir.

### Resolves #130
Dropping the calendar-date directory segment structurally fixes the wrong-date landing reported in #130. No date lookup, no migration — the path is derived from stable DB identifiers.

### Dual-read coexistence (locked product decision)
- New rows store the canonical path.
- Existing rows and files are **untouched** — no backfill, no file move.
- Uploader read-fallback (try canonical, fall back to legacy `output_path`) is **Slice 3**.
- `get_turn_video_path` kept in `paths.py` (Slice 7 removes it). `_date_from_source_path` is now unused in the DAG module — flagged for Slice 7, left in place here.

### Tests
- New `test_canonical_path_in_insert`: 4 assertions (canonical shape, no `/turns/`, no date segment, `execute_plan`↔INSERT wiring equality).
- 2 existing tests retargeted.
- Full suite: **2622 passed, 86.16% coverage**. Diff: 2 files, +88/-10.

Part of #133 (epic — do not auto-close).