### PR TITLE
feat(storage): write turn thumbnail to canonical orador path (Slice 4a of #133)

### DIFF
--- a/congress_videos/config/paths.py
+++ b/congress_videos/config/paths.py
@@ -224,6 +224,77 @@ def get_turn_video_path(date: str, video_id: str, turn_id: int) -> str:
     return f"{get_download_video_path(date, video_id)}/turns/{turn_id}/turn_video.mp4"
 
 
+# ---------------------------------------------------------------------------
+# Canonical per-channel speaker-turn artifact layout
+# {PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/{artifact}
+# See epic #133 for storage layout specification.
+#
+# NOTE: DEFAULT_CHANNEL is resolved via a function-local import of
+# congress_videos.config.youtube_channels.DEFAULT_CHANNEL at call time.
+# A top-level import would create a circular dependency because
+# youtube_channels.py imports YOUTUBE_TOKEN_FILE and YOUTUBE_TOKENS_DIR
+# from this module (paths.py).
+# ---------------------------------------------------------------------------
+
+
+def get_orador_video_dir(
+    source_video_id: str,
+    chapter_id: int,
+    output_turn_id: int,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the oradores turn directory path (no side effects, no mkdir).
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        output_turn_id:  Database turn ID for the output video (e.g. ``42``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to ``{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/
+        video_chapters/{chapter_id}/oradores/{output_turn_id}/``.
+    """
+    if channel_slug is None:
+        # Function-local import avoids paths <-> youtube_channels circular dependency.
+        from congress_videos.config.youtube_channels import DEFAULT_CHANNEL  # noqa: PLC0415
+        channel_slug = DEFAULT_CHANNEL
+    return Path(
+        f"{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}"
+        f"/video_chapters/{chapter_id}/oradores/{output_turn_id}"
+    )
+
+
+def get_orador_artifact_path(
+    source_video_id: str,
+    chapter_id: int,
+    output_turn_id: int,
+    filename: str,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the path to a named artifact inside the orador turn directory.
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        output_turn_id:  Database turn ID for the output video (e.g. ``42``).
+        filename:        Artifact filename (e.g. ``"video.mp4"``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to the artifact file inside the orador turn directory.
+    """
+    return get_orador_video_dir(
+        source_video_id, chapter_id, output_turn_id, channel_slug
+    ) / filename
+
+
 # -------------------------
 # Path Validation
 # -------------------------

--- a/congress_videos/generic_thumbnail_generator_dag.py
+++ b/congress_videos/generic_thumbnail_generator_dag.py
@@ -36,7 +36,9 @@ Pipeline overview::
 
 from __future__ import annotations
 
+import os
 import pathlib
+import shutil
 from datetime import datetime, timedelta, timezone
 
 from airflow import DAG
@@ -184,7 +186,13 @@ def _task_download_option(label: str, ti: TaskInstance, **context: object) -> di
     gen_result: dict = ti.xcom_pull(task_ids=f"generate_thumbnail_{label}") or {}
 
     output_url: str = gen_result.get("output") or gen_result.get("output_url", "")
-    thumb_dir = get_thumbnail_dir(conf["youtube_video_id"])
+    _output_path = conf.get("output_path")
+    if _output_path:
+        # Turn-type item: co-locate thumbnail beside video.mp4 in the canonical dir.
+        thumb_dir = pathlib.Path(os.path.dirname(_output_path))
+    else:
+        # Chapter-type or standalone trigger: use the legacy thumbnail directory.
+        thumb_dir = get_thumbnail_dir(conf["youtube_video_id"])
     local_path = thumb_dir / f"{label}.png"
 
     _pkz.download(output_url, str(local_path))
@@ -265,15 +273,52 @@ def _task_persist_results(ti: TaskInstance, **context: object) -> None:
     )
 
 
+def _persist_canonical_thumbnail(best_local_path: str, canonical_dir: pathlib.Path) -> str:
+    """Copy the chosen best option to thumbnail.png in the canonical directory.
+
+    This reconciliation step ensures the final artifact is always named
+    ``thumbnail.png`` beside ``video.mp4`` for turn-type items, regardless
+    of which option label (option_a / option_b) was selected as the best.
+
+    Args:
+        best_local_path: Absolute path of the best-scored PNG (e.g. .../option_a.png).
+        canonical_dir: Parent directory derived from conf['output_path'] (anchor folder).
+
+    Returns:
+        Absolute path of the resulting ``thumbnail.png`` file.
+    """
+    canonical_thumbnail = canonical_dir / "thumbnail.png"
+    shutil.copy(best_local_path, str(canonical_thumbnail))
+    return str(canonical_thumbnail)
+
+
 def _task_thumbnail_result(ti: TaskInstance, **context: object) -> dict:
-    """Expose the persisted generation result to the DAG that triggered this run."""
+    """Expose the persisted generation result to the DAG that triggered this run.
+
+    For turn-type items (canonical path): copies the best option to thumbnail.png
+    in the canonical directory and returns that path as output_path.
+    For chapter-type or standalone triggers (legacy path): returns best local_path
+    unchanged.
+    """
     conf: dict = ti.xcom_pull(task_ids="validate_input") or {}
     best: dict = ti.xcom_pull(task_ids="choose_best_option") or {}
     title: str = ti.xcom_pull(task_ids="generate_title") or ""
+
+    best_local_path: str | None = best.get("local_path")
+    _conf_output_path = conf.get("output_path")
+
+    if _conf_output_path and best_local_path:
+        # Turn-type canonical path: reconcile to thumbnail.png.
+        canonical_dir = pathlib.Path(os.path.dirname(_conf_output_path))
+        output_path = _persist_canonical_thumbnail(best_local_path, canonical_dir)
+    else:
+        # Legacy chapter path or standalone trigger: use best local_path as-is.
+        output_path = best_local_path
+
     return {
         "chapter_id": int(conf["chapter_id"]),
         "success": True,
-        "output_path": best.get("local_path"),
+        "output_path": output_path,
         "title": title,
     }
 

--- a/congress_videos/speaker_turn_videos_dag.py
+++ b/congress_videos/speaker_turn_videos_dag.py
@@ -42,7 +42,7 @@ from datetime import datetime, timedelta, timezone
 from airflow import DAG
 from airflow.operators.python import PythonOperator
 
-from congress_videos.config.paths import DOWNLOADS_DIR, get_turn_video_path
+from congress_videos.config.paths import DOWNLOADS_DIR, get_orador_video_dir
 from congress_videos.modules.materialization import plan_turn_materialization
 from congress_videos.modules.materialization_executor import execute_plan
 from utils.codec_detection import get_cached_codec
@@ -196,13 +196,13 @@ def _materialize_task(**context) -> dict:
                 summary["skipped"] += len(plan.turn_ids)
                 continue
 
-            # Recording date is not stored in the DB; derive it from the folder
-            # the source video was found in, for the canonical output path.
-            session_date = _date_from_source_path(source_path)
-
-            # Derive output path using first (naming) turn_id
-            output_path = get_turn_video_path(
-                session_date, video_id, plan.output_turn_id
+            # Canonical date-free output path keyed on stable DB identifiers.
+            # chapter_id is typed int (non-optional dataclass field) and is
+            # always populated by plan_turn_materialization from the DB column;
+            # no None guard is needed.
+            output_path = str(
+                get_orador_video_dir(video_id, plan.chapter_id, plan.output_turn_id)
+                / "video.mp4"
             )
 
             try:

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -213,6 +213,11 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
         "key_speakers": key_speakers,
     }
 
+    # Thread the canonical output_path for turn-type items (Slice 4a).
+    # Chapter-type items never have output_path — key is absent by design.
+    if is_turn:
+        config["output_path"] = chapter.get("output_path")
+
     # Resolve SRT fragment for lapidary quote extraction (issue #57).
     video_id = chapter.get("video_id")
     srt_path = (
@@ -290,6 +295,8 @@ def trigger_thumbnail_generation(ti, **context) -> str | None:
     }
     if "srt_fragment" in thumbnail_config:
         child_conf["srt_fragment"] = thumbnail_config["srt_fragment"]
+    if thumbnail_config.get("output_path"):
+        child_conf["output_path"] = thumbnail_config["output_path"]
     try:
         dag_run = trigger_dag_api(
             dag_id=_THUMBNAIL_DAG_ID,

--- a/tests/congress_videos/config/test_paths.py
+++ b/tests/congress_videos/config/test_paths.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 
 import pytest
 
@@ -22,6 +23,8 @@ from congress_videos.config.paths import (
     get_download_date_path,
     get_download_file_path,
     get_download_video_path,
+    get_orador_artifact_path,
+    get_orador_video_dir,
     get_session_path,
     get_topic_path,
     get_video_path,
@@ -246,3 +249,110 @@ class TestEnsureDirectoryExists:
         result = ensure_directory_exists(nested)
         assert os.path.isdir(nested)
         assert result == nested
+
+
+# ---------------------------------------------------------------------------
+# get_orador_video_dir — T1
+# ---------------------------------------------------------------------------
+
+class TestGetOradorVideoDir:
+    """Tests for get_orador_video_dir helper (canonical speaker-turn layout)."""
+
+    def test_default_channel_slug(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        assert result == Path(f"{PROJECT_DATA_DIR}/congreso-es-tv/abc123/video_chapters/7/oradores/42")
+
+    def test_custom_channel_slug(self):
+        result = get_orador_video_dir("abc123", 7, 42, channel_slug="otro-canal")
+        assert result == Path(f"{PROJECT_DATA_DIR}/otro-canal/abc123/video_chapters/7/oradores/42")
+
+    def test_integer_ids_coerce_to_string_form(self):
+        result = get_orador_video_dir("vid1", 10, 99)
+        path_str = str(result)
+        assert "/10/" in path_str
+        assert path_str.endswith("/99")
+
+    def test_string_ids_identical_to_integer_ids(self):
+        assert get_orador_video_dir("vid1", "10", "99") == get_orador_video_dir("vid1", 10, 99)
+
+    def test_no_directory_created(self, tmp_path):
+        result = get_orador_video_dir("nosuchvid", 1, 1)
+        assert not result.exists()
+
+    def test_return_type_is_path(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        assert isinstance(result, Path)
+
+    def test_exact_segment_sequence(self):
+        result = get_orador_video_dir("abc123", 7, 42)
+        parts = result.parts
+        # Verify canonical order in the trailing segments
+        idx = parts.index("congreso-es-tv")
+        assert parts[idx] == "congreso-es-tv"
+        assert parts[idx + 1] == "abc123"
+        assert parts[idx + 2] == "video_chapters"
+        assert parts[idx + 3] == "7"
+        assert parts[idx + 4] == "oradores"
+        assert parts[idx + 5] == "42"
+
+
+# ---------------------------------------------------------------------------
+# get_orador_artifact_path — T2
+# ---------------------------------------------------------------------------
+
+class TestGetOradorArtifactPath:
+    """Tests for get_orador_artifact_path helper."""
+
+    def test_video_artifact_path(self):
+        result = get_orador_artifact_path("abc123", 7, 42, "video.mp4")
+        assert result == get_orador_video_dir("abc123", 7, 42) / "video.mp4"
+
+    @pytest.mark.parametrize("filename", [
+        "video.mp4",
+        "subtitles.srt",
+        "thumbnail.png",
+        "title.txt",
+        "description.txt",
+    ])
+    def test_all_five_artifact_filenames(self, filename: str):
+        result = get_orador_artifact_path("abc123", 7, 42, filename)
+        assert result.name == filename
+        assert result.parent == get_orador_video_dir("abc123", 7, 42)
+
+    def test_composition_via_get_orador_video_dir(self):
+        src, chap, turn, name = "somevid", 3, 17, "thumbnail.png"
+        result = get_orador_artifact_path(src, chap, turn, name)
+        assert result == get_orador_video_dir(src, chap, turn) / name
+
+    def test_no_directory_created(self):
+        result = get_orador_artifact_path("nosuchvid", 1, 1, "video.mp4")
+        assert not result.parent.exists()
+
+    def test_return_type_is_path(self):
+        result = get_orador_artifact_path("abc123", 7, 42, "title.txt")
+        assert isinstance(result, Path)
+
+
+# ---------------------------------------------------------------------------
+# TestOradorHelpersImportPurity — T3
+# ---------------------------------------------------------------------------
+
+class TestOradorHelpersImportPurity:
+    """Tests that helpers are pure, deterministic, and importable without Airflow."""
+
+    def test_deterministic_video_dir(self):
+        args = ("myvid", 5, 10)
+        assert get_orador_video_dir(*args) == get_orador_video_dir(*args)
+
+    def test_deterministic_artifact_path(self):
+        args = ("myvid", 5, 10, "video.mp4")
+        assert get_orador_artifact_path(*args) == get_orador_artifact_path(*args)
+
+    def test_import_requires_only_pathlib_and_config(self):
+        # Re-import inside the test body to confirm no Airflow/DB dependency at import time.
+        from congress_videos.config.paths import (  # noqa: PLC0415
+            get_orador_artifact_path as _a,
+            get_orador_video_dir as _v,
+        )
+        assert callable(_v)
+        assert callable(_a)

--- a/tests/congress_videos/modules/test_generic_thumbnail_dag.py
+++ b/tests/congress_videos/modules/test_generic_thumbnail_dag.py
@@ -1184,3 +1184,194 @@ class TestTaskGenerateTitleKeySpeakers:
         # Must not raise KeyError
         dag_mod._task_generate_title(ti)
         mock_generate_title.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# thumbnail-canonical-path (Slice 4a): canonical download path + reconciliation
+# ---------------------------------------------------------------------------
+
+
+class TestTaskDownloadOptionCanonicalPath:
+    """_task_download_option must write to dirname(output_path) for turn-type items,
+    fall back to get_thumbnail_dir for chapter/standalone items.
+
+    Reconciliation: _task_thumbnail_result must return output_path ending in
+    'thumbnail.png' when the canonical write was used.
+    """
+
+    def test_turn_conf_writes_to_dirname_of_output_path(self, mocker) -> None:
+        """output_path in conf → _pkz.download called with path in dirname(output_path)."""
+        import congress_videos.generic_thumbnail_generator_dag as dag_mod
+
+        conf_with_output_path = {
+            **_FAKE_CONF,
+            "output_path": "/data/oradores/42/video.mp4",
+        }
+        gen_result = {
+            "output": "https://pikzels.com/generated.png",
+            "label": "option_a",
+            "style": "A",
+            "prompt": "A thick gold border...",
+        }
+        ti = _make_fake_ti(
+            {
+                "validate_input": conf_with_output_path,
+                "generate_thumbnail_option_a": gen_result,
+            }
+        )
+
+        mock_pkz = mocker.patch.object(dag_mod, "_pkz")
+        mock_get_thumbnail_dir = mocker.patch(
+            "congress_videos.generic_thumbnail_generator_dag.get_thumbnail_dir"
+        )
+
+        result = dag_mod._task_download_option("option_a", ti=ti)
+
+        # Must use canonical dir, not get_thumbnail_dir
+        mock_get_thumbnail_dir.assert_not_called()
+        # Must write to dirname(output_path)/option_a.png
+        mock_pkz.download.assert_called_once()
+        _, local_path_str = mock_pkz.download.call_args[0]
+        assert local_path_str.startswith("/data/oradores/42/"), (
+            f"Expected path under /data/oradores/42/, got {local_path_str!r}"
+        )
+        assert local_path_str.endswith("option_a.png"), (
+            f"Expected filename option_a.png, got {local_path_str!r}"
+        )
+
+    def test_chapter_conf_falls_back_to_get_thumbnail_dir(self, mocker) -> None:
+        """No output_path in conf → legacy get_thumbnail_dir is used."""
+        import congress_videos.generic_thumbnail_generator_dag as dag_mod
+
+        gen_result = {
+            "output": "https://pikzels.com/generated.png",
+            "label": "option_a",
+            "style": "A",
+            "prompt": "A thick gold border...",
+        }
+        ti = _make_fake_ti(
+            {
+                "validate_input": _FAKE_CONF,  # no output_path
+                "generate_thumbnail_option_a": gen_result,
+            }
+        )
+
+        mock_pkz = mocker.patch.object(dag_mod, "_pkz")
+        mock_get_thumbnail_dir = mocker.patch(
+            "congress_videos.generic_thumbnail_generator_dag.get_thumbnail_dir",
+            side_effect=lambda vid_id: __import__("pathlib").Path(f"/thumbnails/{vid_id}"),
+        )
+
+        result = dag_mod._task_download_option("option_a", ti=ti)
+
+        mock_get_thumbnail_dir.assert_called_once_with(_FAKE_CONF["youtube_video_id"])
+        _, local_path_str = mock_pkz.download.call_args[0]
+        assert local_path_str.startswith("/thumbnails/"), (
+            f"Expected legacy path under /thumbnails/, got {local_path_str!r}"
+        )
+
+    def test_standalone_trigger_without_output_path_completes(self, mocker) -> None:
+        """Conf with only required keys and no output_path → calls get_thumbnail_dir."""
+        import congress_videos.generic_thumbnail_generator_dag as dag_mod
+
+        standalone_conf = {
+            "youtube_video_id": "abc123",
+            "chapter_id": 7,
+            "debate_summary": "El debate ...",
+            "session": "Pleno 2026-06-10",
+            "domain": "congreso",
+            # No output_path
+        }
+        gen_result = {
+            "output": "https://pikzels.com/generated.png",
+            "label": "option_a",
+            "style": "A",
+            "prompt": "A gold border...",
+        }
+        ti = _make_fake_ti(
+            {
+                "validate_input": standalone_conf,
+                "generate_thumbnail_option_a": gen_result,
+            }
+        )
+
+        mocker.patch.object(dag_mod, "_pkz")
+        mock_get_thumbnail_dir = mocker.patch(
+            "congress_videos.generic_thumbnail_generator_dag.get_thumbnail_dir",
+            side_effect=lambda vid_id: __import__("pathlib").Path(f"/thumbnails/{vid_id}"),
+        )
+
+        dag_mod._task_download_option("option_a", ti=ti)
+
+        mock_get_thumbnail_dir.assert_called_once_with("abc123")
+
+    def test_grouped_turn_both_write_to_same_anchor_dir(self, mocker) -> None:
+        """Two turns with same output_path → both write to the same anchor directory."""
+        import congress_videos.generic_thumbnail_generator_dag as dag_mod
+
+        shared_output_path = "/data/oradores/7/video.mp4"
+        conf_turn1 = {**_FAKE_CONF, "output_path": shared_output_path}
+        conf_turn2 = {**_FAKE_CONF, "output_path": shared_output_path}
+
+        gen_result = {
+            "output": "https://pikzels.com/generated.png",
+            "label": "option_a",
+            "style": "A",
+            "prompt": "A gold border...",
+        }
+
+        paths_written = []
+
+        def _fake_download(url, path_str):
+            paths_written.append(path_str)
+
+        for conf in [conf_turn1, conf_turn2]:
+            ti = _make_fake_ti(
+                {
+                    "validate_input": conf,
+                    "generate_thumbnail_option_a": gen_result,
+                }
+            )
+            mock_pkz = mocker.patch.object(dag_mod, "_pkz")
+            mock_pkz.download.side_effect = _fake_download
+            dag_mod._task_download_option("option_a", ti=ti)
+
+        assert len(paths_written) == 2
+        for p in paths_written:
+            assert p.startswith("/data/oradores/7/"), (
+                f"Both turns must write to /data/oradores/7/, got {p!r}"
+            )
+
+    def test_turn_conf_thumbnail_result_basename_is_thumbnail_png(self, mocker) -> None:
+        """Reconciliation: when canonical path used, _task_thumbnail_result.output_path ends with thumbnail.png."""
+        import congress_videos.generic_thumbnail_generator_dag as dag_mod
+
+        conf_with_output_path = {
+            **_FAKE_CONF,
+            "output_path": "/data/oradores/42/video.mp4",
+        }
+        # Simulate what _task_download_option returns for the canonical path:
+        # local_path = /data/oradores/42/option_a.png
+        ti = _make_fake_ti(
+            {
+                "validate_input": conf_with_output_path,
+                "choose_best_option": {"local_path": "/data/oradores/42/option_a.png"},
+                "generate_title": "Un título canónico",
+            }
+        )
+
+        # Patch the file-copy helper so we don't need a real filesystem
+        mocker.patch.object(
+            dag_mod,
+            "_persist_canonical_thumbnail",
+            side_effect=lambda best_path, canonical_dir: str(canonical_dir / "thumbnail.png"),
+        )
+
+        result = dag_mod._task_thumbnail_result(ti)
+
+        assert result["output_path"].endswith("thumbnail.png"), (
+            f"output_path must end with thumbnail.png for turn-type items, got {result['output_path']!r}"
+        )
+        assert result["output_path"] == "/data/oradores/42/thumbnail.png", (
+            f"output_path must be /data/oradores/42/thumbnail.png, got {result['output_path']!r}"
+        )

--- a/tests/congress_videos/test_speaker_turn_videos_dag.py
+++ b/tests/congress_videos/test_speaker_turn_videos_dag.py
@@ -12,6 +12,7 @@ Test organisation:
 from __future__ import annotations
 
 import importlib
+import re
 import sys
 from datetime import date
 from unittest.mock import MagicMock, call
@@ -178,6 +179,79 @@ class TestMaterializeTurns:
             "end_seconds": end,
         }
 
+    def test_canonical_path_in_insert(self, monkeypatch):
+        """TDD RED→GREEN: _materialize_task must store a canonical date-free path.
+
+        Asserts:
+        1. The INSERT output_path contains the canonical layout
+           /congreso-es-tv/{video_id}/video_chapters/{chapter_id}/oradores/{output_turn_id}/video.mp4
+        2. output_path does NOT contain '/turns/'
+        3. output_path does NOT contain a YYYY-MM-DD date segment
+        4. The same output_path value is passed to execute_plan (wiring assertion)
+        """
+        mod = _fresh()
+        monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: "/data/src.mp4")
+
+        plan_mock = MagicMock()
+        plan_mock.turn_ids = (7,)
+        plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
+        plan_mock.needs_reencode = False
+        plan_mock.output_turn_id = 7
+        plan_mock.chapter_id = 3
+
+        execute_plan_mock = MagicMock()
+        monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
+        monkeypatch.setattr(mod, "execute_plan", execute_plan_mock)
+        monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
+
+        pg = MagicMock()
+        conn = MagicMock()
+        cur = MagicMock()
+        cur.fetchall.return_value = []
+        cur.description = [("turn_id",), ("start_seconds",), ("end_seconds",),
+                           ("is_approved",), ("is_voice_free",)]
+        conn.cursor.return_value.__enter__.return_value = cur
+        pg.get_connection.return_value.__enter__.return_value = conn
+        pg.get_qualified_table.side_effect = lambda n: f"test.{n}"
+        monkeypatch.setattr(mod, "PostgresConnection", lambda: pg)
+
+        ti = MagicMock()
+        ti.xcom_pull.return_value = [self._turn(video_id="abc123", chapter_id=3)]
+
+        mod._materialize_task(ti=ti, dag_run=MagicMock(conf={}))
+
+        # Capture INSERT call args
+        all_calls = cur.execute.call_args_list
+        insert_calls = [c for c in all_calls if "INSERT" in str(c).upper()]
+        assert len(insert_calls) >= 1, f"Expected INSERT call; got: {all_calls}"
+
+        # The second positional arg in the INSERT VALUES tuple is output_path
+        insert_args = insert_calls[0].args
+        # args[1] is the params tuple: (tid, output_path)
+        output_path = insert_args[1][1]
+
+        # Assertion 1: canonical path shape
+        assert "/congreso-es-tv/abc123/video_chapters/3/oradores/7/video.mp4" in output_path, (
+            f"Expected canonical path in INSERT output_path; got: {output_path}"
+        )
+
+        # Assertion 2: no legacy /turns/ segment
+        assert "/turns/" not in output_path, (
+            f"output_path must not contain '/turns/'; got: {output_path}"
+        )
+
+        # Assertion 3: no date segment
+        assert re.search(r"\d{4}-\d{2}-\d{2}", output_path) is None, (
+            f"output_path must not contain a date segment; got: {output_path}"
+        )
+
+        # Assertion 4: wiring — same value passed to execute_plan
+        execute_plan_positional_output_path = execute_plan_mock.call_args.args[2]
+        assert execute_plan_positional_output_path == output_path, (
+            f"execute_plan received different output_path than INSERT: "
+            f"execute_plan={execute_plan_positional_output_path!r} vs INSERT={output_path!r}"
+        )
+
     def test_missing_source_video_skips_without_ffmpeg(self, monkeypatch):
         mod = _fresh()
         monkeypatch.setattr(mod, "_find_source_video_any_date", lambda vid: None)
@@ -209,6 +283,7 @@ class TestMaterializeTurns:
         plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
         plan_mock.needs_reencode = False
         plan_mock.output_turn_id = 7
+        plan_mock.chapter_id = 3
 
         monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
         monkeypatch.setattr(mod, "execute_plan", lambda *a, **kw: None)
@@ -216,7 +291,8 @@ class TestMaterializeTurns:
             "congress_videos.modules.materialization_executor.get_cached_codec",
             lambda path, cache: "h264",
         )
-        monkeypatch.setattr(mod, "get_turn_video_path", lambda date, vid, tid: f"/out/{tid}.mp4")
+        from pathlib import Path
+        monkeypatch.setattr(mod, "get_orador_video_dir", lambda vid, chid, tid: Path(f"/out/{tid}"))
         monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
 
         pg = MagicMock()
@@ -251,10 +327,12 @@ class TestMaterializeTurns:
         plan_mock.keep_intervals = (MagicMock(start=600.0, end=700.0),)
         plan_mock.needs_reencode = False
         plan_mock.output_turn_id = 7
+        plan_mock.chapter_id = 3
 
         monkeypatch.setattr(mod, "plan_turn_materialization", lambda turns, trims: [plan_mock])
         monkeypatch.setattr(mod, "execute_plan", MagicMock(side_effect=RuntimeError("ffmpeg boom")))
-        monkeypatch.setattr(mod, "get_turn_video_path", lambda date, vid, tid: f"/out/{tid}.mp4")
+        from pathlib import Path
+        monkeypatch.setattr(mod, "get_orador_video_dir", lambda vid, chid, tid: Path(f"/out/{tid}"))
         monkeypatch.setattr(mod, "get_cached_codec", lambda *a, **k: "h264")
 
         pg = MagicMock()

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -1682,3 +1682,161 @@ class TestQueueSizeIncludesTurns:
         assert result["queue_size"] == 5, (
             f"queue_size must be chapters_pending(2) + turns_pending(3) = 5, got {result['queue_size']}"
         )
+
+
+# ---------------------------------------------------------------------------
+# thumbnail-canonical-path (Slice 4a): output_path threading
+# ---------------------------------------------------------------------------
+
+
+class TestPrepareThumbnailConfigThreadsOutputPath:
+    """_prepare_thumbnail_config must include output_path for turn items, absent for chapters."""
+
+    def test_turn_item_includes_output_path(self):
+        """Turn row with output_path → config['output_path'] equals the row value."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(output_path="/data/oradores/42/video.mp4")
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value=None,
+        ):
+            config = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert config["output_path"] == "/data/oradores/42/video.mp4"
+
+    def test_chapter_item_omits_output_path(self):
+        """Chapter row (no turn_id) → config.get('output_path') is None."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_chapter()
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value=None,
+        ):
+            config = _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert config.get("output_path") is None
+
+    def test_turn_item_with_none_output_path_is_set_to_none(self):
+        """Turn row whose output_path column is NULL → config['output_path'] is None (not absent)."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(output_path=None)  # type: ignore[arg-type]
+
+        with patch(
+            "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+            return_value=None,
+        ):
+            config = _prepare_thumbnail_config(turn, MagicMock())
+
+        # Key must be present (set by is_turn branch) even if value is None
+        assert "output_path" in config
+        assert config["output_path"] is None
+
+
+class TestTriggerThumbnailGenerationForwardsOutputPath:
+    """trigger_thumbnail_generation must forward output_path into child_conf only when truthy."""
+
+    def _make_mock_run(self, mocker, captured_confs):
+        mock_run = MagicMock()
+        mock_run.run_id = "thumb_run_output_path"
+        mock_run.state = "success"
+        mock_run.refresh_from_db = MagicMock()
+
+        def _fake_trigger(dag_id, conf, run_id):
+            captured_confs.append(conf)
+            return mock_run
+
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.trigger_dag_api",
+            side_effect=_fake_trigger,
+        )
+        mocker.patch("congress_videos.youtube_upload_dag.time.sleep")
+        mocker.patch(
+            "congress_videos.youtube_upload_dag.XCom.get_one",
+            return_value={
+                "success": True,
+                "chapter_id": 42,
+                "output_path": "/data/oradores/42/thumbnail.png",
+                "title": "Un título",
+            },
+        )
+        return mock_run
+
+    def test_forwards_output_path_when_present(self, mocker):
+        """When thumbnail_config has a truthy output_path, child_conf must include it."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs: list = []
+        self._make_mock_run(mocker, captured_confs)
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    "output_path": "/data/oradores/42/video.mp4",
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert len(captured_confs) == 1
+        assert captured_confs[0].get("output_path") == "/data/oradores/42/video.mp4"
+
+    def test_omits_output_path_when_absent(self, mocker):
+        """When thumbnail_config lacks output_path, child_conf must NOT contain the key."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs: list = []
+        self._make_mock_run(mocker, captured_confs)
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    # No output_path key
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert len(captured_confs) == 1
+        assert "output_path" not in captured_confs[0]
+
+    def test_omits_output_path_when_none(self, mocker):
+        """When thumbnail_config has output_path=None, child_conf must NOT contain the key."""
+        from congress_videos.youtube_upload_dag import trigger_thumbnail_generation
+
+        captured_confs: list = []
+        self._make_mock_run(mocker, captured_confs)
+
+        ti = _make_ti(
+            {
+                "thumbnail_config": {
+                    "chapter_id": 42,
+                    "debate_summary": "un resumen",
+                    "session": "Sesión 80",
+                    "domain": "congreso",
+                    "slug": None,
+                    "output_path": None,
+                }
+            }
+        )
+
+        trigger_thumbnail_generation(ti, run_id="test_run")
+
+        assert len(captured_confs) == 1
+        assert "output_path" not in captured_confs[0]


### PR DESCRIPTION
## Slice 4a of epic #133 — per-channel artifact hierarchy

**Stacked on #135 (Slice 2).** Targets the Slice 2 branch; retarget up the chain as earlier PRs merge to `dev`.

Moves the **turn thumbnail** from the global `thumbnails/{chapter_id}/` dir into the canonical orador folder beside `video.mp4`. First half of Slice 4 (thumbnail path); the `title.txt`/`description.txt` sidecars are Slice 4b (next chained PR).

### The change
- **Threading (`youtube_upload_dag.py`):** `_prepare_thumbnail_config` adds the canonical `output_path` (stored by Slice 2) for turn-type items; `trigger_thumbnail_generation` forwards it conditionally, mirroring the existing `srt_fragment` optional pattern. **Not** added to `_REQUIRED_CONF_KEYS`, so standalone/chapter triggers are unaffected.
- **Branch (`generic_thumbnail_generator_dag.py`):** `_task_download_option` branches on `conf.get("output_path")` → canonical dir `dirname(output_path)`; else legacy `get_thumbnail_dir`.
- **Reconciliation:** new `_persist_canonical_thumbnail` copies the selected best option to `{dirname(output_path)}/thumbnail.png`, so the final on-disk artifact matches the canonical layout name; `thumbnail_result.output_path` points to it.

### Anchor-folder rule
The orador folder is derived from `dirname(output_path)` — **not** reconstructed from `turn_id` — because `uploadable_turns` exposes no `output_turn_id` column and grouped turns' representative `turn_id` may differ from the anchor. This guarantees the thumbnail lands in the exact same folder as its video.

### Scope / tests
- No DB migration (`video_thumbnails.local_path` is informational; thumbnail travels via XCom).
- 11 new tests; full suite **2633 passed, 86.15% coverage**. Diff: 4 files, +404/-3.
- **Note:** test-heavy slice (58 production / 349 test lines); the ~407 churn is 7 over the 400 review budget, accepted by maintainer (overage is entirely DAG-mock test setup).

Part of #133 (epic — do not auto-close).