### PR TITLE
feat(storage): Reap shorts to canonical chapter path (Slice 6 of #133)

### DIFF
--- a/congress_videos/config/paths.py
+++ b/congress_videos/config/paths.py
@@ -295,6 +295,75 @@ def get_orador_artifact_path(
     ) / filename
 
 
+# --- Chapter-level short clip paths ---
+
+def get_video_chapter_dir(
+    source_video_id: str,
+    chapter_id: int,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the chapter directory path (no side effects, no mkdir).
+
+    The directory is not created by this function; callers are responsible
+    for creating it (e.g. via ``Path.mkdir(parents=True, exist_ok=True)``).
+
+    Args:
+        source_video_id: YouTube video identifier (e.g. ``"abc123"``).
+        chapter_id:      Database chapter ID (e.g. ``7``).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to ``{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}/
+        video_chapters/{chapter_id}/``.
+    """
+    if channel_slug is None:
+        # Function-local import avoids paths <-> youtube_channels circular dependency.
+        from congress_videos.config.youtube_channels import DEFAULT_CHANNEL  # noqa: PLC0415
+        channel_slug = DEFAULT_CHANNEL
+    return Path(
+        f"{PROJECT_DATA_DIR}/{channel_slug}/{source_video_id}"
+        f"/video_chapters/{chapter_id}"
+    )
+
+
+def get_chapter_shorts_dir(
+    source_video_id: str,
+    chapter_id: int,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the shorts sub-directory for a chapter (no side effects, no mkdir).
+
+    Args:
+        source_video_id: YouTube video identifier.
+        chapter_id:      Database chapter ID.
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to the ``shorts/`` directory inside the chapter directory.
+    """
+    return get_video_chapter_dir(source_video_id, chapter_id, channel_slug) / "shorts"
+
+
+def get_chapter_short_file_path(
+    source_video_id: str,
+    chapter_id: int,
+    clip_id: str,
+    channel_slug: str | None = None,
+) -> Path:
+    """Return the canonical path for a Reap short clip (no side effects, no mkdir).
+
+    Args:
+        source_video_id: YouTube source video identifier.
+        chapter_id:      Database chapter ID.
+        clip_id:         Reap clip identifier (used as filename stem).
+        channel_slug:    Channel slug (defaults to ``DEFAULT_CHANNEL``).
+
+    Returns:
+        ``Path`` to ``{shorts_dir}/{clip_id}.mp4``.
+    """
+    return get_chapter_shorts_dir(source_video_id, chapter_id, channel_slug) / f"{clip_id}.mp4"
+
+
 # -------------------------
 # Path Validation
 # -------------------------

--- a/congress_videos/modules/database.py
+++ b/congress_videos/modules/database.py
@@ -1008,6 +1008,26 @@ class CongressionalVideoDB:
                     f"for project {reap_project_id}"
                 )
 
+    def get_source_video_id_for_chapter(self, chapter_id: int) -> str | None:
+        """Return the source YouTube video_id for a chapter row.
+
+        Args:
+            chapter_id: Database chapter ID to look up.
+
+        Returns:
+            The ``video_id`` string when the chapter exists and has a non-NULL
+            ``video_id``; ``None`` otherwise (no row or NULL value).
+        """
+        table = self.pg_conn.get_qualified_table('video_chapters')
+        with self.pg_conn.get_connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    f"SELECT video_id FROM {table} WHERE chapter_id = %s",
+                    (chapter_id,),
+                )
+                row = cur.fetchone()
+                return row['video_id'] if row and row['video_id'] else None
+
     def claim_pending_clip(self) -> dict | None:
         """
         Atomically claim one pending clip from the queue, ordered by priority.

--- a/congress_videos/reap_processor_dag.py
+++ b/congress_videos/reap_processor_dag.py
@@ -15,7 +15,7 @@ from airflow.exceptions import AirflowException
 from airflow.operators.python import PythonOperator, ShortCircuitOperator
 from airflow.sensors.base import BaseSensorOperator
 
-from congress_videos.config.paths import get_short_file_path
+from congress_videos.config.paths import get_chapter_short_file_path
 from congress_videos.modules.database import CongressionalVideoDB
 from congress_videos.reap_api import ReapApiClient, ReapCreditsExhausted
 from utils.env_loader import load_env_if_local
@@ -93,13 +93,24 @@ class ReapJobSensor(BaseSensorOperator):
 
             db.update_video_short_status(reap_project_id, 'done')
 
+            source_video_id = db.get_source_video_id_for_chapter(chapter_id)
+
             for clip in clips:
                 clip_id = clip['clip_id']
                 clip_url = clip['clip_url']
                 virality = float(clip['virality_score'])
 
-                dest_path = get_short_file_path(chapter_id, clip_id)
-                reap_client.download_clip(clip_url, dest_path)
+                if source_video_id is None:
+                    logging.warning(
+                        "ReapJobSensor: no source video_id for chapter %s — skipping clip %s",
+                        chapter_id,
+                        clip_id,
+                    )
+                    continue
+
+                dest_path = get_chapter_short_file_path(source_video_id, chapter_id, clip_id)
+                dest_path.parent.mkdir(parents=True, exist_ok=True)
+                reap_client.download_clip(clip_url, str(dest_path))
 
                 db.insert_video_short_clip(
                     chapter_id=chapter_id,
@@ -107,7 +118,7 @@ class ReapJobSensor(BaseSensorOperator):
                     reap_clip_id=clip_id,
                     reap_virality_score=virality,
                     reap_clip_url=clip_url,
-                    local_file_path=dest_path,
+                    local_file_path=str(dest_path),
                 )
 
             return True

--- a/tests/congress_videos/config/test_paths.py
+++ b/tests/congress_videos/config/test_paths.py
@@ -20,6 +20,8 @@ from congress_videos.config.paths import (
     VIDEOS_DIR,
     YOUTUBE_TOKEN_FILE,
     ensure_directory_exists,
+    get_chapter_short_file_path,
+    get_chapter_shorts_dir,
     get_download_date_path,
     get_download_file_path,
     get_download_video_path,
@@ -28,6 +30,7 @@ from congress_videos.config.paths import (
     get_session_path,
     get_topic_path,
     get_video_path,
+    get_video_chapter_dir,
 )
 
 
@@ -356,3 +359,46 @@ class TestOradorHelpersImportPurity:
         )
         assert callable(_v)
         assert callable(_a)
+
+
+# ---------------------------------------------------------------------------
+# TestChapterShortPathHelpers — Slice 6 (#133)
+# ---------------------------------------------------------------------------
+
+class TestChapterShortPathHelpers:
+    """Unit tests for chapter-level short-clip path helpers (Slice 6)."""
+
+    @pytest.mark.parametrize("source_video_id,chapter_id,clip_id,expected_suffix", [
+        ("abc123", 7, "clip01", "congreso-es-tv/abc123/video_chapters/7/shorts/clip01.mp4"),
+        ("xyz999", 42, "clip99", "congreso-es-tv/xyz999/video_chapters/42/shorts/clip99.mp4"),
+    ])
+    def test_canonical_segment_order(self, source_video_id, chapter_id, clip_id, expected_suffix):
+        result = get_chapter_short_file_path(source_video_id, chapter_id, clip_id)
+        assert str(result).endswith(expected_suffix)
+
+    def test_explicit_channel_slug_overrides_default(self):
+        result = get_chapter_short_file_path("abc123", 7, "clip01", channel_slug="custom-channel")
+        assert "custom-channel/" in str(result)
+        assert "congreso-es-tv" not in str(result)
+
+    def test_integer_chapter_id_coerces_to_string_segment(self):
+        result = get_video_chapter_dir("abc", 42)
+        parts = result.parts
+        assert "42" in parts
+
+    def test_file_path_is_strict_child_of_shorts_dir(self):
+        src, ch, clip = "vid1", 5, "c01"
+        file_path = get_chapter_short_file_path(src, ch, clip)
+        shorts_dir = get_chapter_shorts_dir(src, ch)
+        assert file_path.parent == shorts_dir
+
+    def test_shorts_dir_is_strict_child_of_chapter_dir(self):
+        src, ch = "vid1", 5
+        shorts_dir = get_chapter_shorts_dir(src, ch)
+        chapter_dir = get_video_chapter_dir(src, ch)
+        assert shorts_dir.parent == chapter_dir
+
+    def test_return_types_are_path(self):
+        assert isinstance(get_video_chapter_dir("v", 1), Path)
+        assert isinstance(get_chapter_shorts_dir("v", 1), Path)
+        assert isinstance(get_chapter_short_file_path("v", 1, "c"), Path)

--- a/tests/congress_videos/modules/test_reap_db_methods.py
+++ b/tests/congress_videos/modules/test_reap_db_methods.py
@@ -469,3 +469,49 @@ class TestGetChapterMetadata:
         assert "youtube_video_id" in sql
         assert "source_video_title" in sql
         assert "source_video_url" in sql
+
+
+# --------------------------------------------------------------------------- #
+# get_source_video_id_for_chapter
+# --------------------------------------------------------------------------- #
+
+class TestGetSourceVideoIdForChapter:
+
+    @pytest.mark.parametrize("row,expected", [
+        ({"video_id": "src_vid_001"}, "src_vid_001"),
+        (None, None),
+    ])
+    def test_returns_video_id_or_none(self, db, row, expected):
+        instance, mock_cursor = db
+        mock_cursor.fetchone.return_value = row
+
+        result = instance.get_source_video_id_for_chapter(7)
+
+        assert result == expected
+
+    def test_null_video_id_in_row_returns_none(self, db):
+        instance, mock_cursor = db
+        mock_cursor.fetchone.return_value = {"video_id": None}
+
+        result = instance.get_source_video_id_for_chapter(99)
+
+        assert result is None
+
+    def test_query_selects_from_video_chapters(self, db):
+        instance, mock_cursor = db
+        mock_cursor.fetchone.return_value = None
+
+        instance.get_source_video_id_for_chapter(5)
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "video_chapters" in sql
+        assert "video_id" in sql
+
+    def test_passes_chapter_id_as_param(self, db):
+        instance, mock_cursor = db
+        mock_cursor.fetchone.return_value = None
+
+        instance.get_source_video_id_for_chapter(42)
+
+        _, params = mock_cursor.execute.call_args[0]
+        assert 42 in params

--- a/tests/congress_videos/test_reap_processor_dag.py
+++ b/tests/congress_videos/test_reap_processor_dag.py
@@ -187,11 +187,14 @@ class TestReapJobSensor:
         mock_db_cls = mocker.patch("congress_videos.reap_processor_dag.CongressionalVideoDB")
         mock_db = mock_db_cls.return_value
         mock_db.insert_video_short_clip.return_value = 1
+        mock_db.get_source_video_id_for_chapter.return_value = "src_vid_001"
 
-        mocker.patch("os.makedirs")
+        mock_path = MagicMock()
+        mock_path.__str__ = MagicMock(side_effect=lambda: "/data/canonical/clip.mp4")
+        mock_path.parent = MagicMock()
         mocker.patch(
-            "congress_videos.reap_processor_dag.get_short_file_path",
-            side_effect=lambda ch, cl: f"/data/{ch}/{cl}.mp4",
+            "congress_videos.reap_processor_dag.get_chapter_short_file_path",
+            return_value=mock_path,
         )
 
         result = sensor.poke(context)
@@ -216,10 +219,14 @@ class TestReapJobSensor:
 
         mock_db_cls = mocker.patch("congress_videos.reap_processor_dag.CongressionalVideoDB")
         mock_db = mock_db_cls.return_value
+        mock_db.get_source_video_id_for_chapter.return_value = "src_vid_001"
 
+        mock_path = MagicMock()
+        mock_path.__str__ = MagicMock(return_value="/data/canonical/clip.mp4")
+        mock_path.parent = MagicMock()
         mocker.patch(
-            "congress_videos.reap_processor_dag.get_short_file_path",
-            side_effect=lambda ch, cl: f"/data/{ch}/{cl}.mp4",
+            "congress_videos.reap_processor_dag.get_chapter_short_file_path",
+            return_value=mock_path,
         )
 
         sensor.poke(context)
@@ -434,3 +441,129 @@ class TestCreateReapJob:
         _create_reap_job(ti, params={})
 
         assert ti.xcom_store.get("credits_exhausted") is True
+
+
+# ---------------------------------------------------------------------------
+# TestReapJobSensorCanonicalPath — Slice 6 (#133)
+# ---------------------------------------------------------------------------
+
+class TestReapJobSensorCanonicalPath:
+    """Tests for the canonical write-point rewire in ReapJobSensor.poke."""
+
+    def _build_sensor(self):
+        from congress_videos.reap_processor_dag import ReapJobSensor
+        return ReapJobSensor(
+            task_id="wait_for_reap_canonical_test",
+            reap_project_id_key="reap_project_id_for_sensor",
+            chapter_id_key="chapter_id_for_sensor",
+            poke_interval=900,
+            timeout=7200,
+            mode="reschedule",
+        )
+
+    def test_canonical_path_used_when_source_video_id_present(self, mocker):
+        """download_clip and insert_video_short_clip both receive the canonical str path."""
+        sensor = self._build_sensor()
+        context = _make_context({
+            "reap_project_id_for_sensor": "proj-abc",
+            "chapter_id_for_sensor": 7,
+        })
+
+        clips = [{"clip_id": "clip-1", "clip_url": "https://cdn.reap.video/c1.mp4", "virality_score": 0.8}]
+
+        mock_client_cls = mocker.patch("congress_videos.reap_processor_dag.ReapApiClient")
+        mock_client = mock_client_cls.return_value
+        mock_client.get_project_status.return_value = {"status": "completed"}
+        mock_client.get_project_clips.return_value = clips
+
+        mock_db_cls = mocker.patch("congress_videos.reap_processor_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_source_video_id_for_chapter.return_value = "src001"
+
+        canonical_str = "/data/congreso-es-tv/src001/video_chapters/7/shorts/clip-1.mp4"
+        mock_path = MagicMock()
+        mock_path.__str__ = MagicMock(return_value=canonical_str)
+        mock_path.parent = MagicMock()
+        mocker.patch(
+            "congress_videos.reap_processor_dag.get_chapter_short_file_path",
+            return_value=mock_path,
+        )
+
+        sensor.poke(context)
+
+        # download_clip must receive str, not Path
+        download_args = mock_client.download_clip.call_args[0]
+        assert download_args[1] == canonical_str
+        assert isinstance(download_args[1], str)
+
+        # insert_video_short_clip must receive the same str via local_file_path
+        insert_kwargs = mock_db.insert_video_short_clip.call_args[1]
+        assert insert_kwargs["local_file_path"] == canonical_str
+
+    def test_skip_with_warning_when_source_video_id_is_none(self, mocker, caplog):
+        """When get_source_video_id_for_chapter returns None, no download/insert, no exception."""
+        import logging
+        sensor = self._build_sensor()
+        context = _make_context({
+            "reap_project_id_for_sensor": "proj-xyz",
+            "chapter_id_for_sensor": 99,
+        })
+
+        clips = [{"clip_id": "clip-X", "clip_url": "https://cdn.reap.video/cx.mp4", "virality_score": 0.5}]
+
+        mock_client_cls = mocker.patch("congress_videos.reap_processor_dag.ReapApiClient")
+        mock_client = mock_client_cls.return_value
+        mock_client.get_project_status.return_value = {"status": "completed"}
+        mock_client.get_project_clips.return_value = clips
+
+        mock_db_cls = mocker.patch("congress_videos.reap_processor_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_source_video_id_for_chapter.return_value = None
+
+        mocker.patch("congress_videos.reap_processor_dag.get_chapter_short_file_path")
+
+        with caplog.at_level(logging.WARNING):
+            result = sensor.poke(context)
+
+        assert result is True
+        mock_client.download_clip.assert_not_called()
+        mock_db.insert_video_short_clip.assert_not_called()
+        warnings = [r for r in caplog.records if r.levelno == logging.WARNING and "99" in r.message]
+        assert len(warnings) >= 1
+
+    def test_parent_mkdir_called_before_download(self, mocker):
+        """dest_path.parent.mkdir(parents=True, exist_ok=True) must be called before download."""
+        from pathlib import Path
+        sensor = self._build_sensor()
+        context = _make_context({
+            "reap_project_id_for_sensor": "proj-mkdir",
+            "chapter_id_for_sensor": 5,
+        })
+
+        clips = [{"clip_id": "c1", "clip_url": "https://cdn.reap.video/c1.mp4", "virality_score": 0.6}]
+
+        mock_client_cls = mocker.patch("congress_videos.reap_processor_dag.ReapApiClient")
+        mock_client = mock_client_cls.return_value
+        mock_client.get_project_status.return_value = {"status": "completed"}
+        mock_client.get_project_clips.return_value = clips
+
+        mock_db_cls = mocker.patch("congress_videos.reap_processor_dag.CongressionalVideoDB")
+        mock_db = mock_db_cls.return_value
+        mock_db.get_source_video_id_for_chapter.return_value = "svid5"
+
+        mock_path = MagicMock(spec=Path)
+        mock_path.__str__ = MagicMock(return_value="/data/canonical/c1.mp4")
+        mock_path.parent = MagicMock()
+        mocker.patch(
+            "congress_videos.reap_processor_dag.get_chapter_short_file_path",
+            return_value=mock_path,
+        )
+
+        call_order = []
+        mock_path.parent.mkdir.side_effect = lambda **kw: call_order.append("mkdir")
+        mock_client.download_clip.side_effect = lambda *a: call_order.append("download")
+
+        sensor.poke(context)
+
+        mock_path.parent.mkdir.assert_called_once_with(parents=True, exist_ok=True)
+        assert call_order.index("mkdir") < call_order.index("download")


### PR DESCRIPTION
## Slice 6 of epic #133 — per-channel artifact hierarchy

Moves Reap shorts from the flat Scheme-6 path (`{DATA}/{chapter_id}/shorts/{clip}.mp4`) to the **chapter level** of the canonical hierarchy:
```
{DATA}/congreso-es-tv/{source_video_id}/video_chapters/{chapter_id}/shorts/{clip_id}.mp4
```
**Domain decision (option A):** a Reap short is derived from a *chapter* (it can span multiple turns), so it belongs at the chapter level — not under `oradores/`.

### The change
- **`config/paths.py`:** 3 new chapter-level helpers — `get_video_chapter_dir`, `get_chapter_shorts_dir`, `get_chapter_short_file_path` — DRY-composed, return `Path`, no mkdir, function-local `DEFAULT_CHANNEL` import (mirrors the S1 orador helpers to dodge the `paths↔youtube_channels` cycle). These also introduce the missing `video_chapters/{chapter_id}/` level helper.
- **`modules/database.py`:** `get_source_video_id_for_chapter(chapter_id) -> str | None` — single-column lookup of `video_chapters.video_id` (the **source** YouTube id, not `youtube_video_id`). None for unlinked/missing chapters.
- **`reap_processor_dag.py`:** `ReapJobSensor.poke` completed branch looks up the source video id, builds the canonical path, guards a `parent.mkdir` (the canonical tree is fresh), and stores `str(dest_path)` into `video_shorts.local_file_path`. Unlinked chapter → **skip-with-warning + continue** (never fails the poke).

### Why no migration / no uploader change
The uploader reads the **stored** `local_file_path`, never re-deriving the helper — so writing canonical + storing that string means legacy rows coexist untouched. No fallback probe, no migration.

### Scope / tests
- 15 new tests; full suite **2667 passed, 86.25% coverage**. Diff: 6 files, +334/-9.
- `video_splitter.py:359` chapter-video path (Scheme 2) deliberately **deferred** (its own re-read surface).

Part of #133 (epic — do not auto-close).