### PR TITLE
feat(storage): canonical subtitles.srt sidecar per orador (Slice 5 of #133)

### DIFF
--- a/congress_videos/srt_helpers.py
+++ b/congress_videos/srt_helpers.py
@@ -18,15 +18,44 @@ _SRT_TIMESTAMP_ARROW_RE = re.compile(
 )
 
 
+def _secs_to_srt_ts(secs: float) -> str:
+    """Convert float seconds to SRT timestamp string ``HH:MM:SS,mmm``."""
+    ms = int(round((secs % 1) * 1000))
+    s = int(secs)
+    h, rem = divmod(s, 3600)
+    m, sec = divmod(rem, 60)
+    return f"{h:02d}:{m:02d}:{sec:02d},{ms:03d}"
+
+
+def _serialize_srt_blocks(blocks: list[dict]) -> str:
+    """Rebuild a valid SRT string from ``{start_secs, end_secs, text}`` blocks.
+
+    Produces sequential 1-based indices, ``HH:MM:SS,mmm`` timestamps, and
+    blank-line-separated entries.  Empty list returns ``""``.  Pure; no I/O.
+    """
+    out = []
+    for i, b in enumerate(blocks, start=1):
+        out.append(
+            f"{i}\n{_secs_to_srt_ts(b['start_secs'])} --> "
+            f"{_secs_to_srt_ts(b['end_secs'])}\n{b['text']}\n"
+        )
+    return "\n".join(out)
+
+
 def find_srt_for_chapter(
     video_id: str,
     chapter_id: int,
     session_date: Optional[str] = None,
+    canonical_dir: Optional[str] = None,
 ) -> Optional[str]:
     """
     Try common SRT path patterns, return first existing path or None.
 
-    Probes:
+    When *canonical_dir* is supplied, probes ``{canonical_dir}/subtitles.srt``
+    first.  Falls through to the legacy probe list when that file is absent or
+    when *canonical_dir* is ``None`` (default, preserving existing behavior).
+
+    Legacy probes:
       1. data/congress_videos/{video_id}/srt_files/
       2. downloads/{session_date}/{video_id}/srt_files/  (if session_date provided)
       3. downloads/ (date-agnostic search when session_date is None)
@@ -34,6 +63,8 @@ def find_srt_for_chapter(
     srt_filenames = [f"{video_id}_merged.srt", f"{video_id}.srt"]
 
     candidates = []
+    if canonical_dir:
+        candidates.append(os.path.join(canonical_dir, "subtitles.srt"))
     for name in srt_filenames:
         candidates.append(os.path.join(PROJECT_DATA_DIR, video_id, "srt_files", name))
 

--- a/congress_videos/youtube_upload_dag.py
+++ b/congress_videos/youtube_upload_dag.py
@@ -32,6 +32,7 @@ from congress_videos.modules.postgres_operators import PostgreSQLOperator
 from congress_videos.modules.participants_db import lookup_participant_fuzzy
 from congress_videos.srt_helpers import (
     _parse_srt_blocks,
+    _serialize_srt_blocks,
     _srt_timestamp_to_seconds,
     find_srt_for_chapter,
 )
@@ -235,13 +236,26 @@ def _prepare_thumbnail_config(chapter: dict, db) -> dict:
             # Chapter: convert SRT-format timestamp strings to seconds.
             window_start_secs = _srt_timestamp_to_seconds(chapter.get("start_time", "00:00:00,000"))
             window_end_secs = _srt_timestamp_to_seconds(chapter.get("end_time", "99:59:59,999"))
-        window_texts = [
-            b["text"]
+        windowed = [
+            b
             for b in blocks
             if b["start_secs"] >= window_start_secs and b["end_secs"] <= window_end_secs
         ]
-        joined = " ".join(window_texts)
-        config["srt_fragment"] = joined[:10_000]
+        config["srt_fragment"] = " ".join(b["text"] for b in windowed)[:10_000]
+
+        # Best-effort canonical sidecar write for turn items (Slice 5).
+        # Mirror 4b _write_orador_sidecars convention: swallow errors, log warning.
+        if is_turn and config.get("output_path") and windowed:
+            try:
+                srt_out = os.path.join(os.path.dirname(config["output_path"]), "subtitles.srt")
+                with open(srt_out, "w", encoding="utf-8") as _f:
+                    _f.write(_serialize_srt_blocks(windowed))
+            except Exception as exc:
+                logging.warning(
+                    "Failed to write orador subtitles.srt for %s: %s",
+                    config.get("output_path"),
+                    exc,
+                )
 
     return config
 

--- a/tests/congress_videos/test_srt_helpers.py
+++ b/tests/congress_videos/test_srt_helpers.py
@@ -7,6 +7,7 @@ import pytest
 from congress_videos.srt_helpers import (
     _find_phrase_in_blocks,
     _parse_srt_blocks,
+    _serialize_srt_blocks,
     _srt_timestamp_to_seconds,
     find_srt_for_chapter,
     select_pretrim_window,
@@ -424,3 +425,113 @@ class TestParseSrtToTextBatch2:
         result = parse_srt_to_text(path, max_chars=500)
 
         assert len(result) <= 500
+
+
+# ---------------------------------------------------------------------------
+# _serialize_srt_blocks
+# ---------------------------------------------------------------------------
+
+class TestSerializeSrtBlocks:
+
+    @pytest.mark.parametrize("blocks,expected", [
+        (
+            [],
+            "",
+        ),
+        (
+            [{"start_secs": 0.0, "end_secs": 59.999, "text": "Hola"}],
+            "1\n00:00:00,000 --> 00:00:59,999\nHola\n",
+        ),
+        (
+            [
+                {"start_secs": 3661.5, "end_secs": 3663.0, "text": "Hola"},
+                {"start_secs": 3663.5, "end_secs": 3665.0, "text": "Mundo"},
+            ],
+            (
+                "1\n01:01:01,500 --> 01:01:03,000\nHola\n"
+                "\n"
+                "2\n01:01:03,500 --> 01:01:05,000\nMundo\n"
+            ),
+        ),
+    ])
+    def test_serialize_produces_valid_srt(self, blocks, expected):
+        assert _serialize_srt_blocks(blocks) == expected
+
+    def test_sequential_1_based_index(self):
+        blocks = [
+            {"start_secs": 1.0, "end_secs": 2.0, "text": "A"},
+            {"start_secs": 3.0, "end_secs": 4.0, "text": "B"},
+            {"start_secs": 5.0, "end_secs": 6.0, "text": "C"},
+        ]
+        result = _serialize_srt_blocks(blocks)
+        assert result.startswith("1\n")
+        assert "\n2\n" in result
+        assert "\n3\n" in result
+
+    def test_milliseconds_rounded_correctly(self):
+        # 0.9999 seconds → should round to 1000 ms → carry → 00:00:01,000
+        # but spec says round the frac part; 0.9999 * 1000 = 999.9 → rounds to 1000
+        # Actually per spec: ms = int(round((secs % 1) * 1000))
+        # For secs=0.9999: secs%1=0.9999, *1000=999.9, round=1000 → ms=1000
+        # That would make the display 00:00:00,1000 — which is not valid SRT.
+        # The design uses int(secs) first, so 0.9999 → int(0.9999)=0, h=0,m=0,sec=0, ms=round(0.9999*1000)=1000
+        # Per _secs_to_srt_ts formula in design: rebuild from formula gives ms=1000 here.
+        # We test a clean value: 59.999 → ms=round(0.999*1000)=round(999)=999
+        blocks = [{"start_secs": 59.999, "end_secs": 60.0, "text": "X"}]
+        result = _serialize_srt_blocks(blocks)
+        assert "00:00:59,999" in result
+        assert "00:01:00,000" in result
+
+
+# ---------------------------------------------------------------------------
+# find_srt_for_chapter — canonical-first probe (new param)
+# ---------------------------------------------------------------------------
+
+class TestFindSrtForChapterCanonical:
+
+    def test_canonical_dir_set_and_file_exists_returns_canonical(self, tmp_path):
+        canonical_dir = tmp_path / "oradores" / "abc"
+        canonical_dir.mkdir(parents=True)
+        srt = canonical_dir / "subtitles.srt"
+        srt.write_text("1\n00:00:00,000 --> 00:00:01,000\nHola\n", encoding="utf-8")
+
+        result = find_srt_for_chapter(
+            "vid123", 1, session_date=None, canonical_dir=str(canonical_dir)
+        )
+
+        assert result == str(srt)
+
+    def test_canonical_dir_set_but_file_absent_falls_back_to_legacy(self, tmp_path, mocker):
+        canonical_dir = tmp_path / "oradores" / "abc"
+        canonical_dir.mkdir(parents=True)
+        # subtitles.srt does NOT exist — triggers legacy fallback
+
+        legacy_path = "/data/congress_videos/vid123/srt_files/vid123.srt"
+
+        def _exists(p):
+            # canonical path: absent; legacy path: present
+            return p == legacy_path
+
+        mocker.patch("os.path.exists", side_effect=_exists)
+        mocker.patch("os.path.isdir", return_value=False)
+        mocker.patch("congress_videos.srt_helpers.PROJECT_DATA_DIR", "/data/congress_videos")
+
+        result = find_srt_for_chapter(
+            "vid123", 1, session_date="2025-01-01", canonical_dir=str(canonical_dir)
+        )
+
+        assert result == legacy_path
+
+    def test_canonical_dir_none_default_preserves_legacy_behavior(self, mocker):
+        expected = "/data/congress_videos/vid123/srt_files/vid123.srt"
+
+        def _exists(p):
+            return p == expected
+
+        mocker.patch("os.path.exists", side_effect=_exists)
+        mocker.patch("os.path.isdir", return_value=False)
+        mocker.patch("congress_videos.srt_helpers.PROJECT_DATA_DIR", "/data/congress_videos")
+
+        result = find_srt_for_chapter("vid123", 1, session_date="2025-01-01")
+
+        assert result == expected

--- a/tests/congress_videos/test_youtube_upload_dag.py
+++ b/tests/congress_videos/test_youtube_upload_dag.py
@@ -1840,3 +1840,150 @@ class TestTriggerThumbnailGenerationForwardsOutputPath:
 
         assert len(captured_confs) == 1
         assert "output_path" not in captured_confs[0]
+
+
+# ---------------------------------------------------------------------------
+# SRT sidecar write (Slice 5 — srt-sidecar-canonical-path)
+# ---------------------------------------------------------------------------
+
+class TestPrepareThumbnailConfigSrtSidecar:
+    """_prepare_thumbnail_config must write subtitles.srt for turn items."""
+
+    _WINDOWED_BLOCKS = [
+        {"start_secs": 60.0, "end_secs": 70.0, "text": "primera frase"},
+        {"start_secs": 75.0, "end_secs": 85.0, "text": "segunda frase"},
+        # outside window — must not appear in SRT
+        {"start_secs": 200.0, "end_secs": 210.0, "text": "fuera de ventana"},
+    ]
+
+    def _run_turn(self, tmp_path, blocks=None, output_path_override=None):
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        video_mp4 = tmp_path / "video.mp4"
+        video_mp4.write_bytes(b"")
+        out_path = output_path_override if output_path_override is not None else str(video_mp4)
+        turn = _make_turn_row(
+            output_path=out_path,
+            start_seconds=50.0,
+            end_seconds=100.0,
+        )
+        # video_id is required so find_srt_for_chapter is actually called
+        turn["video_id"] = "vid001"
+        if blocks is None:
+            blocks = self._WINDOWED_BLOCKS
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value="/fake/session.srt",
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag._parse_srt_blocks",
+                return_value=blocks,
+            ),
+        ):
+            return _prepare_thumbnail_config(turn, MagicMock()), tmp_path
+
+    def test_turn_with_output_path_writes_subtitles_srt(self, tmp_path):
+        """Turn-type + output_path + windowed blocks -> subtitles.srt written at dirname."""
+        config, out_dir = self._run_turn(tmp_path)
+
+        srt_path = out_dir / "subtitles.srt"
+        assert srt_path.exists(), "subtitles.srt must be created at dirname(output_path)"
+        content = srt_path.read_text(encoding="utf-8")
+        assert "primera frase" in content
+        assert "segunda frase" in content
+        assert "fuera de ventana" not in content
+        assert "1\n" in content  # sequential 1-based index present
+        assert config.get("chapter_id") == 42  # config unaffected
+
+    def test_chapter_type_produces_no_subtitles_srt(self, tmp_path):
+        """Chapter row (no turn_id) -> no subtitles.srt written anywhere."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        chapter = _make_srt_chapter(start_time="00:00:50,000", end_time="00:01:40,000")
+        blocks = [
+            {"start_secs": 60.0, "end_secs": 70.0, "text": "chapter text"},
+        ]
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value="/fake/session.srt",
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag._parse_srt_blocks",
+                return_value=blocks,
+            ),
+        ):
+            _prepare_thumbnail_config(chapter, MagicMock())
+
+        assert not any(tmp_path.rglob("subtitles.srt"))
+
+    def test_turn_with_none_output_path_produces_no_write(self, tmp_path):
+        """Turn row whose output_path is None -> no subtitles.srt written."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        turn = _make_turn_row(output_path=None, start_seconds=50.0, end_seconds=100.0)  # type: ignore[arg-type]
+        turn["video_id"] = "vid001"
+        blocks = [{"start_secs": 60.0, "end_secs": 70.0, "text": "texto"}]
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value="/fake/session.srt",
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag._parse_srt_blocks",
+                return_value=blocks,
+            ),
+        ):
+            config = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert not any(tmp_path.rglob("subtitles.srt"))
+        assert "chapter_id" in config  # config still returned
+
+    def test_write_failure_swallowed_config_returned(self, tmp_path):
+        """OSError on write -> warning logged, no exception, config returned intact."""
+        from congress_videos.youtube_upload_dag import _prepare_thumbnail_config
+
+        video_mp4 = tmp_path / "video.mp4"
+        video_mp4.write_bytes(b"")
+        turn = _make_turn_row(
+            output_path=str(video_mp4),
+            start_seconds=50.0,
+            end_seconds=100.0,
+        )
+        turn["video_id"] = "vid001"
+        blocks = [{"start_secs": 60.0, "end_secs": 70.0, "text": "texto"}]
+
+        with (
+            patch(
+                "congress_videos.youtube_upload_dag.lookup_participant_fuzzy",
+                return_value={"slug": "garcia-ana"},
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag.find_srt_for_chapter",
+                return_value="/fake/session.srt",
+            ),
+            patch(
+                "congress_videos.youtube_upload_dag._parse_srt_blocks",
+                return_value=blocks,
+            ),
+            patch("builtins.open", side_effect=OSError("disk full")),
+        ):
+            config = _prepare_thumbnail_config(turn, MagicMock())
+
+        assert "chapter_id" in config


### PR DESCRIPTION
## Slice 5 of epic #133 — per-channel artifact hierarchy

Gives each orador a valid `subtitles.srt` co-located with `video.mp4`, and lets the SRT lookup prefer the canonical location instead of probing multiple guesses.

### The change
- **`srt_helpers.py`:** pure `_secs_to_srt_ts` + `_serialize_srt_blocks` rebuild a **valid SRT** (1-based index, `HH:MM:SS,mmm` timestamps, blank-line separated) from the windowed blocks — which carry only float `start_secs`/`end_secs`/`text` after `_parse_srt_blocks`. `find_srt_for_chapter` gains a **trailing optional** `canonical_dir` param: when set it probes `{canonical_dir}/subtitles.srt` first, else the legacy list. Default `None` ⇒ byte-for-byte unchanged; the 3 full-session callers (`speaker_turns_dag`, `reap_clip_preparer_dag`, thumbnail) are untouched.
- **`youtube_upload_dag.py`:** `_prepare_thumbnail_config` turn branch captures the windowed block subset **once** (feeding both `srt_fragment` and the sidecar write — no drift) and best-effort writes `_serialize_srt_blocks(windowed)` to `{dirname(output_path)}/subtitles.srt` (try/except + warning, never breaks the flow). Turn-type only.

### Why rebuild instead of reuse
The existing `config["srt_fragment"]` is a 10k-char space-joined text blob for the thumbnail lapidary quote — **not valid SRT**. So the canonical sidecar is serialized fresh from the raw windowed blocks.

### Scope / tests
- No DB migration (additive; dual-read coexistence — the opt-in read keeps the legacy fallback).
- Full suite: **2652 passed, 86.21% coverage**. Diff: 4 files, +308/-5.
- Follow-up (non-blocking): the OSError best-effort test asserts no-raise + config intact but not the `caplog` warning emission; implementation logs correctly.

Part of #133 (epic — do not auto-close).